### PR TITLE
test: cover facilitator hook exceptions

### DIFF
--- a/test/x402/facilitator_hooks_exception_test.exs
+++ b/test/x402/facilitator_hooks_exception_test.exs
@@ -1,0 +1,75 @@
+defmodule X402.FacilitatorHooksExceptionTest do
+  use ExUnit.Case, async: false
+
+  alias X402.Facilitator
+  alias X402.Hooks.Context
+
+  import X402.TestHelpers
+
+  defmodule RaisingHooks do
+    @moduledoc false
+    @behaviour X402.Hooks
+
+    def before_verify(_context, _metadata) do
+      raise "hook exception"
+    end
+
+    def after_verify(context, _metadata), do: {:cont, context}
+    def on_verify_failure(context, _metadata), do: {:cont, context}
+    def before_settle(context, _metadata), do: {:cont, context}
+    def after_settle(context, _metadata), do: {:cont, context}
+    def on_settle_failure(context, _metadata), do: {:cont, context}
+  end
+
+  defmodule ThrowingHooks do
+    @moduledoc false
+    @behaviour X402.Hooks
+
+    def before_verify(_context, _metadata) do
+      throw(:hook_throw)
+    end
+
+    def after_verify(context, _metadata), do: {:cont, context}
+    def on_verify_failure(context, _metadata), do: {:cont, context}
+    def before_settle(context, _metadata), do: {:cont, context}
+    def after_settle(context, _metadata), do: {:cont, context}
+    def on_settle_failure(context, _metadata), do: {:cont, context}
+  end
+
+  setup :setup_bypass
+  setup :setup_finch
+
+  test "verify/4 returns error on hook exception", %{
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    facilitator =
+      start_supervised!(
+        {Facilitator,
+         name: String.to_atom("facilitator_#{System.unique_integer([:positive, :monotonic])}"),
+         finch: finch,
+         url: facilitator_url,
+         hooks: RaisingHooks}
+      )
+
+    assert {:error, {:hook_callback_failed, :before_verify, {:exception, %RuntimeError{message: "hook exception"}}}} =
+             Facilitator.verify(facilitator, %{}, %{})
+  end
+
+  test "verify/4 returns error on hook throw", %{
+    finch: finch,
+    facilitator_url: facilitator_url
+  } do
+    facilitator =
+      start_supervised!(
+        {Facilitator,
+         name: String.to_atom("facilitator_#{System.unique_integer([:positive, :monotonic])}"),
+         finch: finch,
+         url: facilitator_url,
+         hooks: ThrowingHooks}
+      )
+
+    assert {:error, {:hook_callback_failed, :before_verify, {:throw, :hook_throw}}} =
+             Facilitator.verify(facilitator, %{}, %{})
+  end
+end

--- a/test/x402/facilitator_hooks_exception_test.exs
+++ b/test/x402/facilitator_hooks_exception_test.exs
@@ -2,7 +2,6 @@ defmodule X402.FacilitatorHooksExceptionTest do
   use ExUnit.Case, async: false
 
   alias X402.Facilitator
-  alias X402.Hooks.Context
 
   import X402.TestHelpers
 
@@ -52,7 +51,9 @@ defmodule X402.FacilitatorHooksExceptionTest do
          hooks: RaisingHooks}
       )
 
-    assert {:error, {:hook_callback_failed, :before_verify, {:exception, %RuntimeError{message: "hook exception"}}}} =
+    assert {:error,
+            {:hook_callback_failed, :before_verify,
+             {:exception, %RuntimeError{message: "hook exception"}}}} =
              Facilitator.verify(facilitator, %{}, %{})
   end
 


### PR DESCRIPTION
This PR adds a new test suite `test/x402/facilitator_hooks_exception_test.exs` to verify that the `X402.Facilitator` correctly handles exceptions and throws originating from hook callbacks.

🎯 **What:**
- Added `test/x402/facilitator_hooks_exception_test.exs`
- Defined `RaisingHooks` module that raises a runtime error in `before_verify`.
- Defined `ThrowingHooks` module that throws a value in `before_verify`.
- Added tests asserting that `Facilitator.verify/3` returns the correct `{:error, {:hook_callback_failed, ...}}` tuple in both cases.

📊 **Coverage:**
- Covers the `rescue` block in `invoke_hook/4`.
- Covers the `catch` block in `invoke_hook/4`.

✨ **Result:**
- Increases confidence in the robustness of the hook execution mechanism.
- Ensures that user-defined hooks cannot crash the facilitator process unexpectedly, but instead return structured errors.

---
*PR created automatically by Jules for task [13818478174327976330](https://jules.google.com/task/13818478174327976330) started by @cardotrejos*