### PR TITLE
fix: prevent double-settlement on retry and normalize ETS address casing

### DIFF
--- a/lib/x402/extensions/siwx/ets_storage.ex
+++ b/lib/x402/extensions/siwx/ets_storage.ex
@@ -16,6 +16,7 @@ defmodule X402.Extensions.SIWX.ETSStorage do
   @default_name __MODULE__
   @default_table :x402_siwx_storage
   @default_cleanup_interval_ms 60_000
+  @max_resource_bytes 2048
 
   @start_link_options_schema [
     name: [
@@ -98,7 +99,7 @@ defmodule X402.Extensions.SIWX.ETSStorage do
           {:ok, X402.Extensions.SIWX.Storage.access_record()} | {:error, :not_found}
   def get(table, address, resource)
       when is_atom(table) and is_binary(address) and is_binary(resource) do
-    key = {address, resource}
+    key = {String.downcase(address), resource}
     now = now_ms()
 
     case :ets.lookup(table, key) do
@@ -129,7 +130,11 @@ defmodule X402.Extensions.SIWX.ETSStorage do
   @spec put(server(), String.t(), String.t(), term(), non_neg_integer()) :: :ok | {:error, term()}
   def put(server, address, resource, payment_proof, ttl_ms)
       when is_binary(address) and is_binary(resource) and is_integer(ttl_ms) and ttl_ms >= 0 do
-    GenServer.call(server, {:put, address, resource, payment_proof, ttl_ms})
+    if byte_size(resource) > @max_resource_bytes do
+      {:error, {:resource_too_long, @max_resource_bytes}}
+    else
+      GenServer.call(server, {:put, address, resource, payment_proof, ttl_ms})
+    end
   end
 
   def put(_server, _address, _resource, _payment_proof, _ttl_ms), do: {:error, :invalid_arguments}
@@ -179,7 +184,7 @@ defmodule X402.Extensions.SIWX.ETSStorage do
   @spec handle_call(term(), GenServer.from(), state()) ::
           {:reply, :ok | {:error, term()}, state()}
   def handle_call({:put, address, resource, payment_proof, ttl_ms}, _from, state) do
-    key = {address, resource}
+    key = {String.downcase(address), resource}
     expires_at_ms = now_ms() + ttl_ms
 
     true = :ets.insert(state.table, {key, payment_proof, expires_at_ms})
@@ -188,7 +193,7 @@ defmodule X402.Extensions.SIWX.ETSStorage do
   end
 
   def handle_call({:delete, address, resource}, _from, state) do
-    :ets.delete(state.table, {address, resource})
+    :ets.delete(state.table, {String.downcase(address), resource})
     {:reply, :ok, state}
   end
 

--- a/lib/x402/facilitator.ex
+++ b/lib/x402/facilitator.ex
@@ -38,7 +38,16 @@ defmodule X402.Facilitator do
     max_retries: [
       type: :non_neg_integer,
       default: 2,
-      doc: "Maximum retry count for transient errors."
+      doc: "Maximum retry count for transient errors (applies to verify only)."
+    ],
+    settle_max_retries: [
+      type: :non_neg_integer,
+      default: 0,
+      doc: """
+      Maximum retry count for settle requests. Defaults to `0` because settle
+      is not idempotent — retrying a successful settle that returned a transient
+      error causes double-settlement of the same payment proof.
+      """
     ],
     retry_backoff_ms: [
       type: :non_neg_integer,
@@ -65,6 +74,7 @@ defmodule X402.Facilitator do
           finch: term(),
           hooks: module(),
           max_retries: non_neg_integer(),
+          settle_max_retries: non_neg_integer(),
           retry_backoff_ms: non_neg_integer(),
           receive_timeout_ms: non_neg_integer()
         }
@@ -183,6 +193,7 @@ defmodule X402.Facilitator do
       finch: Keyword.fetch!(opts, :finch),
       hooks: Keyword.fetch!(opts, :hooks),
       max_retries: Keyword.fetch!(opts, :max_retries),
+      settle_max_retries: Keyword.fetch!(opts, :settle_max_retries),
       retry_backoff_ms: Keyword.fetch!(opts, :retry_backoff_ms),
       receive_timeout_ms: Keyword.fetch!(opts, :receive_timeout_ms)
     }
@@ -240,6 +251,12 @@ defmodule X402.Facilitator do
 
     case run_before_hook(hooks_module, operation, context, metadata) do
       {:cont, %Context{} = before_context} ->
+        # settle is not idempotent: use settle_max_retries (default 0) to prevent
+        # double-settlement when the server settles successfully but returns a
+        # transient 5xx before responding.
+        effective_max_retries =
+          if operation == :settle, do: state.settle_max_retries, else: state.max_retries
+
         result =
           with :ok <- validate_scheme_payment(before_context.payload, before_context.requirements) do
             HTTP.request(
@@ -250,7 +267,7 @@ defmodule X402.Facilitator do
                 payload: before_context.payload,
                 requirements: before_context.requirements
               },
-              max_retries: state.max_retries,
+              max_retries: effective_max_retries,
               retry_backoff_ms: state.retry_backoff_ms,
               receive_timeout_ms: state.receive_timeout_ms
             )


### PR DESCRIPTION
## Security Council Findings — Feb 24, 2026

### 🔴 HIGH: Double-settlement risk in `Facilitator.HTTP`

**Problem:** `settle` used the same `max_retries` as `verify`. If the facilitator server settles a payment successfully but returns a transient 500/502/503/504 before the response completes, the client retries — sending the same payment proof to be settled again.

**Fix:** Added `settle_max_retries` config option (default `0`) to `Facilitator`. The settle path now uses `settle_max_retries` instead of `max_retries`. Operators who have idempotent settle implementations (e.g., server-side deduplication) can opt into retries by setting `settle_max_retries: 1` or higher.

### 🟡 MEDIUM: ETS key case-sensitivity in `SIWX.ETSStorage`

**Problem:** Keys were stored as `{address, resource}` with raw address casing. Ethereum addresses are case-insensitive (checksummed vs lowercase), so `0xABCD` and `0xabcd` created separate ETS entries — allowing a user to bypass TTL expiry by reusing the same wallet with different casing.

**Fix:** `String.downcase(address)` applied consistently in `get/3`, `handle_call({:put, ...})`, and `handle_call({:delete, ...})`.

### 🟢 LOW: Unbounded `resource` key length

**Problem:** No length validation on the `resource` parameter in `put/5` — arbitrarily long strings inflate ETS memory.

**Fix:** Reject resources exceeding 2048 bytes with `{:error, {:resource_too_long, 2048}}`.

---

**Breaking changes:** None for standard usage. `settle_max_retries` is additive config. The ETS normalization is a behavior change only if callers were intentionally using mixed-case addresses to create separate sessions (they shouldn't be).