### PR TITLE
🧹 [code health] Centralize duplicate module validation logic

### DIFF
--- a/lib/x402/behaviour.ex
+++ b/lib/x402/behaviour.ex
@@ -3,6 +3,18 @@ defmodule X402.Behaviour do
   Utilities for working with Elixir behaviours and callback implementations.
   """
 
+  @doc since: "0.3.0"
+  defmacro __using__(opts) do
+    callbacks = Keyword.fetch!(opts, :callbacks)
+
+    quote do
+      @required_callbacks unquote(callbacks)
+
+      @spec implementation?(module()) :: boolean()
+      defp implementation?(module), do: X402.Behaviour.implements?(module, @required_callbacks)
+    end
+  end
+
   @doc since: "0.1.0"
   @doc """
   Checks if a module implements a set of callbacks.
@@ -15,5 +27,25 @@ defmodule X402.Behaviour do
       Enum.all?(callbacks, fn {name, arity} ->
         function_exported?(module, name, arity)
       end)
+  end
+
+  @doc since: "0.3.0"
+  @doc """
+  Validates that a module implements a behaviour.
+
+  This function is designed for `NimbleOptions` custom validation.
+  """
+  @spec validate_implementation(term(), module(), [{atom(), integer()}]) ::
+          :ok | {:error, String.t()}
+  def validate_implementation(module, behaviour, callbacks) when is_atom(module) do
+    if implements?(module, callbacks) do
+      :ok
+    else
+      {:error, "expected a module implementing #{inspect(behaviour)}"}
+    end
+  end
+
+  def validate_implementation(_invalid, behaviour, _callbacks) do
+    {:error, "expected a module implementing #{inspect(behaviour)}"}
   end
 end

--- a/lib/x402/extensions/payment_identifier/cache.ex
+++ b/lib/x402/extensions/payment_identifier/cache.ex
@@ -7,6 +7,8 @@ defmodule X402.Extensions.PaymentIdentifier.Cache do
   (for example, a pid or registered process name).
   """
 
+  use X402.Behaviour, callbacks: [get: 2, put: 3, delete: 2]
+
   alias X402.Extensions.PaymentIdentifier
 
   @typedoc "Payment identifier cache key."
@@ -28,17 +30,16 @@ defmodule X402.Extensions.PaymentIdentifier.Cache do
   @callback put(cache :: term(), key(), value()) :: write_result()
   @callback delete(cache :: term(), key()) :: write_result()
 
-  @required_callbacks [get: 2, put: 3, delete: 2]
-
   @doc since: "0.1.0"
   @doc """
   Validates a cache adapter tuple for `NimbleOptions` custom validation.
   """
   @spec validate_adapter(term()) :: :ok | {:error, String.t()}
   def validate_adapter({module, _cache}) when is_atom(module) do
-    case implementation?(module) do
-      true -> :ok
-      false -> {:error, "expected a cache adapter tuple {module, cache}"}
+    if implementation?(module) do
+      :ok
+    else
+      {:error, "expected a cache adapter tuple {module, cache}"}
     end
   end
 
@@ -86,7 +87,4 @@ defmodule X402.Extensions.PaymentIdentifier.Cache do
   end
 
   def delete(_adapter, _payment_id), do: {:error, :invalid_adapter}
-
-  @spec implementation?(module()) :: boolean()
-  defp implementation?(module), do: X402.Behaviour.implements?(module, @required_callbacks)
 end

--- a/lib/x402/extensions/siwx/storage.ex
+++ b/lib/x402/extensions/siwx/storage.ex
@@ -5,6 +5,8 @@ defmodule X402.Extensions.SIWX.Storage do
   Storage adapters persist wallet access grants keyed by `{address, resource}`.
   """
 
+  use X402.Behaviour, callbacks: [get: 2, put: 4, delete: 2]
+
   @typedoc "Stored access record for a wallet/resource pair."
   @type access_record :: %{
           required(:payment_proof) => term(),
@@ -32,8 +34,6 @@ defmodule X402.Extensions.SIWX.Storage do
   """
   @callback delete(address :: String.t(), resource :: String.t()) :: :ok
 
-  @required_callbacks [get: 2, put: 4, delete: 2]
-
   @doc since: "0.3.0"
   @doc """
   Validates that a value is a module implementing `X402.Extensions.SIWX.Storage`.
@@ -41,16 +41,6 @@ defmodule X402.Extensions.SIWX.Storage do
   This function is intended for `NimbleOptions` custom validation.
   """
   @spec validate_module(term()) :: :ok | {:error, String.t()}
-  def validate_module(module) when is_atom(module) do
-    case implementation?(module) do
-      true -> :ok
-      false -> {:error, "expected a module implementing X402.Extensions.SIWX.Storage"}
-    end
-  end
-
-  def validate_module(_invalid),
-    do: {:error, "expected a module implementing X402.Extensions.SIWX.Storage"}
-
-  @spec implementation?(module()) :: boolean()
-  defp implementation?(module), do: X402.Behaviour.implements?(module, @required_callbacks)
+  def validate_module(module),
+    do: X402.Behaviour.validate_implementation(module, __MODULE__, @required_callbacks)
 end

--- a/lib/x402/extensions/siwx/verifier.ex
+++ b/lib/x402/extensions/siwx/verifier.ex
@@ -6,6 +6,8 @@ defmodule X402.Extensions.SIWX.Verifier do
   signature matches the claimed wallet address.
   """
 
+  use X402.Behaviour, callbacks: [verify_signature: 3]
+
   @typedoc "Verifier return value."
   @type verify_result :: {:ok, boolean()} | {:error, term()}
 
@@ -19,8 +21,6 @@ defmodule X402.Extensions.SIWX.Verifier do
             ) ::
               verify_result()
 
-  @required_callbacks [verify_signature: 3]
-
   @doc since: "0.3.0"
   @doc """
   Validates that a value is a module implementing `X402.Extensions.SIWX.Verifier`.
@@ -28,16 +28,6 @@ defmodule X402.Extensions.SIWX.Verifier do
   This function is intended for `NimbleOptions` custom validation.
   """
   @spec validate_module(term()) :: :ok | {:error, String.t()}
-  def validate_module(module) when is_atom(module) do
-    case implementation?(module) do
-      true -> :ok
-      false -> {:error, "expected a module implementing X402.Extensions.SIWX.Verifier"}
-    end
-  end
-
-  def validate_module(_invalid),
-    do: {:error, "expected a module implementing X402.Extensions.SIWX.Verifier"}
-
-  @spec implementation?(module()) :: boolean()
-  defp implementation?(module), do: X402.Behaviour.implements?(module, @required_callbacks)
+  def validate_module(module),
+    do: X402.Behaviour.validate_implementation(module, __MODULE__, @required_callbacks)
 end

--- a/lib/x402/hooks.ex
+++ b/lib/x402/hooks.ex
@@ -15,6 +15,16 @@ defmodule X402.Hooks do
   or recover the operation with `{:recover, result}`.
   """
 
+  use X402.Behaviour,
+    callbacks: [
+      before_verify: 2,
+      after_verify: 2,
+      on_verify_failure: 2,
+      before_settle: 2,
+      after_settle: 2,
+      on_settle_failure: 2
+    ]
+
   alias X402.Hooks.Context
 
   @typedoc "Lifecycle callback metadata passed to hooks."
@@ -80,15 +90,6 @@ defmodule X402.Hooks do
   """
   @callback on_settle_failure(Context.t(), metadata()) :: on_failure_result()
 
-  @required_callbacks [
-    before_verify: 2,
-    after_verify: 2,
-    on_verify_failure: 2,
-    before_settle: 2,
-    after_settle: 2,
-    on_settle_failure: 2
-  ]
-
   @doc since: "0.1.0"
   @doc """
   Validates that a value is a module implementing `X402.Hooks`.
@@ -96,15 +97,6 @@ defmodule X402.Hooks do
   This function is designed for `NimbleOptions` custom validation.
   """
   @spec validate_module(term()) :: :ok | {:error, String.t()}
-  def validate_module(module) when is_atom(module) do
-    case implementation?(module) do
-      true -> :ok
-      false -> {:error, "expected a module implementing X402.Hooks"}
-    end
-  end
-
-  def validate_module(_invalid), do: {:error, "expected a module implementing X402.Hooks"}
-
-  @spec implementation?(module()) :: boolean()
-  defp implementation?(module), do: X402.Behaviour.implements?(module, @required_callbacks)
+  def validate_module(module),
+    do: X402.Behaviour.validate_implementation(module, __MODULE__, @required_callbacks)
 end


### PR DESCRIPTION
Refactored the codebase to eliminate duplicate module validation logic. 

Key changes:
- Modified `X402.Behaviour` to include a `__using__` macro that defines `@required_callbacks` and a private `implementation?/1` helper.
- Added `X402.Behaviour.validate_implementation/3` to centralize the logic for `NimbleOptions` custom validation.
- Refactored `X402.Extensions.SIWX.Verifier`, `X402.Extensions.SIWX.Storage`, `X402.Hooks`, and `X402.Extensions.PaymentIdentifier.Cache` to use these new utilities, significantly reducing boilerplate.

Verification:
- Manual code review confirmed that logic and error messages remain identical.
- Positive code review from automated tool.
- Attempted to run tests, but `mix` was unavailable in the environment.

---
*PR created automatically by Jules for task [1516730396694931048](https://jules.google.com/task/1516730396694931048) started by @cardotrejos*