### PR TITLE
⚡ [performance] Implement lazy evaluation for max price and payment sources

### DIFF
--- a/lib/x402/facilitator.ex
+++ b/lib/x402/facilitator.ex
@@ -386,10 +386,10 @@ defmodule X402.Facilitator do
   defp extract_max_price(payload, requirements) do
     value =
       first_present([
-        map_value(requirements, {"maxPrice", :maxPrice}),
-        map_value(requirements, {"maxAmountRequired", :maxAmountRequired}),
-        map_value(payload, {"maxPrice", :maxPrice}),
-        map_value(payload, {"maxAmountRequired", :maxAmountRequired})
+        fn -> map_value(requirements, {"maxPrice", :maxPrice}) end,
+        fn -> map_value(requirements, {"maxAmountRequired", :maxAmountRequired}) end,
+        fn -> map_value(payload, {"maxPrice", :maxPrice}) end,
+        fn -> map_value(payload, {"maxAmountRequired", :maxAmountRequired}) end
       ])
 
     case value do
@@ -407,14 +407,18 @@ defmodule X402.Facilitator do
   defp extract_payment_value(payload) do
     value =
       first_present([
-        map_value(payload, {"value", :value}),
-        nested_map_value(payload, [{"payload", :payload}, {"value", :value}]),
-        nested_map_value(payload, [
-          {"payload", :payload},
-          {"authorization", :authorization},
-          {"value", :value}
-        ]),
-        nested_map_value(payload, [{"authorization", :authorization}, {"value", :value}])
+        fn -> map_value(payload, {"value", :value}) end,
+        fn -> nested_map_value(payload, [{"payload", :payload}, {"value", :value}]) end,
+        fn ->
+          nested_map_value(payload, [
+            {"payload", :payload},
+            {"authorization", :authorization},
+            {"value", :value}
+          ])
+        end,
+        fn ->
+          nested_map_value(payload, [{"authorization", :authorization}, {"value", :value}])
+        end
       ])
 
     case value do
@@ -504,7 +508,14 @@ defmodule X402.Facilitator do
     end
   end
 
-  defp first_present(values), do: Enum.find(values, &(not is_nil(&1)))
+  defp first_present(thunks) do
+    Enum.reduce_while(thunks, nil, fn thunk, _acc ->
+      case thunk.() do
+        nil -> {:cont, nil}
+        value -> {:halt, value}
+      end
+    end)
+  end
 
   defp before_callback(:verify), do: :before_verify
   defp before_callback(:settle), do: :before_settle

--- a/lib/x402/payment_signature.ex
+++ b/lib/x402/payment_signature.ex
@@ -259,10 +259,10 @@ defmodule X402.PaymentSignature do
   defp extract_max_price(payload, requirements) do
     value =
       first_present([
-        map_value(requirements, {"maxPrice", :maxPrice}),
-        map_value(requirements, {"maxAmountRequired", :maxAmountRequired}),
-        map_value(payload, {"maxPrice", :maxPrice}),
-        map_value(payload, {"maxAmountRequired", :maxAmountRequired})
+        fn -> map_value(requirements, {"maxPrice", :maxPrice}) end,
+        fn -> map_value(requirements, {"maxAmountRequired", :maxAmountRequired}) end,
+        fn -> map_value(payload, {"maxPrice", :maxPrice}) end,
+        fn -> map_value(payload, {"maxAmountRequired", :maxAmountRequired}) end
       ])
 
     case value do
@@ -283,14 +283,18 @@ defmodule X402.PaymentSignature do
   defp extract_payment_value(payload) do
     value =
       first_present([
-        map_value(payload, {"value", :value}),
-        nested_map_value(payload, [{"payload", :payload}, {"value", :value}]),
-        nested_map_value(payload, [
-          {"payload", :payload},
-          {"authorization", :authorization},
-          {"value", :value}
-        ]),
-        nested_map_value(payload, [{"authorization", :authorization}, {"value", :value}])
+        fn -> map_value(payload, {"value", :value}) end,
+        fn -> nested_map_value(payload, [{"payload", :payload}, {"value", :value}]) end,
+        fn ->
+          nested_map_value(payload, [
+            {"payload", :payload},
+            {"authorization", :authorization},
+            {"value", :value}
+          ])
+        end,
+        fn ->
+          nested_map_value(payload, [{"authorization", :authorization}, {"value", :value}])
+        end
       ])
 
     case value do
@@ -393,6 +397,13 @@ defmodule X402.PaymentSignature do
     end
   end
 
-  @spec first_present([term()]) :: term() | nil
-  defp first_present(values), do: Enum.find(values, &(not is_nil(&1)))
+  @spec first_present([(() -> term())]) :: term() | nil
+  defp first_present(thunks) do
+    Enum.reduce_while(thunks, nil, fn thunk, _acc ->
+      case thunk.() do
+        nil -> {:cont, nil}
+        value -> {:halt, value}
+      end
+    end)
+  end
 end


### PR DESCRIPTION
💡 **What:** Refactored `first_present/1` to support lazy evaluation using thunks (anonymous functions) and updated call sites in `PaymentSignature` and `Facilitator`.
🎯 **Why:** The previous implementation eagerly evaluated multiple data sources (involving map lookups and nested map traversals) even when the first source provided a value. Lazy evaluation ensures we only perform the necessary lookups.
📊 **Measured Improvement:** Impractical to measure via benchmarks in the current sandbox environment due to missing Elixir runtime. However, the theoretical improvement is significant: reducing up to 8 map lookups per call down to 1 in the most common cases for `extract_max_price` and `extract_payment_value`.

---
*PR created automatically by Jules for task [18042447694965715362](https://jules.google.com/task/18042447694965715362) started by @cardotrejos*