### PR TITLE
🔒 [security fix] Fix Unbounded ETS Cache Growth (DoS)

### DIFF
--- a/lib/x402/extensions/payment_identifier/ets_cache.ex
+++ b/lib/x402/extensions/payment_identifier/ets_cache.ex
@@ -166,7 +166,8 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCache do
   end
 
   def handle_call({:put, payment_id, value}, _from, state) do
-    if :ets.info(state.table, :size) >= state.max_size and not :ets.member(state.table, payment_id) do
+    if :ets.info(state.table, :size) >= state.max_size and
+         not :ets.member(state.table, payment_id) do
       case :ets.first(state.table) do
         :"$end_of_table" -> :ok
         key -> :ets.delete(state.table, key)

--- a/lib/x402/extensions/payment_identifier/ets_cache.ex
+++ b/lib/x402/extensions/payment_identifier/ets_cache.ex
@@ -15,6 +15,7 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCache do
   @default_name __MODULE__
   @default_ttl_ms :timer.hours(1)
   @default_cleanup_interval_ms :timer.minutes(1)
+  @default_max_size 10_000
 
   @start_link_options_schema [
     name: [
@@ -31,6 +32,11 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCache do
       type: :pos_integer,
       default: @default_cleanup_interval_ms,
       doc: "How often expired entries are cleaned up, in milliseconds."
+    ],
+    max_size: [
+      type: :pos_integer,
+      default: @default_max_size,
+      doc: "Maximum number of entries in the cache."
     ]
   ]
 
@@ -41,6 +47,7 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCache do
   @type state :: %{
           table: :ets.tid(),
           ttl_ms: non_neg_integer(),
+          max_size: pos_integer(),
           cleanup_interval_ms: pos_integer(),
           cleanup_timer: reference()
         }
@@ -122,12 +129,14 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCache do
   @spec init(keyword()) :: {:ok, state()}
   def init(opts) do
     ttl_ms = Keyword.fetch!(opts, :ttl_ms)
+    max_size = Keyword.fetch!(opts, :max_size)
     cleanup_interval_ms = Keyword.fetch!(opts, :cleanup_interval_ms)
     table = :ets.new(__MODULE__, [:set, :private, read_concurrency: true])
 
     state = %{
       table: table,
       ttl_ms: ttl_ms,
+      max_size: max_size,
       cleanup_interval_ms: cleanup_interval_ms,
       cleanup_timer: schedule_cleanup(cleanup_interval_ms)
     }
@@ -157,6 +166,13 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCache do
   end
 
   def handle_call({:put, payment_id, value}, _from, state) do
+    if :ets.info(state.table, :size) >= state.max_size and not :ets.member(state.table, payment_id) do
+      case :ets.first(state.table) do
+        :"$end_of_table" -> :ok
+        key -> :ets.delete(state.table, key)
+      end
+    end
+
     expires_at_ms = now_ms() + state.ttl_ms
     true = :ets.insert(state.table, {payment_id, value, expires_at_ms})
     {:reply, :ok, state}

--- a/test/x402/extensions/payment_identifier/ets_cache_security_test.exs
+++ b/test/x402/extensions/payment_identifier/ets_cache_security_test.exs
@@ -1,0 +1,55 @@
+defmodule X402.Extensions.PaymentIdentifier.ETSCacheSecurityTest do
+  use ExUnit.Case, async: false
+
+  alias X402.Extensions.PaymentIdentifier.ETSCache
+
+  test "enforces max_size limit" do
+    max_size = 10
+    cache = start_cache(max_size: max_size)
+
+    # Fill the cache
+    for i <- 1..max_size do
+      assert :ok = ETSCache.put(cache, "payment-#{i}", :verified)
+    end
+
+    %{table: table} = :sys.get_state(cache)
+    assert :ets.info(table, :size) == max_size
+
+    # Add one more
+    assert :ok = ETSCache.put(cache, "payment-#{max_size + 1}", :verified)
+
+    # Size should still be max_size
+    assert :ets.info(table, :size) == max_size
+  end
+
+  test "updating existing key does not evict another key when at max_size" do
+    max_size = 10
+    cache = start_cache(max_size: max_size)
+
+    # Fill the cache
+    for i <- 1..max_size do
+      assert :ok = ETSCache.put(cache, "payment-#{i}", :verified)
+    end
+
+    %{table: table} = :sys.get_state(cache)
+    assert :ets.info(table, :size) == max_size
+
+    # Update an existing key
+    assert :ok = ETSCache.put(cache, "payment-1", :verified)
+
+    # Size should still be max_size
+    assert :ets.info(table, :size) == max_size
+    # Ensure "payment-1" is still there
+    assert {:hit, :verified} = ETSCache.get(cache, "payment-1")
+  end
+
+  defp start_cache(opts) do
+    name = String.to_atom("ets_cache_security_#{System.unique_integer([:positive, :monotonic])}")
+    options = Keyword.merge([name: name, cleanup_interval_ms: 60_000], opts)
+
+    start_supervised!(%{
+      id: {:ets_cache, System.unique_integer([:positive, :monotonic])},
+      start: {ETSCache, :start_link, [options]}
+    })
+  end
+end


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
This PR fixes an **Unbounded ETS Cache Growth** vulnerability in the `ETSCache` adapter, which could be exploited to cause a **Denial of Service (DoS)** by exhausting server memory.

### ⚠️ Risk: The potential impact if left unfixed
An attacker could repeatedly trigger cache insertions with unique payment identifiers, causing the ETS table to grow indefinitely until the Erlang VM runs out of memory and crashes.

### 🛡️ Solution: How the fix addresses the vulnerability
- **Bounded Growth:** Introduced a `max_size` configuration option (defaulting to 10,000 entries).
- **Eviction Policy:** When the cache is full and a new entry is added, the oldest (or arbitrary, via `:ets.first/1`) entry is evicted to make room for the new one.
- **Efficiency:** The size check and eviction are O(1) operations, ensuring no performance penalty under normal load or attack.
- **Idempotency Awareness:** Updates to existing keys do not trigger eviction, preserving the integrity of the cache when re-verifying payments.
- **Verification:** Added a new test suite that validates the size limit enforcement and correct update behavior.


---
*PR created automatically by Jules for task [2953027326812864403](https://jules.google.com/task/2953027326812864403) started by @cardotrejos*