### PR TITLE
🔒 [security fix] Denial of Service via Unbounded Decimal Precision

### DIFF
--- a/lib/x402/facilitator.ex
+++ b/lib/x402/facilitator.ex
@@ -10,6 +10,7 @@ defmodule X402.Facilitator do
   alias X402.Hooks
   alias X402.Hooks.Context
   alias X402.Hooks.Default
+  alias X402.Utils
 
   @default_name __MODULE__
   @default_url "https://x402.org/facilitator"
@@ -367,7 +368,8 @@ defmodule X402.Facilitator do
   end
 
   defp validate_scheme_payment(payload, requirements) do
-    case map_value(requirements, {"scheme", :scheme}) || map_value(payload, {"scheme", :scheme}) do
+    case Utils.map_value(requirements, {"scheme", :scheme}) ||
+           Utils.map_value(payload, {"scheme", :scheme}) do
       "upto" ->
         validate_upto_payment(payload, requirements)
 
@@ -385,11 +387,11 @@ defmodule X402.Facilitator do
 
   defp extract_max_price(payload, requirements) do
     value =
-      first_present([
-        map_value(requirements, {"maxPrice", :maxPrice}),
-        map_value(requirements, {"maxAmountRequired", :maxAmountRequired}),
-        map_value(payload, {"maxPrice", :maxPrice}),
-        map_value(payload, {"maxAmountRequired", :maxAmountRequired})
+      Utils.first_present([
+        fn -> Utils.map_value(requirements, {"maxPrice", :maxPrice}) end,
+        fn -> Utils.map_value(requirements, {"maxAmountRequired", :maxAmountRequired}) end,
+        fn -> Utils.map_value(payload, {"maxPrice", :maxPrice}) end,
+        fn -> Utils.map_value(payload, {"maxAmountRequired", :maxAmountRequired}) end
       ])
 
     case value do
@@ -397,7 +399,7 @@ defmodule X402.Facilitator do
         {:error, {:invalid_upto_payment, :missing_max_price}}
 
       max_price ->
-        case parse_decimal(max_price) do
+        case Utils.parse_decimal(max_price) do
           {:ok, parsed} -> {:ok, parsed}
           :error -> {:error, {:invalid_upto_payment, :invalid_max_price}}
         end
@@ -406,15 +408,19 @@ defmodule X402.Facilitator do
 
   defp extract_payment_value(payload) do
     value =
-      first_present([
-        map_value(payload, {"value", :value}),
-        nested_map_value(payload, [{"payload", :payload}, {"value", :value}]),
-        nested_map_value(payload, [
-          {"payload", :payload},
-          {"authorization", :authorization},
-          {"value", :value}
-        ]),
-        nested_map_value(payload, [{"authorization", :authorization}, {"value", :value}])
+      Utils.first_present([
+        fn -> Utils.map_value(payload, {"value", :value}) end,
+        fn -> Utils.nested_map_value(payload, [{"payload", :payload}, {"value", :value}]) end,
+        fn ->
+          Utils.nested_map_value(payload, [
+            {"payload", :payload},
+            {"authorization", :authorization},
+            {"value", :value}
+          ])
+        end,
+        fn ->
+          Utils.nested_map_value(payload, [{"authorization", :authorization}, {"value", :value}])
+        end
       ])
 
     case value do
@@ -422,7 +428,7 @@ defmodule X402.Facilitator do
         {:error, {:invalid_upto_payment, :missing_payment_value}}
 
       payment_value ->
-        case parse_decimal(payment_value) do
+        case Utils.parse_decimal(payment_value) do
           {:ok, parsed} -> {:ok, parsed}
           :error -> {:error, {:invalid_upto_payment, :invalid_payment_value}}
         end
@@ -430,81 +436,11 @@ defmodule X402.Facilitator do
   end
 
   defp ensure_not_exceeds(payment_value, max_price) do
-    case compare_decimal(payment_value, max_price) do
+    case Utils.compare_decimal(payment_value, max_price) do
       :gt -> {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
       _comparison -> :ok
     end
   end
-
-  defp compare_decimal({left_value, left_scale}, {right_value, right_scale})
-       when left_scale == right_scale do
-    compare_integer(left_value, right_value)
-  end
-
-  defp compare_decimal({left_value, left_scale}, {right_value, right_scale})
-       when left_scale > right_scale do
-    compare_integer(left_value, right_value * Integer.pow(10, left_scale - right_scale))
-  end
-
-  defp compare_decimal({left_value, left_scale}, {right_value, right_scale}) do
-    compare_integer(left_value * Integer.pow(10, right_scale - left_scale), right_value)
-  end
-
-  defp compare_integer(left, right) when left < right, do: :lt
-  defp compare_integer(left, right) when left > right, do: :gt
-  defp compare_integer(_left, _right), do: :eq
-
-  defp parse_decimal(value) when is_integer(value) and value >= 0, do: {:ok, {value, 0}}
-  defp parse_decimal(value) when is_binary(value), do: parse_decimal_string(String.trim(value))
-  defp parse_decimal(_value), do: :error
-
-  defp parse_decimal_string(""), do: :error
-
-  defp parse_decimal_string(value) do
-    cond do
-      Regex.match?(~r/^\d+$/, value) ->
-        {:ok, {String.to_integer(value), 0}}
-
-      Regex.match?(~r/^\d+\.\d+$/, value) ->
-        [whole, fraction] = String.split(value, ".", parts: 2)
-        normalized_fraction = String.trim_trailing(fraction, "0")
-
-        case normalized_fraction do
-          "" ->
-            {:ok, {String.to_integer(whole), 0}}
-
-          fraction_digits ->
-            digits = whole <> fraction_digits
-            {:ok, {String.to_integer(digits), String.length(fraction_digits)}}
-        end
-
-      true ->
-        :error
-    end
-  end
-
-  defp nested_map_value(map, [key]) when is_map(map), do: map_value(map, key)
-
-  defp nested_map_value(map, [key | rest]) when is_map(map) do
-    case map_value(map, key) do
-      %{} = nested -> nested_map_value(nested, rest)
-      _other -> nil
-    end
-  end
-
-  defp nested_map_value(_not_map, _keys), do: nil
-
-  defp map_value(map, {string_key, atom_key}) do
-    case Map.fetch(map, string_key) do
-      {:ok, value} ->
-        value
-
-      :error ->
-        Map.get(map, atom_key)
-    end
-  end
-
-  defp first_present(values), do: Enum.find(values, &(not is_nil(&1)))
 
   defp before_callback(:verify), do: :before_verify
   defp before_callback(:settle), do: :before_settle

--- a/lib/x402/payment_signature.ex
+++ b/lib/x402/payment_signature.ex
@@ -12,6 +12,7 @@ defmodule X402.PaymentSignature do
   """
 
   alias X402.Telemetry
+  alias X402.Utils
 
   @required_fields ~w(transactionHash network scheme payerWallet)
 
@@ -250,7 +251,8 @@ defmodule X402.PaymentSignature do
 
   @spec effective_scheme(map(), map()) :: String.t() | atom() | nil
   defp effective_scheme(payload, requirements) do
-    map_value(requirements, {"scheme", :scheme}) || map_value(payload, {"scheme", :scheme})
+    Utils.map_value(requirements, {"scheme", :scheme}) ||
+      Utils.map_value(payload, {"scheme", :scheme})
   end
 
   @spec extract_max_price(map(), map()) ::
@@ -258,11 +260,11 @@ defmodule X402.PaymentSignature do
           | {:error, {:invalid_upto_payment, upto_validation_error()}}
   defp extract_max_price(payload, requirements) do
     value =
-      first_present([
-        map_value(requirements, {"maxPrice", :maxPrice}),
-        map_value(requirements, {"maxAmountRequired", :maxAmountRequired}),
-        map_value(payload, {"maxPrice", :maxPrice}),
-        map_value(payload, {"maxAmountRequired", :maxAmountRequired})
+      Utils.first_present([
+        fn -> Utils.map_value(requirements, {"maxPrice", :maxPrice}) end,
+        fn -> Utils.map_value(requirements, {"maxAmountRequired", :maxAmountRequired}) end,
+        fn -> Utils.map_value(payload, {"maxPrice", :maxPrice}) end,
+        fn -> Utils.map_value(payload, {"maxAmountRequired", :maxAmountRequired}) end
       ])
 
     case value do
@@ -270,7 +272,7 @@ defmodule X402.PaymentSignature do
         {:error, {:invalid_upto_payment, :missing_max_price}}
 
       max_price ->
-        case parse_decimal(max_price) do
+        case Utils.parse_decimal(max_price) do
           {:ok, parsed} -> {:ok, parsed}
           :error -> {:error, {:invalid_upto_payment, :invalid_max_price}}
         end
@@ -282,15 +284,19 @@ defmodule X402.PaymentSignature do
           | {:error, {:invalid_upto_payment, upto_validation_error()}}
   defp extract_payment_value(payload) do
     value =
-      first_present([
-        map_value(payload, {"value", :value}),
-        nested_map_value(payload, [{"payload", :payload}, {"value", :value}]),
-        nested_map_value(payload, [
-          {"payload", :payload},
-          {"authorization", :authorization},
-          {"value", :value}
-        ]),
-        nested_map_value(payload, [{"authorization", :authorization}, {"value", :value}])
+      Utils.first_present([
+        fn -> Utils.map_value(payload, {"value", :value}) end,
+        fn -> Utils.nested_map_value(payload, [{"payload", :payload}, {"value", :value}]) end,
+        fn ->
+          Utils.nested_map_value(payload, [
+            {"payload", :payload},
+            {"authorization", :authorization},
+            {"value", :value}
+          ])
+        end,
+        fn ->
+          Utils.nested_map_value(payload, [{"authorization", :authorization}, {"value", :value}])
+        end
       ])
 
     case value do
@@ -298,7 +304,7 @@ defmodule X402.PaymentSignature do
         {:error, {:invalid_upto_payment, :missing_payment_value}}
 
       payment_value ->
-        case parse_decimal(payment_value) do
+        case Utils.parse_decimal(payment_value) do
           {:ok, parsed} -> {:ok, parsed}
           :error -> {:error, {:invalid_upto_payment, :invalid_payment_value}}
         end
@@ -310,89 +316,9 @@ defmodule X402.PaymentSignature do
           {non_neg_integer(), non_neg_integer()}
         ) :: :ok | {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
   defp ensure_not_exceeds(payment_value, max_price) do
-    case compare_decimal(payment_value, max_price) do
+    case Utils.compare_decimal(payment_value, max_price) do
       :gt -> {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
       _comparison -> :ok
     end
   end
-
-  @spec compare_decimal(
-          {non_neg_integer(), non_neg_integer()},
-          {non_neg_integer(), non_neg_integer()}
-        ) :: :lt | :eq | :gt
-  defp compare_decimal({left_value, left_scale}, {right_value, right_scale})
-       when left_scale == right_scale do
-    compare_integer(left_value, right_value)
-  end
-
-  defp compare_decimal({left_value, left_scale}, {right_value, right_scale})
-       when left_scale > right_scale do
-    compare_integer(left_value, right_value * Integer.pow(10, left_scale - right_scale))
-  end
-
-  defp compare_decimal({left_value, left_scale}, {right_value, right_scale}) do
-    compare_integer(left_value * Integer.pow(10, right_scale - left_scale), right_value)
-  end
-
-  @spec compare_integer(non_neg_integer(), non_neg_integer()) :: :lt | :eq | :gt
-  defp compare_integer(left, right) when left < right, do: :lt
-  defp compare_integer(left, right) when left > right, do: :gt
-  defp compare_integer(_left, _right), do: :eq
-
-  @spec parse_decimal(term()) :: {:ok, {non_neg_integer(), non_neg_integer()}} | :error
-  defp parse_decimal(value) when is_integer(value) and value >= 0, do: {:ok, {value, 0}}
-  defp parse_decimal(value) when is_binary(value), do: parse_decimal_string(String.trim(value))
-  defp parse_decimal(_value), do: :error
-
-  @spec parse_decimal_string(String.t()) :: {:ok, {non_neg_integer(), non_neg_integer()}} | :error
-  defp parse_decimal_string(""), do: :error
-
-  defp parse_decimal_string(value) do
-    cond do
-      Regex.match?(~r/^\d+$/, value) ->
-        {:ok, {String.to_integer(value), 0}}
-
-      Regex.match?(~r/^\d+\.\d+$/, value) ->
-        [whole, fraction] = String.split(value, ".", parts: 2)
-        normalized_fraction = String.trim_trailing(fraction, "0")
-
-        case normalized_fraction do
-          "" ->
-            {:ok, {String.to_integer(whole), 0}}
-
-          fraction_digits ->
-            digits = whole <> fraction_digits
-            {:ok, {String.to_integer(digits), String.length(fraction_digits)}}
-        end
-
-      true ->
-        :error
-    end
-  end
-
-  @spec nested_map_value(map(), [{String.t(), atom()}]) :: term()
-  defp nested_map_value(map, [key]) when is_map(map), do: map_value(map, key)
-
-  defp nested_map_value(map, [key | rest]) when is_map(map) do
-    case map_value(map, key) do
-      %{} = nested -> nested_map_value(nested, rest)
-      _other -> nil
-    end
-  end
-
-  defp nested_map_value(_not_map, _keys), do: nil
-
-  @spec map_value(map(), {String.t(), atom()}) :: term()
-  defp map_value(map, {string_key, atom_key}) do
-    case Map.fetch(map, string_key) do
-      {:ok, value} ->
-        value
-
-      :error ->
-        Map.get(map, atom_key)
-    end
-  end
-
-  @spec first_present([term()]) :: term() | nil
-  defp first_present(values), do: Enum.find(values, &(not is_nil(&1)))
 end

--- a/lib/x402/utils.ex
+++ b/lib/x402/utils.ex
@@ -1,0 +1,99 @@
+defmodule X402.Utils do
+  @moduledoc false
+
+  @max_decimal_scale 18
+
+  @spec parse_decimal(term()) :: {:ok, {non_neg_integer(), non_neg_integer()}} | :error
+  def parse_decimal(value) when is_integer(value) and value >= 0, do: {:ok, {value, 0}}
+  def parse_decimal(value) when is_binary(value), do: parse_decimal_string(String.trim(value))
+  def parse_decimal(_value), do: :error
+
+  @spec parse_decimal_string(String.t()) :: {:ok, {non_neg_integer(), non_neg_integer()}} | :error
+  defp parse_decimal_string(""), do: :error
+
+  defp parse_decimal_string(value) do
+    cond do
+      Regex.match?(~r/^\d+$/, value) ->
+        {:ok, {String.to_integer(value), 0}}
+
+      Regex.match?(~r/^\d+\.\d+$/, value) ->
+        [whole, fraction] = String.split(value, ".", parts: 2)
+        normalized_fraction = String.trim_trailing(fraction, "0")
+
+        case normalized_fraction do
+          "" ->
+            {:ok, {String.to_integer(whole), 0}}
+
+          fraction_digits ->
+            if String.length(fraction_digits) > @max_decimal_scale do
+              :error
+            else
+              digits = whole <> fraction_digits
+              {:ok, {String.to_integer(digits), String.length(fraction_digits)}}
+            end
+        end
+
+      true ->
+        :error
+    end
+  end
+
+  @spec compare_decimal(
+          {non_neg_integer(), non_neg_integer()},
+          {non_neg_integer(), non_neg_integer()}
+        ) :: :lt | :eq | :gt
+  def compare_decimal({left_value, left_scale}, {right_value, right_scale})
+      when left_scale == right_scale do
+    compare_integer(left_value, right_value)
+  end
+
+  def compare_decimal({left_value, left_scale}, {right_value, right_scale})
+      when left_scale > right_scale do
+    compare_integer(left_value, right_value * Integer.pow(10, left_scale - right_scale))
+  end
+
+  def compare_decimal({left_value, left_scale}, {right_value, right_scale}) do
+    compare_integer(left_value * Integer.pow(10, right_scale - left_scale), right_value)
+  end
+
+  @spec compare_integer(non_neg_integer(), non_neg_integer()) :: :lt | :eq | :gt
+  def compare_integer(left, right) when left < right, do: :lt
+  def compare_integer(left, right) when left > right, do: :gt
+  def compare_integer(_left, _right), do: :eq
+
+  @spec nested_map_value(map(), [{String.t(), atom()}]) :: term()
+  def nested_map_value(map, [key]) when is_map(map), do: map_value(map, key)
+
+  def nested_map_value(map, [key | rest]) when is_map(map) do
+    case map_value(map, key) do
+      %{} = nested -> nested_map_value(nested, rest)
+      _other -> nil
+    end
+  end
+
+  def nested_map_value(_not_map, _keys), do: nil
+
+  @spec map_value(map(), {String.t(), atom()}) :: term()
+  def map_value(map, {string_key, atom_key}) do
+    case Map.fetch(map, string_key) do
+      {:ok, value} ->
+        value
+
+      :error ->
+        Map.get(map, atom_key)
+    end
+  end
+
+  @spec first_present([term() | (-> term())]) :: term() | nil
+  def first_present([]), do: nil
+
+  def first_present([func | rest]) when is_function(func, 0) do
+    case func.() do
+      nil -> first_present(rest)
+      value -> value
+    end
+  end
+
+  def first_present([nil | rest]), do: first_present(rest)
+  def first_present([value | _rest]), do: value
+end

--- a/lib/x402/utils.ex
+++ b/lib/x402/utils.ex
@@ -18,23 +18,22 @@ defmodule X402.Utils do
 
       Regex.match?(~r/^\d+\.\d+$/, value) ->
         [whole, fraction] = String.split(value, ".", parts: 2)
-        normalized_fraction = String.trim_trailing(fraction, "0")
-
-        case normalized_fraction do
-          "" ->
-            {:ok, {String.to_integer(whole), 0}}
-
-          fraction_digits ->
-            if String.length(fraction_digits) > @max_decimal_scale do
-              :error
-            else
-              digits = whole <> fraction_digits
-              {:ok, {String.to_integer(digits), String.length(fraction_digits)}}
-            end
-        end
+        do_parse_fractional(whole, String.trim_trailing(fraction, "0"))
 
       true ->
         :error
+    end
+  end
+
+  defp do_parse_fractional(whole, ""), do: {:ok, {String.to_integer(whole), 0}}
+
+  defp do_parse_fractional(whole, fraction) do
+    scale = String.length(fraction)
+
+    if scale <= @max_decimal_scale do
+      {:ok, {String.to_integer(whole <> fraction), scale}}
+    else
+      :error
     end
   end
 


### PR DESCRIPTION
This PR fixes a Denial of Service (DoS) vulnerability in the Facilitator and PaymentSignature modules. The vulnerability was caused by accepting unbounded decimal precision from user input, which was then used as an exponent in `Integer.pow/2`. An attacker could provide a value with a very large number of digits after the decimal point, causing the server to consume excessive CPU and memory.

The fix involves:
1.  **Centralizing Logic:** Moving decimal parsing and comparison to a new internal `X402.Utils` module.
2.  **Scale Limit:** Enforcing a maximum of 18 decimal places during parsing. If a value exceeds this limit, it is rejected as an error.
3.  **Lazy Evaluation:** Updating `first_present/1` to support thunks, minimizing unnecessary computations during requirement extraction.

This approach effectively mitigates the DoS risk while maintaining compatibility with standard payment networks.

---
*PR created automatically by Jules for task [5409596309521540431](https://jules.google.com/task/5409596309521540431) started by @cardotrejos*