### PR TITLE
feat: payment-identifier idempotency extension

### DIFF
--- a/lib/x402/extensions/payment_identifier.ex
+++ b/lib/x402/extensions/payment_identifier.ex
@@ -1,0 +1,101 @@
+defmodule X402.Extensions.PaymentIdentifier do
+  @moduledoc """
+  Encodes and decodes x402 payment identifier payloads.
+
+  The payment identifier extension payload is Base64-encoded JSON with a
+  required `"paymentId"` field.
+  """
+
+  @typedoc "Payment identifier value used for idempotency."
+  @type payment_id :: String.t()
+
+  @type encode_error :: :invalid_payment_id | :invalid_json
+
+  @type decode_error ::
+          :invalid_base64 | :invalid_json | :missing_payment_id | :invalid_payment_id
+
+  @doc since: "0.1.0"
+  @doc """
+  Encodes a payment identifier to a Base64 JSON payload.
+
+  ## Examples
+
+      iex> {:ok, encoded} = X402.Extensions.PaymentIdentifier.encode("payment-123")
+      iex> {:ok, "payment-123"} = X402.Extensions.PaymentIdentifier.decode(encoded)
+  """
+  @spec encode(payment_id()) :: {:ok, String.t()} | {:error, encode_error()}
+  def encode(payment_id) when is_binary(payment_id) and payment_id != "" do
+    payload = %{"paymentId" => payment_id}
+
+    case Jason.encode(payload) do
+      {:ok, json} -> {:ok, Base.encode64(json)}
+      {:error, _reason} -> {:error, :invalid_json}
+    end
+  end
+
+  def encode(_payment_id), do: {:error, :invalid_payment_id}
+
+  @doc since: "0.1.0"
+  @doc """
+  Decodes a Base64 JSON payload and returns the payment identifier.
+
+  ## Examples
+
+      iex> {:ok, encoded} = X402.Extensions.PaymentIdentifier.encode("payment-123")
+      iex> X402.Extensions.PaymentIdentifier.decode(encoded)
+      {:ok, "payment-123"}
+
+      iex> X402.Extensions.PaymentIdentifier.decode("not-base64")
+      {:error, :invalid_base64}
+  """
+  @spec decode(String.t()) :: {:ok, payment_id()} | {:error, decode_error()}
+  def decode(value) when is_binary(value) do
+    with {:ok, json} <- decode_base64(value),
+         {:ok, decoded} <- Jason.decode(json),
+         {:ok, payment_id} <- fetch_payment_id(decoded) do
+      {:ok, payment_id}
+    else
+      {:error, :invalid_base64} -> {:error, :invalid_base64}
+      {:error, :missing_payment_id} -> {:error, :missing_payment_id}
+      {:error, :invalid_payment_id} -> {:error, :invalid_payment_id}
+      {:error, %Jason.DecodeError{}} -> {:error, :invalid_json}
+      _other -> {:error, :invalid_json}
+    end
+  end
+
+  def decode(_value), do: {:error, :invalid_base64}
+
+  @doc since: "0.1.0"
+  @doc """
+  Extracts and validates `"paymentId"` from a decoded payload map.
+
+  ## Examples
+
+      iex> X402.Extensions.PaymentIdentifier.fetch_payment_id(%{"paymentId" => "pay-1"})
+      {:ok, "pay-1"}
+
+      iex> X402.Extensions.PaymentIdentifier.fetch_payment_id(%{})
+      {:error, :missing_payment_id}
+  """
+  @spec fetch_payment_id(term()) ::
+          {:ok, payment_id()} | {:error, :missing_payment_id | :invalid_payment_id}
+  def fetch_payment_id(payload) when is_map(payload) do
+    case Map.fetch(payload, "paymentId") do
+      {:ok, payment_id} when is_binary(payment_id) and payment_id != "" -> {:ok, payment_id}
+      {:ok, _invalid} -> {:error, :invalid_payment_id}
+      :error -> {:error, :missing_payment_id}
+    end
+  end
+
+  def fetch_payment_id(_payload), do: {:error, :invalid_payment_id}
+
+  @spec decode_base64(String.t()) :: {:ok, String.t()} | {:error, :invalid_base64}
+  defp decode_base64(""), do: {:error, :invalid_base64}
+
+  defp decode_base64(value) do
+    case Base.decode64(value) do
+      {:ok, decoded} -> {:ok, decoded}
+      :error -> {:error, :invalid_base64}
+    end
+  end
+end

--- a/lib/x402/extensions/payment_identifier.ex
+++ b/lib/x402/extensions/payment_identifier.ex
@@ -59,7 +59,6 @@ defmodule X402.Extensions.PaymentIdentifier do
       {:error, :missing_payment_id} -> {:error, :missing_payment_id}
       {:error, :invalid_payment_id} -> {:error, :invalid_payment_id}
       {:error, %Jason.DecodeError{}} -> {:error, :invalid_json}
-      _other -> {:error, :invalid_json}
     end
   end
 

--- a/lib/x402/extensions/payment_identifier/cache.ex
+++ b/lib/x402/extensions/payment_identifier/cache.ex
@@ -1,0 +1,97 @@
+defmodule X402.Extensions.PaymentIdentifier.Cache do
+  @moduledoc """
+  Behaviour and adapter helpers for payment identifier idempotency caches.
+
+  Cache adapters are configured as `{module, cache}` tuples where `module`
+  implements this behaviour and `cache` is adapter-specific runtime state
+  (for example, a pid or registered process name).
+  """
+
+  alias X402.Extensions.PaymentIdentifier
+
+  @typedoc "Payment identifier cache key."
+  @type key :: PaymentIdentifier.payment_id()
+
+  @typedoc "Value stored for a given payment identifier."
+  @type value :: :verified | {:rejected, term()}
+
+  @typedoc "Adapter tuple accepted by `X402.Plug.PaymentGate`."
+  @type adapter :: {module(), term()}
+
+  @typedoc "Result returned by `get/2`."
+  @type get_result :: {:hit, value()} | :miss | {:error, term()}
+
+  @typedoc "Result returned by write/delete operations."
+  @type write_result :: :ok | {:error, term()}
+
+  @callback get(cache :: term(), key()) :: get_result()
+  @callback put(cache :: term(), key(), value()) :: write_result()
+  @callback delete(cache :: term(), key()) :: write_result()
+
+  @required_callbacks [get: 2, put: 3, delete: 2]
+
+  @doc since: "0.1.0"
+  @doc """
+  Validates a cache adapter tuple for `NimbleOptions` custom validation.
+  """
+  @spec validate_adapter(term()) :: :ok | {:error, String.t()}
+  def validate_adapter({module, _cache}) when is_atom(module) do
+    case implementation?(module) do
+      true -> :ok
+      false -> {:error, "expected a cache adapter tuple {module, cache}"}
+    end
+  end
+
+  def validate_adapter(_invalid), do: {:error, "expected a cache adapter tuple {module, cache}"}
+
+  @doc since: "0.1.0"
+  @doc """
+  Validates an optional cache adapter for `NimbleOptions`.
+
+  `nil` disables idempotency caching.
+  """
+  @spec validate_optional_adapter(term()) :: :ok | {:error, String.t()}
+  def validate_optional_adapter(nil), do: :ok
+  def validate_optional_adapter(adapter), do: validate_adapter(adapter)
+
+  @doc since: "0.1.0"
+  @doc """
+  Reads a cached value for a payment identifier.
+  """
+  @spec get(adapter(), key()) :: get_result()
+  def get({module, cache}, payment_id) when is_binary(payment_id) do
+    module.get(cache, payment_id)
+  end
+
+  def get(_adapter, _payment_id), do: {:error, :invalid_adapter}
+
+  @doc since: "0.1.0"
+  @doc """
+  Stores a cached value for a payment identifier.
+  """
+  @spec put(adapter(), key(), value()) :: write_result()
+  def put({module, cache}, payment_id, value) when is_binary(payment_id) do
+    module.put(cache, payment_id, value)
+  end
+
+  def put(_adapter, _payment_id, _value), do: {:error, :invalid_adapter}
+
+  @doc since: "0.1.0"
+  @doc """
+  Deletes a cached value for a payment identifier.
+  """
+  @spec delete(adapter(), key()) :: write_result()
+  def delete({module, cache}, payment_id) when is_binary(payment_id) do
+    module.delete(cache, payment_id)
+  end
+
+  def delete(_adapter, _payment_id), do: {:error, :invalid_adapter}
+
+  @spec implementation?(module()) :: boolean()
+  defp implementation?(module) do
+    Code.ensure_loaded?(module) and
+      Enum.all?(@required_callbacks, fn {name, arity} ->
+        function_exported?(module, name, arity)
+      end)
+  end
+end

--- a/lib/x402/extensions/payment_identifier/ets_cache.ex
+++ b/lib/x402/extensions/payment_identifier/ets_cache.ex
@@ -1,0 +1,196 @@
+defmodule X402.Extensions.PaymentIdentifier.ETSCache do
+  @moduledoc """
+  ETS-backed cache adapter for payment identifier idempotency.
+
+  Entries expire after `:ttl_ms` (default: 1 hour). Expired entries are removed
+  by an internal periodic cleanup loop.
+  """
+
+  use GenServer
+
+  @behaviour X402.Extensions.PaymentIdentifier.Cache
+
+  alias X402.Extensions.PaymentIdentifier.Cache
+
+  @default_name __MODULE__
+  @default_ttl_ms :timer.hours(1)
+  @default_cleanup_interval_ms :timer.minutes(1)
+
+  @start_link_options_schema [
+    name: [
+      type: :any,
+      default: @default_name,
+      doc: "Registered name for the ETS cache process."
+    ],
+    ttl_ms: [
+      type: :non_neg_integer,
+      default: @default_ttl_ms,
+      doc: "Time-to-live for entries in milliseconds."
+    ],
+    cleanup_interval_ms: [
+      type: :pos_integer,
+      default: @default_cleanup_interval_ms,
+      doc: "How often expired entries are cleaned up, in milliseconds."
+    ]
+  ]
+
+  @typedoc "Server identifier accepted by `GenServer.call/3`."
+  @type server :: GenServer.server()
+
+  @typedoc false
+  @type state :: %{
+          table: :ets.tid(),
+          ttl_ms: non_neg_integer(),
+          cleanup_interval_ms: pos_integer(),
+          cleanup_timer: reference()
+        }
+
+  @doc """
+  Starts an ETS-backed idempotency cache process.
+
+  ## Options
+
+  #{NimbleOptions.docs(@start_link_options_schema)}
+  """
+  @doc since: "0.1.0"
+  @spec start_link(keyword()) ::
+          GenServer.on_start() | {:error, NimbleOptions.ValidationError.t()}
+  def start_link(opts \\ []) when is_list(opts) do
+    with {:ok, validated_opts} <- NimbleOptions.validate(opts, @start_link_options_schema) do
+      name = Keyword.fetch!(validated_opts, :name)
+      GenServer.start_link(__MODULE__, validated_opts, name: name)
+    end
+  end
+
+  @doc """
+  Returns a child specification for `X402.Extensions.PaymentIdentifier.ETSCache`.
+  """
+  @doc since: "0.1.0"
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) when is_list(opts) do
+    validated_opts = NimbleOptions.validate!(opts, @start_link_options_schema)
+
+    %{
+      id: Keyword.fetch!(validated_opts, :name),
+      start: {__MODULE__, :start_link, [validated_opts]},
+      type: :worker,
+      restart: :permanent,
+      shutdown: 5_000
+    }
+  end
+
+  @doc since: "0.1.0"
+  @doc """
+  Looks up a payment identifier in the cache.
+  """
+  @impl Cache
+  @spec get(server(), Cache.key()) :: Cache.get_result()
+  def get(cache, payment_id) when is_binary(payment_id) do
+    GenServer.call(cache, {:get, payment_id})
+  end
+
+  def get(_cache, _payment_id), do: {:error, :invalid_payment_id}
+
+  @doc since: "0.1.0"
+  @doc """
+  Stores a payment identifier result in the cache.
+  """
+  @impl Cache
+  @spec put(server(), Cache.key(), Cache.value()) :: Cache.write_result()
+  def put(cache, payment_id, value) when is_binary(payment_id) do
+    case valid_value?(value) do
+      true -> GenServer.call(cache, {:put, payment_id, value})
+      false -> {:error, :invalid_cache_value}
+    end
+  end
+
+  def put(_cache, _payment_id, _value), do: {:error, :invalid_payment_id}
+
+  @doc since: "0.1.0"
+  @doc """
+  Deletes a payment identifier entry from the cache.
+  """
+  @impl Cache
+  @spec delete(server(), Cache.key()) :: Cache.write_result()
+  def delete(cache, payment_id) when is_binary(payment_id) do
+    GenServer.call(cache, {:delete, payment_id})
+  end
+
+  def delete(_cache, _payment_id), do: {:error, :invalid_payment_id}
+
+  @impl true
+  @spec init(keyword()) :: {:ok, state()}
+  def init(opts) do
+    ttl_ms = Keyword.fetch!(opts, :ttl_ms)
+    cleanup_interval_ms = Keyword.fetch!(opts, :cleanup_interval_ms)
+    table = :ets.new(__MODULE__, [:set, :private, read_concurrency: true])
+
+    state = %{
+      table: table,
+      ttl_ms: ttl_ms,
+      cleanup_interval_ms: cleanup_interval_ms,
+      cleanup_timer: schedule_cleanup(cleanup_interval_ms)
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  @spec handle_call(term(), GenServer.from(), state()) :: {:reply, term(), state()}
+  def handle_call({:get, payment_id}, _from, state) do
+    now_ms = now_ms()
+
+    reply =
+      case :ets.lookup(state.table, payment_id) do
+        [{^payment_id, value, expires_at_ms}] when expires_at_ms > now_ms ->
+          {:hit, value}
+
+        [{^payment_id, _value, _expires_at_ms}] ->
+          :ets.delete(state.table, payment_id)
+          :miss
+
+        [] ->
+          :miss
+      end
+
+    {:reply, reply, state}
+  end
+
+  def handle_call({:put, payment_id, value}, _from, state) do
+    expires_at_ms = now_ms() + state.ttl_ms
+    true = :ets.insert(state.table, {payment_id, value, expires_at_ms})
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:delete, payment_id}, _from, state) do
+    true = :ets.delete(state.table, payment_id)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  @spec handle_info(:cleanup, state()) :: {:noreply, state()}
+  def handle_info(:cleanup, state) do
+    delete_expired_entries(state.table, now_ms())
+
+    next_state = %{state | cleanup_timer: schedule_cleanup(state.cleanup_interval_ms)}
+    {:noreply, next_state}
+  end
+
+  @spec schedule_cleanup(pos_integer()) :: reference()
+  defp schedule_cleanup(cleanup_interval_ms) do
+    Process.send_after(self(), :cleanup, cleanup_interval_ms)
+  end
+
+  @spec delete_expired_entries(:ets.tid(), non_neg_integer()) :: non_neg_integer()
+  defp delete_expired_entries(table, now_ms) do
+    :ets.select_delete(table, [{{:"$1", :"$2", :"$3"}, [{:"=<", :"$3", now_ms}], [true]}])
+  end
+
+  @spec now_ms() :: non_neg_integer()
+  defp now_ms, do: System.monotonic_time(:millisecond)
+
+  @spec valid_value?(term()) :: boolean()
+  defp valid_value?(:verified), do: true
+  defp valid_value?({:rejected, _reason}), do: true
+  defp valid_value?(_invalid), do: false
+end

--- a/test/x402/extensions/payment_identifier/cache_test.exs
+++ b/test/x402/extensions/payment_identifier/cache_test.exs
@@ -1,0 +1,67 @@
+defmodule X402.Extensions.PaymentIdentifier.CacheTest do
+  use ExUnit.Case, async: true
+
+  alias X402.Extensions.PaymentIdentifier.Cache
+
+  defmodule ValidCache do
+    @moduledoc false
+    @behaviour Cache
+
+    @impl Cache
+    def get(owner, payment_id) do
+      send(owner, {:cache_get, payment_id})
+      :miss
+    end
+
+    @impl Cache
+    def put(owner, payment_id, value) do
+      send(owner, {:cache_put, payment_id, value})
+      :ok
+    end
+
+    @impl Cache
+    def delete(owner, payment_id) do
+      send(owner, {:cache_delete, payment_id})
+      :ok
+    end
+  end
+
+  defmodule InvalidCache do
+    @moduledoc false
+
+    def get(_cache, _payment_id), do: :miss
+  end
+
+  test "validate_adapter/1 accepts behaviour implementations" do
+    assert :ok = Cache.validate_adapter({ValidCache, self()})
+  end
+
+  test "validate_adapter/1 rejects invalid adapter values" do
+    assert {:error, _message} = Cache.validate_adapter({InvalidCache, self()})
+    assert {:error, _message} = Cache.validate_adapter(:invalid)
+  end
+
+  test "validate_optional_adapter/1 allows nil and valid adapters" do
+    assert :ok = Cache.validate_optional_adapter(nil)
+    assert :ok = Cache.validate_optional_adapter({ValidCache, self()})
+  end
+
+  test "get/2, put/3, and delete/2 dispatch to adapter module" do
+    adapter = {ValidCache, self()}
+
+    assert :miss = Cache.get(adapter, "payment-1")
+    assert_receive {:cache_get, "payment-1"}
+
+    assert :ok = Cache.put(adapter, "payment-1", :verified)
+    assert_receive {:cache_put, "payment-1", :verified}
+
+    assert :ok = Cache.delete(adapter, "payment-1")
+    assert_receive {:cache_delete, "payment-1"}
+  end
+
+  test "returns invalid adapter errors for malformed adapter tuples" do
+    assert {:error, :invalid_adapter} = Cache.get(:invalid, "payment-1")
+    assert {:error, :invalid_adapter} = Cache.put(:invalid, "payment-1", :verified)
+    assert {:error, :invalid_adapter} = Cache.delete(:invalid, "payment-1")
+  end
+end

--- a/test/x402/extensions/payment_identifier/ets_cache_test.exs
+++ b/test/x402/extensions/payment_identifier/ets_cache_test.exs
@@ -1,0 +1,90 @@
+defmodule X402.Extensions.PaymentIdentifier.ETSCacheTest do
+  use ExUnit.Case, async: false
+
+  alias X402.Extensions.PaymentIdentifier.ETSCache
+
+  test "put/3 and get/2 store and retrieve verified entries" do
+    cache = start_cache(ttl_ms: 1_000)
+
+    assert :ok = ETSCache.put(cache, "payment-1", :verified)
+    assert {:hit, :verified} = ETSCache.get(cache, "payment-1")
+  end
+
+  test "delete/2 removes entries" do
+    cache = start_cache(ttl_ms: 1_000)
+
+    assert :ok = ETSCache.put(cache, "payment-1", :verified)
+    assert :ok = ETSCache.delete(cache, "payment-1")
+    assert :miss = ETSCache.get(cache, "payment-1")
+  end
+
+  test "get/2 expires entries after ttl" do
+    cache = start_cache(ttl_ms: 10)
+
+    assert :ok = ETSCache.put(cache, "payment-1", :verified)
+    Process.sleep(20)
+
+    assert :miss = ETSCache.get(cache, "payment-1")
+  end
+
+  test "cleanup process removes expired entries periodically" do
+    cache = start_cache(ttl_ms: 10, cleanup_interval_ms: 10)
+
+    assert :ok = ETSCache.put(cache, "payment-1", :verified)
+
+    %{table: table} = :sys.get_state(cache)
+    assert :ets.info(table, :size) == 1
+
+    assert :ok = wait_until(fn -> :ets.info(table, :size) == 0 end)
+  end
+
+  test "supports rejected values" do
+    cache = start_cache(ttl_ms: 1_000)
+
+    assert :ok = ETSCache.put(cache, "payment-1", {:rejected, :verification_failed})
+    assert {:hit, {:rejected, :verification_failed}} = ETSCache.get(cache, "payment-1")
+  end
+
+  test "rejects invalid value and invalid payment identifiers" do
+    cache = start_cache(ttl_ms: 1_000)
+
+    assert {:error, :invalid_cache_value} = ETSCache.put(cache, "payment-1", :unknown)
+    assert {:error, :invalid_payment_id} = ETSCache.put(cache, :invalid, :verified)
+    assert {:error, :invalid_payment_id} = ETSCache.get(cache, :invalid)
+    assert {:error, :invalid_payment_id} = ETSCache.delete(cache, :invalid)
+  end
+
+  test "start_link/1 validates options" do
+    assert {:error, %NimbleOptions.ValidationError{}} =
+             ETSCache.start_link(cleanup_interval_ms: 0)
+  end
+
+  test "child_spec/1 uses the configured name as id" do
+    assert %{id: :custom_cache} = ETSCache.child_spec(name: :custom_cache)
+  end
+
+  defp start_cache(opts) do
+    name = String.to_atom("ets_cache_#{System.unique_integer([:positive, :monotonic])}")
+    options = Keyword.merge([name: name, cleanup_interval_ms: 50], opts)
+
+    start_supervised!(%{
+      id: {:ets_cache, System.unique_integer([:positive, :monotonic])},
+      start: {ETSCache, :start_link, [options]}
+    })
+  end
+
+  defp wait_until(fun, attempts \\ 20)
+
+  defp wait_until(fun, attempts) when attempts > 0 do
+    case fun.() do
+      true ->
+        :ok
+
+      false ->
+        Process.sleep(10)
+        wait_until(fun, attempts - 1)
+    end
+  end
+
+  defp wait_until(_fun, 0), do: {:error, :timeout}
+end

--- a/test/x402/extensions/payment_identifier_test.exs
+++ b/test/x402/extensions/payment_identifier_test.exs
@@ -1,0 +1,51 @@
+defmodule X402.Extensions.PaymentIdentifierTest do
+  use ExUnit.Case, async: true
+
+  doctest X402.Extensions.PaymentIdentifier
+
+  alias X402.Extensions.PaymentIdentifier
+
+  test "encode/1 returns Base64 JSON payload with paymentId" do
+    assert {:ok, encoded} = PaymentIdentifier.encode("payment-123")
+
+    assert {:ok, decoded_json} = Base.decode64(encoded)
+    assert %{"paymentId" => "payment-123"} = Jason.decode!(decoded_json)
+  end
+
+  test "encode/1 rejects empty and non-binary payment identifiers" do
+    assert {:error, :invalid_payment_id} = PaymentIdentifier.encode("")
+    assert {:error, :invalid_payment_id} = PaymentIdentifier.encode(nil)
+    assert {:error, :invalid_payment_id} = PaymentIdentifier.encode(123)
+  end
+
+  test "decode/1 returns payment identifier from encoded payload" do
+    assert {:ok, encoded} = PaymentIdentifier.encode("payment-abc")
+    assert {:ok, "payment-abc"} = PaymentIdentifier.decode(encoded)
+  end
+
+  test "decode/1 handles malformed payloads" do
+    assert {:error, :invalid_base64} = PaymentIdentifier.decode("not-base64")
+    assert {:error, :invalid_base64} = PaymentIdentifier.decode("")
+    assert {:error, :invalid_base64} = PaymentIdentifier.decode(nil)
+
+    invalid_json = Base.encode64("not-json")
+    assert {:error, :invalid_json} = PaymentIdentifier.decode(invalid_json)
+
+    missing_id = Base.encode64(Jason.encode!(%{"foo" => "bar"}))
+    assert {:error, :missing_payment_id} = PaymentIdentifier.decode(missing_id)
+
+    invalid_id = Base.encode64(Jason.encode!(%{"paymentId" => 123}))
+    assert {:error, :invalid_payment_id} = PaymentIdentifier.decode(invalid_id)
+  end
+
+  test "fetch_payment_id/1 validates paymentId field" do
+    assert {:ok, "payment-1"} = PaymentIdentifier.fetch_payment_id(%{"paymentId" => "payment-1"})
+    assert {:error, :missing_payment_id} = PaymentIdentifier.fetch_payment_id(%{})
+
+    assert {:error, :invalid_payment_id} =
+             PaymentIdentifier.fetch_payment_id(%{"paymentId" => ""})
+
+    assert {:error, :invalid_payment_id} = PaymentIdentifier.fetch_payment_id(%{"paymentId" => 1})
+    assert {:error, :invalid_payment_id} = PaymentIdentifier.fetch_payment_id("bad")
+  end
+end


### PR DESCRIPTION
## Payment-Identifier Extension (v0.2 Roadmap)

New modules (602 lines):
- `X402.Extensions.PaymentIdentifier` — encode/decode payment IDs
- `X402.Extensions.PaymentIdentifier.Cache` — behaviour for cache adapters  
- `X402.Extensions.PaymentIdentifier.ETSCache` — default ETS adapter with TTL

125 tests pass. Formatted. --warnings-as-errors clean.

_Built by Codex, curated by Kai._