### PR TITLE
feat: facilitator HTTP client with retry and telemetry

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -1,0 +1,37 @@
+# Task: Build the Facilitator Client
+
+Read CLAUDE.md for coding standards. This is an Elixir LIBRARY following Dashbit/Jose Valim conventions.
+
+## Modules to create:
+
+### 1. lib/x402/facilitator.ex — X402.Facilitator (GenServer)
+- start_link/1 with NimbleOptions validation for: :name, :url (default "https://x402.org/facilitator"), :finch (required), :max_retries (default 2), :retry_backoff_ms (default 100), :receive_timeout_ms (default 5000)
+- verify/2 and verify/3: verify payment payload against requirements via facilitator /verify
+- settle/2 and settle/3: settle payment via facilitator /settle  
+- child_spec/1 for supervision tree integration
+- Returns {:ok, %{status: integer, body: map}} or {:error, %X402.Facilitator.Error{}}
+- Emits telemetry events via :telemetry.span
+
+### 2. lib/x402/facilitator/http.ex — X402.Facilitator.HTTP
+- Pure HTTP transport functions (no GenServer state)
+- request/5: makes the actual Finch HTTP request
+- Retry logic with exponential backoff for transient errors (408, 429, 500, 502, 503, 504)
+- Structured error types
+
+### 3. lib/x402/facilitator/error.ex — X402.Facilitator.Error
+- Defexception with fields: type, status, body, reason, retryable, attempt
+- Nice message/1 implementation
+
+## Tests (use Bypass to mock HTTP):
+- Successful verify and settle
+- HTTP errors (400, 401, 500)
+- Transient errors with retry
+- Timeout handling
+- Invalid JSON responses
+- NimbleOptions validation errors
+
+Test files: test/x402/facilitator_test.exs, test/x402/facilitator/http_test.exs
+Create test/support/test_helpers.ex with shared Bypass setup.
+
+Run mix test && mix compile --warnings-as-errors. Commit when passing.
+When finished, run: openclaw system event --text "Done: x402 facilitator client" --mode now

--- a/lib/x402/facilitator.ex
+++ b/lib/x402/facilitator.ex
@@ -1,0 +1,202 @@
+defmodule X402.Facilitator do
+  @moduledoc """
+  Stateful client for x402 facilitator verify and settle operations.
+  """
+
+  use GenServer
+
+  alias X402.Facilitator.Error
+  alias X402.Facilitator.HTTP
+
+  @default_name __MODULE__
+  @default_url "https://x402.org/facilitator"
+
+  @start_link_options_schema [
+    name: [
+      type: :any,
+      default: @default_name,
+      doc: "Registered name of the facilitator client process."
+    ],
+    url: [
+      type: :string,
+      default: @default_url,
+      doc: "Facilitator base URL."
+    ],
+    finch: [
+      type: :any,
+      required: true,
+      doc: "Finch process name used for HTTP requests."
+    ],
+    max_retries: [
+      type: :non_neg_integer,
+      default: 2,
+      doc: "Maximum retry count for transient errors."
+    ],
+    retry_backoff_ms: [
+      type: :non_neg_integer,
+      default: 100,
+      doc: "Initial retry backoff in milliseconds."
+    ],
+    receive_timeout_ms: [
+      type: :non_neg_integer,
+      default: 5_000,
+      doc: "HTTP receive timeout in milliseconds."
+    ]
+  ]
+
+  @typedoc "Facilitator server identifier accepted by `GenServer.call/3`."
+  @type server :: GenServer.server()
+
+  @type response :: {:ok, %{status: non_neg_integer(), body: map()}} | {:error, Error.t()}
+
+  @type state :: %{
+          url: String.t(),
+          finch: term(),
+          max_retries: non_neg_integer(),
+          retry_backoff_ms: non_neg_integer(),
+          receive_timeout_ms: non_neg_integer()
+        }
+
+  @doc """
+  Starts the facilitator client.
+
+  ## Options
+
+  #{NimbleOptions.docs(@start_link_options_schema)}
+  """
+  @doc since: "0.1.0"
+  @spec start_link(keyword()) ::
+          GenServer.on_start() | {:error, NimbleOptions.ValidationError.t()}
+  def start_link(opts) when is_list(opts) do
+    with {:ok, validated_opts} <- NimbleOptions.validate(opts, @start_link_options_schema) do
+      name = Keyword.fetch!(validated_opts, :name)
+      GenServer.start_link(__MODULE__, validated_opts, name: name)
+    end
+  end
+
+  @doc """
+  Returns a child specification for `X402.Facilitator`.
+  """
+  @doc since: "0.1.0"
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) when is_list(opts) do
+    validated_opts = NimbleOptions.validate!(opts, @start_link_options_schema)
+
+    %{
+      id: Keyword.fetch!(validated_opts, :name),
+      start: {__MODULE__, :start_link, [validated_opts]},
+      type: :worker,
+      restart: :permanent,
+      shutdown: 5_000
+    }
+  end
+
+  @doc """
+  Verifies a payment using the default facilitator process name.
+  """
+  @doc group: :verification
+  @doc since: "0.1.0"
+  @spec verify(map(), map()) :: response()
+  def verify(payment_payload, requirements)
+      when is_map(payment_payload) and is_map(requirements) do
+    verify(@default_name, payment_payload, requirements)
+  end
+
+  @doc """
+  Verifies a payment using the given facilitator process.
+  """
+  @doc group: :verification
+  @doc since: "0.1.0"
+  @spec verify(server(), map(), map()) :: response()
+  def verify(server, payment_payload, requirements)
+      when is_map(payment_payload) and is_map(requirements) do
+    GenServer.call(server, {:verify, payment_payload, requirements})
+  end
+
+  @doc """
+  Settles a payment using the default facilitator process name.
+  """
+  @doc group: :verification
+  @doc since: "0.1.0"
+  @spec settle(map(), map()) :: response()
+  def settle(payment_payload, requirements)
+      when is_map(payment_payload) and is_map(requirements) do
+    settle(@default_name, payment_payload, requirements)
+  end
+
+  @doc """
+  Settles a payment using the given facilitator process.
+  """
+  @doc group: :verification
+  @doc since: "0.1.0"
+  @spec settle(server(), map(), map()) :: response()
+  def settle(server, payment_payload, requirements)
+      when is_map(payment_payload) and is_map(requirements) do
+    GenServer.call(server, {:settle, payment_payload, requirements})
+  end
+
+  @impl true
+  @spec init(keyword()) :: {:ok, state()}
+  def init(opts) do
+    state = %{
+      url: Keyword.fetch!(opts, :url),
+      finch: Keyword.fetch!(opts, :finch),
+      max_retries: Keyword.fetch!(opts, :max_retries),
+      retry_backoff_ms: Keyword.fetch!(opts, :retry_backoff_ms),
+      receive_timeout_ms: Keyword.fetch!(opts, :receive_timeout_ms)
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  @spec handle_call(term(), GenServer.from(), state()) :: {:reply, response(), state()}
+  def handle_call({:verify, payment_payload, requirements}, _from, state) do
+    response = request_with_telemetry(state, :verify, payment_payload, requirements)
+    {:reply, response, state}
+  end
+
+  def handle_call({:settle, payment_payload, requirements}, _from, state) do
+    response = request_with_telemetry(state, :settle, payment_payload, requirements)
+    {:reply, response, state}
+  end
+
+  defp request_with_telemetry(state, operation, payment_payload, requirements) do
+    endpoint = operation_endpoint(operation)
+
+    :telemetry.span(
+      [:x402, :facilitator, operation],
+      %{operation: operation, endpoint: endpoint},
+      fn ->
+        result =
+          HTTP.request(
+            state.finch,
+            state.url,
+            endpoint,
+            %{payload: payment_payload, requirements: requirements},
+            max_retries: state.max_retries,
+            retry_backoff_ms: state.retry_backoff_ms,
+            receive_timeout_ms: state.receive_timeout_ms
+          )
+
+        {result, telemetry_result_metadata(result)}
+      end
+    )
+  end
+
+  defp operation_endpoint(:verify), do: "/verify"
+  defp operation_endpoint(:settle), do: "/settle"
+
+  defp telemetry_result_metadata({:ok, %{status: status}}),
+    do: %{status: status, success: true}
+
+  defp telemetry_result_metadata({:error, %Error{} = error}) do
+    %{
+      status: error.status,
+      success: false,
+      error_type: error.type,
+      retryable: error.retryable,
+      attempt: error.attempt
+    }
+  end
+end

--- a/lib/x402/facilitator/error.ex
+++ b/lib/x402/facilitator/error.ex
@@ -1,0 +1,56 @@
+defmodule X402.Facilitator.Error do
+  @moduledoc """
+  Structured error returned by facilitator verify/settle operations.
+  """
+
+  @typedoc """
+  Error type identifier.
+  """
+  @type error_type ::
+          :finch_unavailable
+          | :http_error
+          | :invalid_json
+          | :invalid_option
+          | :request_setup_failed
+          | :timeout
+          | :transport_error
+          | :unexpected_response
+
+  @type t :: %__MODULE__{
+          type: error_type(),
+          status: non_neg_integer() | nil,
+          body: map() | nil,
+          reason: term(),
+          retryable: boolean(),
+          attempt: pos_integer() | nil
+        }
+
+  defexception type: :transport_error,
+               status: nil,
+               body: nil,
+               reason: nil,
+               retryable: false,
+               attempt: nil
+
+  @impl true
+  def message(%__MODULE__{} = error) do
+    base = "facilitator request failed (type=#{error.type})"
+
+    base
+    |> append_status(error.status)
+    |> append_attempt(error.attempt)
+    |> append_retryable(error.retryable)
+    |> append_reason(error.reason)
+  end
+
+  defp append_status(message, nil), do: message
+  defp append_status(message, status), do: "#{message}, status=#{status}"
+
+  defp append_attempt(message, nil), do: message
+  defp append_attempt(message, attempt), do: "#{message}, attempt=#{attempt}"
+
+  defp append_retryable(message, retryable), do: "#{message}, retryable=#{retryable}"
+
+  defp append_reason(message, nil), do: message
+  defp append_reason(message, reason), do: "#{message}, reason=#{inspect(reason)}"
+end

--- a/lib/x402/facilitator/http.ex
+++ b/lib/x402/facilitator/http.ex
@@ -1,0 +1,315 @@
+defmodule X402.Facilitator.HTTP do
+  @moduledoc """
+  HTTP transport for facilitator verify and settle requests.
+  """
+
+  alias X402.Facilitator.Error
+
+  @transient_statuses [408, 429, 500, 502, 503, 504]
+  @json_headers [{"content-type", "application/json"}, {"accept", "application/json"}]
+
+  @type finch_name :: atom() | pid() | {:via, module(), term()}
+  @type response :: {:ok, %{status: non_neg_integer(), body: map()}} | {:error, Error.t()}
+
+  @doc """
+  Performs a facilitator HTTP POST request.
+
+  `opts` supports:
+
+  - `:max_retries` (default: `2`)
+  - `:retry_backoff_ms` (default: `100`)
+  - `:receive_timeout_ms` (default: `5_000`)
+  """
+  @doc since: "0.1.0"
+  @spec request(finch_name(), String.t(), String.t(), map(), keyword()) :: response()
+  def request(finch_name, base_url, path, payload, opts \\ [])
+      when is_binary(base_url) and is_binary(path) and is_map(payload) and is_list(opts) do
+    with {:ok, max_retries} <- fetch_non_negative_integer(opts, :max_retries, 2),
+         {:ok, retry_backoff_ms} <- fetch_non_negative_integer(opts, :retry_backoff_ms, 100),
+         {:ok, receive_timeout_ms} <- fetch_non_negative_integer(opts, :receive_timeout_ms, 5_000),
+         {:ok, finch_module} <- ensure_finch_module(),
+         {:ok, encoded_payload} <- Jason.encode(payload) do
+      max_attempts = max_retries + 1
+      url = join_url(base_url, path)
+
+      do_request(
+        finch_module,
+        finch_name,
+        url,
+        encoded_payload,
+        receive_timeout_ms,
+        retry_backoff_ms,
+        1,
+        max_attempts
+      )
+    else
+      {:error, %Error{} = error} ->
+        {:error, error}
+
+      {:error, reason} ->
+        {:error,
+         %Error{
+           type: :request_setup_failed,
+           reason: reason,
+           retryable: false,
+           attempt: 1
+         }}
+    end
+  end
+
+  defp do_request(
+         finch_module,
+         finch_name,
+         url,
+         encoded_payload,
+         receive_timeout_ms,
+         retry_backoff_ms,
+         attempt,
+         max_attempts
+       ) do
+    result =
+      perform_request(
+        finch_module,
+        finch_name,
+        url,
+        encoded_payload,
+        receive_timeout_ms,
+        attempt
+      )
+
+    maybe_retry(
+      result,
+      finch_module,
+      finch_name,
+      url,
+      encoded_payload,
+      receive_timeout_ms,
+      retry_backoff_ms,
+      attempt,
+      max_attempts
+    )
+  end
+
+  defp perform_request(
+         finch_module,
+         finch_name,
+         url,
+         encoded_payload,
+         receive_timeout_ms,
+         attempt
+       ) do
+    request = apply(finch_module, :build, [:post, url, @json_headers, encoded_payload])
+
+    response =
+      try do
+        apply(finch_module, :request, [
+          request,
+          finch_name,
+          [receive_timeout: receive_timeout_ms]
+        ])
+      catch
+        :exit, reason -> {:error, reason}
+      end
+
+    case response do
+      {:ok, %{status: status, body: body}} when status in 200..299 ->
+        decode_success_response(status, body, attempt)
+
+      {:ok, %{status: status, body: body}} when status in @transient_statuses ->
+        {:error,
+         %Error{
+           type: :http_error,
+           status: status,
+           body: decode_error_body(body),
+           retryable: true,
+           attempt: attempt
+         }}
+
+      {:ok, %{status: status, body: body}} when is_integer(status) ->
+        {:error,
+         %Error{
+           type: :http_error,
+           status: status,
+           body: decode_error_body(body),
+           retryable: false,
+           attempt: attempt
+         }}
+
+      {:ok, response} ->
+        {:error,
+         %Error{
+           type: :unexpected_response,
+           reason: response,
+           retryable: false,
+           attempt: attempt
+         }}
+
+      {:error, reason} ->
+        build_transport_error(reason, attempt)
+    end
+  end
+
+  defp maybe_retry(
+         {:error, %Error{retryable: true} = _error},
+         finch_module,
+         finch_name,
+         url,
+         encoded_payload,
+         receive_timeout_ms,
+         retry_backoff_ms,
+         attempt,
+         max_attempts
+       )
+       when attempt < max_attempts do
+    :timer.sleep(backoff_ms(retry_backoff_ms, attempt))
+
+    do_request(
+      finch_module,
+      finch_name,
+      url,
+      encoded_payload,
+      receive_timeout_ms,
+      retry_backoff_ms,
+      attempt + 1,
+      max_attempts
+    )
+  end
+
+  defp maybe_retry(
+         {:error, %Error{} = error},
+         _finch_module,
+         _finch_name,
+         _url,
+         _encoded_payload,
+         _receive_timeout_ms,
+         _retry_backoff_ms,
+         _attempt,
+         _max_attempts
+       ) do
+    {:error, error}
+  end
+
+  defp maybe_retry(
+         {:ok, _response} = ok,
+         _finch_module,
+         _finch_name,
+         _url,
+         _encoded_payload,
+         _receive_timeout_ms,
+         _retry_backoff_ms,
+         _attempt,
+         _max_attempts
+       ) do
+    ok
+  end
+
+  defp decode_success_response(status, body, attempt) do
+    case decode_json_body(body) do
+      {:ok, decoded_body} ->
+        {:ok, %{status: status, body: decoded_body}}
+
+      {:error, reason} ->
+        {:error,
+         %Error{
+           type: :invalid_json,
+           status: status,
+           body: raw_body_map(body),
+           reason: reason,
+           retryable: false,
+           attempt: attempt
+         }}
+    end
+  end
+
+  defp decode_error_body(body) do
+    case decode_json_body(body) do
+      {:ok, decoded_body} -> decoded_body
+      {:error, _reason} -> raw_body_map(body)
+    end
+  end
+
+  defp decode_json_body(nil), do: {:ok, %{}}
+  defp decode_json_body(""), do: {:ok, %{}}
+
+  defp decode_json_body(body) when is_binary(body) do
+    case Jason.decode(body) do
+      {:ok, map} when is_map(map) -> {:ok, map}
+      {:ok, other} -> {:error, {:invalid_json_object, other}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp decode_json_body(other), do: {:error, {:invalid_body_type, other}}
+
+  defp raw_body_map(nil), do: %{}
+  defp raw_body_map(body) when is_binary(body), do: %{"raw_body" => body}
+  defp raw_body_map(body), do: %{"raw_body" => inspect(body)}
+
+  defp build_transport_error(reason, attempt) do
+    case timeout_reason?(reason) do
+      true ->
+        {:error,
+         %Error{
+           type: :timeout,
+           reason: reason,
+           retryable: true,
+           attempt: attempt
+         }}
+
+      false ->
+        {:error,
+         %Error{
+           type: :transport_error,
+           reason: reason,
+           retryable: true,
+           attempt: attempt
+         }}
+    end
+  end
+
+  defp timeout_reason?(:timeout), do: true
+  defp timeout_reason?(%{reason: :timeout}), do: true
+  defp timeout_reason?(%{reason: {:timeout, _details}}), do: true
+  defp timeout_reason?(_reason), do: false
+
+  defp backoff_ms(retry_backoff_ms, attempt) do
+    retry_backoff_ms * trunc(:math.pow(2, attempt - 1))
+  end
+
+  defp fetch_non_negative_integer(opts, key, default) do
+    value = Keyword.get(opts, key, default)
+
+    case value do
+      integer when is_integer(integer) and integer >= 0 -> {:ok, integer}
+      invalid -> {:error, invalid_option_error(key, invalid)}
+    end
+  end
+
+  defp invalid_option_error(key, invalid) do
+    %Error{
+      type: :invalid_option,
+      reason: {key, invalid},
+      retryable: false,
+      attempt: 1
+    }
+  end
+
+  defp ensure_finch_module do
+    finch_module = Module.concat(["Finch"])
+
+    case Code.ensure_loaded?(finch_module) and function_exported?(finch_module, :request, 3) and
+           function_exported?(finch_module, :build, 4) do
+      true ->
+        {:ok, finch_module}
+
+      false ->
+        {:error, %Error{type: :finch_unavailable, reason: :missing_dependency, retryable: false}}
+    end
+  end
+
+  defp join_url(base_url, path) do
+    base_url = String.trim_trailing(base_url, "/")
+    path = String.trim_leading(path, "/")
+    base_url <> "/" <> path
+  end
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,0 +1,15 @@
+defmodule X402.TestHelpers do
+  @moduledoc false
+
+  def setup_bypass(_context) do
+    bypass = Bypass.open()
+    {:ok, bypass: bypass, facilitator_url: "http://localhost:#{bypass.port}"}
+  end
+
+  def setup_finch(_context) do
+    finch_name = String.to_atom("finch_#{System.unique_integer([:positive, :monotonic])}")
+    ExUnit.Callbacks.start_supervised!({Finch, name: finch_name})
+
+    {:ok, finch: finch_name}
+  end
+end

--- a/test/x402/facilitator/http_test.exs
+++ b/test/x402/facilitator/http_test.exs
@@ -1,0 +1,131 @@
+defmodule X402.Facilitator.HTTPTest do
+  use ExUnit.Case, async: false
+
+  alias X402.Facilitator.Error
+  alias X402.Facilitator.HTTP
+
+  import X402.TestHelpers
+
+  setup :setup_bypass
+  setup :setup_finch
+
+  test "request/5 returns status and decoded body on success", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    Bypass.expect(bypass, "POST", "/verify", fn conn ->
+      Plug.Conn.resp(conn, 200, Jason.encode!(%{"ok" => true}))
+    end)
+
+    assert {:ok, %{status: 200, body: %{"ok" => true}}} =
+             HTTP.request(finch, facilitator_url, "/verify", %{"payload" => %{}}, [])
+  end
+
+  test "request/5 returns non-retryable error for 400", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    Bypass.expect(bypass, "POST", "/verify", fn conn ->
+      Plug.Conn.resp(conn, 400, Jason.encode!(%{"error" => "bad request"}))
+    end)
+
+    assert {:error,
+            %Error{
+              type: :http_error,
+              status: 400,
+              body: %{"error" => "bad request"},
+              retryable: false
+            }} =
+             HTTP.request(finch, facilitator_url, "/verify", %{}, max_retries: 2)
+  end
+
+  test "request/5 returns non-retryable error for 401", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    Bypass.expect(bypass, "POST", "/verify", fn conn ->
+      Plug.Conn.resp(conn, 401, Jason.encode!(%{"error" => "unauthorized"}))
+    end)
+
+    assert {:error,
+            %Error{
+              type: :http_error,
+              status: 401,
+              body: %{"error" => "unauthorized"},
+              retryable: false
+            }} = HTTP.request(finch, facilitator_url, "/verify", %{}, max_retries: 2)
+  end
+
+  test "request/5 retries transient errors and eventually succeeds", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    {:ok, attempts} = Agent.start_link(fn -> 0 end)
+
+    Bypass.stub(bypass, "POST", "/verify", fn conn ->
+      current_attempt = Agent.get_and_update(attempts, &{&1 + 1, &1 + 1})
+
+      case current_attempt do
+        attempt when attempt < 3 ->
+          Plug.Conn.resp(conn, 503, Jason.encode!(%{"error" => "busy"}))
+
+        _attempt ->
+          Plug.Conn.resp(conn, 200, Jason.encode!(%{"ok" => true}))
+      end
+    end)
+
+    assert {:ok, %{status: 200, body: %{"ok" => true}}} =
+             HTTP.request(finch, facilitator_url, "/verify", %{},
+               max_retries: 2,
+               retry_backoff_ms: 1
+             )
+
+    assert Agent.get(attempts, & &1) == 3
+  end
+
+  test "request/5 returns retryable error for 500 after retries exhausted", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    Bypass.stub(bypass, "POST", "/verify", fn conn ->
+      Plug.Conn.resp(conn, 500, Jason.encode!(%{"error" => "server"}))
+    end)
+
+    assert {:error, %Error{type: :http_error, status: 500, retryable: true, attempt: 3}} =
+             HTTP.request(finch, facilitator_url, "/verify", %{},
+               max_retries: 2,
+               retry_backoff_ms: 1
+             )
+  end
+
+  test "request/5 handles receive timeout", %{finch: finch} do
+    assert {:error, %Error{type: :timeout, retryable: true}} =
+             HTTP.request(finch, "http://10.255.255.1:81", "/verify", %{},
+               max_retries: 0,
+               receive_timeout_ms: 10
+             )
+  end
+
+  test "request/5 handles invalid JSON in successful response", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    Bypass.expect(bypass, "POST", "/verify", fn conn ->
+      Plug.Conn.resp(conn, 200, "not-json")
+    end)
+
+    assert {:error, %Error{type: :invalid_json, status: 200, retryable: false}} =
+             HTTP.request(finch, facilitator_url, "/verify", %{}, [])
+  end
+
+  test "request/5 validates options" do
+    assert {:error, %Error{type: :invalid_option, reason: {:max_retries, -1}}} =
+             HTTP.request(:finch, "https://example.com", "/verify", %{}, max_retries: -1)
+  end
+end

--- a/test/x402/facilitator_test.exs
+++ b/test/x402/facilitator_test.exs
@@ -1,0 +1,156 @@
+defmodule X402.FacilitatorTest do
+  use ExUnit.Case, async: false
+
+  alias X402.Facilitator
+  alias X402.Facilitator.Error
+
+  import X402.TestHelpers
+
+  setup :setup_bypass
+  setup :setup_finch
+
+  test "verify/3 posts payload and requirements to /verify", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    payment_payload = %{"signature" => "abc"}
+    requirements = %{"scheme" => "exact"}
+
+    Bypass.expect(bypass, "POST", "/verify", fn conn ->
+      assert {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+      assert %{"payload" => ^payment_payload, "requirements" => ^requirements} =
+               Jason.decode!(body)
+
+      Plug.Conn.resp(conn, 200, Jason.encode!(%{"verified" => true}))
+    end)
+
+    facilitator =
+      start_supervised!(
+        {Facilitator, name: unique_name("facilitator"), finch: finch, url: facilitator_url}
+      )
+
+    assert {:ok, %{status: 200, body: %{"verified" => true}}} =
+             Facilitator.verify(facilitator, payment_payload, requirements)
+  end
+
+  test "settle/3 posts payload and requirements to /settle", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    payment_payload = %{"tx" => "0xdeadbeef"}
+    requirements = %{"network" => "eip155:8453"}
+
+    Bypass.expect(bypass, "POST", "/settle", fn conn ->
+      assert {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+      assert %{"payload" => ^payment_payload, "requirements" => ^requirements} =
+               Jason.decode!(body)
+
+      Plug.Conn.resp(conn, 200, Jason.encode!(%{"settled" => true}))
+    end)
+
+    facilitator =
+      start_supervised!(
+        {Facilitator, name: unique_name("facilitator"), finch: finch, url: facilitator_url}
+      )
+
+    assert {:ok, %{status: 200, body: %{"settled" => true}}} =
+             Facilitator.settle(facilitator, payment_payload, requirements)
+  end
+
+  test "verify/2 and settle/2 use default registered name", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    Bypass.expect(bypass, "POST", "/verify", fn conn ->
+      Plug.Conn.resp(conn, 200, Jason.encode!(%{"verified" => true}))
+    end)
+
+    Bypass.expect(bypass, "POST", "/settle", fn conn ->
+      Plug.Conn.resp(conn, 200, Jason.encode!(%{"settled" => true}))
+    end)
+
+    start_supervised!({Facilitator, finch: finch, url: facilitator_url})
+
+    assert {:ok, %{status: 200, body: %{"verified" => true}}} =
+             Facilitator.verify(%{"p" => 1}, %{"r" => 1})
+
+    assert {:ok, %{status: 200, body: %{"settled" => true}}} =
+             Facilitator.settle(%{"p" => 2}, %{"r" => 2})
+  end
+
+  test "returns structured errors from transport", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    Bypass.expect(bypass, "POST", "/verify", fn conn ->
+      Plug.Conn.resp(conn, 400, Jason.encode!(%{"error" => "bad request"}))
+    end)
+
+    facilitator =
+      start_supervised!(
+        {Facilitator, name: unique_name("facilitator"), finch: finch, url: facilitator_url}
+      )
+
+    assert {:error, %Error{type: :http_error, status: 400, retryable: false}} =
+             Facilitator.verify(facilitator, %{}, %{})
+  end
+
+  test "emits telemetry span events", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    parent = self()
+    handler_id = "facilitator-span-#{System.unique_integer([:positive, :monotonic])}"
+
+    :ok =
+      :telemetry.attach_many(
+        handler_id,
+        [[:x402, :facilitator, :verify, :start], [:x402, :facilitator, :verify, :stop]],
+        fn event, measurements, metadata, _config ->
+          send(parent, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    Bypass.expect(bypass, "POST", "/verify", fn conn ->
+      Plug.Conn.resp(conn, 200, Jason.encode!(%{"verified" => true}))
+    end)
+
+    facilitator =
+      start_supervised!(
+        {Facilitator, name: unique_name("facilitator"), finch: finch, url: facilitator_url}
+      )
+
+    assert {:ok, %{status: 200, body: %{"verified" => true}}} =
+             Facilitator.verify(facilitator, %{}, %{})
+
+    assert_receive {:telemetry, [:x402, :facilitator, :verify, :start], _measurements,
+                    %{operation: :verify, endpoint: "/verify"}}
+
+    assert_receive {:telemetry, [:x402, :facilitator, :verify, :stop], measurements,
+                    %{success: true, status: 200}}
+
+    assert %{duration: duration} = measurements
+    assert is_integer(duration)
+  end
+
+  test "start_link validates required options" do
+    assert {:error, %NimbleOptions.ValidationError{}} = Facilitator.start_link([])
+
+    assert {:error, %NimbleOptions.ValidationError{}} =
+             Facilitator.start_link(finch: :finch, max_retries: -1)
+  end
+
+  defp unique_name(prefix) do
+    String.to_atom("#{prefix}_#{System.unique_integer([:positive, :monotonic])}")
+  end
+end


### PR DESCRIPTION
## Wave 1: Facilitator Client

Implements the facilitator client for x402 payment verification and settlement:

- **X402.Facilitator** — GenServer-based client with NimbleOptions validation
- **X402.Facilitator.HTTP** — HTTP transport with exponential backoff retries
- **X402.Facilitator.Error** — structured error type with retryable flag

### Features
- Verify and settle endpoints with proper error handling
- Exponential backoff retry for transient HTTP errors (408, 429, 5xx)
- Timeout detection and transport error classification
- Finch is optional dependency — graceful error when missing
- NimbleOptions schema validation for all config
- Telemetry spans for observability

### Quality
- 1 doctest + 15 tests = **16 total, 0 failures**
- `mix compile --warnings-as-errors` ✅
- `mix compile --no-optional-deps --warnings-as-errors` ✅
- `mix format --check-formatted` ✅
- `mix credo --strict` ✅ (0 issues after refactor)