### PR TITLE
🧪 test: verify SIWX statement newline rejection

### DIFF
--- a/test/x402/extensions/siwx_test.exs
+++ b/test/x402/extensions/siwx_test.exs
@@ -68,6 +68,11 @@ defmodule X402.Extensions.SIWXTest do
       assert SIWX.encode(invalid_expiration) == {:error, {:invalid_field, :expiration_time}}
     end
 
+    test "rejects statement containing newlines" do
+      invalid_statement = Map.put(valid_payload(), :statement, "First line\nSecond line")
+      assert SIWX.encode(invalid_statement) == {:error, {:invalid_field, :statement}}
+    end
+
     test "returns invalid_message when format is malformed" do
       assert SIWX.decode("not a siwx message") == {:error, :invalid_message}
       assert SIWX.decode(nil) == {:error, :invalid_message}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added a test case to `test/x402/extensions/siwx_test.exs` to explicitly verify that the SIWX encoder rejects statements containing newline characters.

📊 **Coverage:** What scenarios are now tested
- The scenario where a user attempts to encode an SIWX message with a statement containing `\n` is now covered.
- Confirms that the function returns `{:error, {:invalid_field, :statement}}` as expected.

✨ **Result:** The improvement in test coverage
- Ensures that the `validate_statement/1` logic in `X402.Extensions.SIWX` is not accidentally removed or broken in future refactors.


---
*PR created automatically by Jules for task [6839509748693954977](https://jules.google.com/task/6839509748693954977) started by @cardotrejos*