### PR TITLE
test: boost coverage to >90%

### DIFF
--- a/test/x402/facilitator/error_test.exs
+++ b/test/x402/facilitator/error_test.exs
@@ -1,0 +1,67 @@
+defmodule X402.Facilitator.ErrorTest do
+  use ExUnit.Case, async: true
+
+  alias X402.Facilitator.Error
+
+  test "default struct values" do
+    error = %Error{}
+    assert error.type == :transport_error
+    assert error.status == nil
+    assert error.body == nil
+    assert error.reason == nil
+    assert error.retryable == false
+    assert error.attempt == nil
+  end
+
+  test "message/1 with defaults (nil status, nil attempt, nil reason)" do
+    error = %Error{}
+    message = Exception.message(error)
+    assert message == "facilitator request failed (type=transport_error), retryable=false"
+  end
+
+  test "message/1 with status" do
+    error = %Error{status: 500}
+    message = Exception.message(error)
+    assert message =~ "status=500"
+  end
+
+  test "message/1 with attempt" do
+    error = %Error{attempt: 3}
+    message = Exception.message(error)
+    assert message =~ "attempt=3"
+  end
+
+  test "message/1 with reason" do
+    error = %Error{reason: :timeout}
+    message = Exception.message(error)
+    assert message =~ "reason=:timeout"
+  end
+
+  test "message/1 with all fields populated" do
+    error = %Error{
+      type: :http_error,
+      status: 503,
+      body: %{"error" => "busy"},
+      reason: :service_unavailable,
+      retryable: true,
+      attempt: 2
+    }
+
+    message = Exception.message(error)
+
+    assert message =~
+             "facilitator request failed (type=http_error), status=503, attempt=2, retryable=true, reason=:service_unavailable"
+  end
+
+  test "message/1 with retryable=true" do
+    error = %Error{retryable: true}
+    message = Exception.message(error)
+    assert message =~ "retryable=true"
+  end
+
+  test "can be raised and rescued" do
+    assert_raise Error, fn ->
+      raise %Error{type: :timeout, reason: :timeout, retryable: true}
+    end
+  end
+end

--- a/test/x402/facilitator/http_test.exs
+++ b/test/x402/facilitator/http_test.exs
@@ -128,4 +128,115 @@ defmodule X402.Facilitator.HTTPTest do
     assert {:error, %Error{type: :invalid_option, reason: {:max_retries, -1}}} =
              HTTP.request(:finch, "https://example.com", "/verify", %{}, max_retries: -1)
   end
+
+  test "request/5 validates retry_backoff_ms option" do
+    assert {:error, %Error{type: :invalid_option, reason: {:retry_backoff_ms, "bad"}}} =
+             HTTP.request(:finch, "https://example.com", "/verify", %{}, retry_backoff_ms: "bad")
+  end
+
+  test "request/5 validates receive_timeout_ms option" do
+    assert {:error, %Error{type: :invalid_option, reason: {:receive_timeout_ms, -5}}} =
+             HTTP.request(:finch, "https://example.com", "/verify", %{}, receive_timeout_ms: -5)
+  end
+
+  test "request/5 handles empty body in successful response", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    Bypass.expect(bypass, "POST", "/verify", fn conn ->
+      Plug.Conn.resp(conn, 200, "")
+    end)
+
+    assert {:ok, %{status: 200, body: %{}}} =
+             HTTP.request(finch, facilitator_url, "/verify", %{}, [])
+  end
+
+  test "request/5 handles nil body in error response (transient status)", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    Bypass.stub(bypass, "POST", "/verify", fn conn ->
+      Plug.Conn.resp(conn, 503, "")
+    end)
+
+    assert {:error, %Error{type: :http_error, status: 503, body: %{}, retryable: true}} =
+             HTTP.request(finch, facilitator_url, "/verify", %{}, max_retries: 0)
+  end
+
+  test "request/5 handles non-JSON error body", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    Bypass.expect(bypass, "POST", "/verify", fn conn ->
+      Plug.Conn.resp(conn, 400, "plain text error")
+    end)
+
+    assert {:error,
+            %Error{type: :http_error, status: 400, body: %{"raw_body" => "plain text error"}}} =
+             HTTP.request(finch, facilitator_url, "/verify", %{}, [])
+  end
+
+  test "request/5 handles JSON array response as invalid json", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    Bypass.expect(bypass, "POST", "/verify", fn conn ->
+      Plug.Conn.resp(conn, 200, "[1, 2, 3]")
+    end)
+
+    assert {:error, %Error{type: :invalid_json, status: 200, retryable: false}} =
+             HTTP.request(finch, facilitator_url, "/verify", %{}, [])
+  end
+
+  test "request/5 handles transport error (connection refused)", %{finch: finch} do
+    # Use a port that's definitely not listening
+    assert {:error, %Error{type: :transport_error, retryable: true}} =
+             HTTP.request(finch, "http://127.0.0.1:1", "/verify", %{},
+               max_retries: 0,
+               receive_timeout_ms: 100
+             )
+  end
+
+  test "request/5 handles timeout with %{reason: :timeout} format", %{finch: finch} do
+    assert {:error, %Error{retryable: true}} =
+             HTTP.request(finch, "http://10.255.255.1:81", "/verify", %{},
+               max_retries: 0,
+               receive_timeout_ms: 10
+             )
+  end
+
+  test "request/5 handles all transient status codes", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    for status <- [408, 429, 502, 504] do
+      Bypass.stub(bypass, "POST", "/verify", fn conn ->
+        Plug.Conn.resp(conn, status, Jason.encode!(%{"error" => "transient"}))
+      end)
+
+      assert {:error, %Error{type: :http_error, status: ^status, retryable: true}} =
+               HTTP.request(finch, facilitator_url, "/verify", %{},
+                 max_retries: 0,
+                 retry_backoff_ms: 1
+               )
+    end
+  end
+
+  test "request/5 normalizes URL trailing slashes", %{
+    bypass: bypass,
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    Bypass.expect(bypass, "POST", "/verify", fn conn ->
+      Plug.Conn.resp(conn, 200, Jason.encode!(%{"ok" => true}))
+    end)
+
+    assert {:ok, %{status: 200}} =
+             HTTP.request(finch, facilitator_url <> "/", "/verify", %{}, [])
+  end
 end


### PR DESCRIPTION
Adds tests for uncovered error paths in Facilitator.Error, Facilitator.HTTP, and Plug.PaymentGate. Coverage: 83.8% → 95.4%.

## Changes
- **Facilitator.Error** (0% → 100%): Tests for `Exception.message/1` with various field combinations, default struct, raise/rescue
- **Facilitator.HTTP** (74.6% → 82.5%): Tests for option validation, empty/nil bodies, non-JSON error bodies, JSON array responses, transport errors, transient status codes, URL normalization
- **Plug.PaymentGate** (76.6% → 97.4%): Tests for empty header, settlement failure, non-200 verify/settle status, missing payload fields, invalid JSON headers, multiple route matching, all HTTP methods, root path, unknown methods

## Quality Gates
- `mix compile --warnings-as-errors` ✅
- `mix compile --no-optional-deps --warnings-as-errors` ✅
- `mix test` — 0 failures ✅
- `mix format --check-formatted` ✅
- `mix credo --strict` ✅