### PR TITLE
Refactor: Centralize duplicate decode_base64 helper to X402.Utils

### DIFF
--- a/lib/x402/extensions/payment_identifier.ex
+++ b/lib/x402/extensions/payment_identifier.ex
@@ -50,7 +50,7 @@ defmodule X402.Extensions.PaymentIdentifier do
   """
   @spec decode(String.t()) :: {:ok, payment_id()} | {:error, decode_error()}
   def decode(value) when is_binary(value) do
-    with {:ok, json} <- decode_base64(value),
+    with {:ok, json} <- X402.Utils.decode_base64(value),
          {:ok, decoded} <- Jason.decode(json),
          {:ok, payment_id} <- fetch_payment_id(decoded) do
       {:ok, payment_id}
@@ -87,14 +87,4 @@ defmodule X402.Extensions.PaymentIdentifier do
   end
 
   def fetch_payment_id(_payload), do: {:error, :invalid_payment_id}
-
-  @spec decode_base64(String.t()) :: {:ok, String.t()} | {:error, :invalid_base64}
-  defp decode_base64(""), do: {:error, :invalid_base64}
-
-  defp decode_base64(value) do
-    case Base.decode64(value) do
-      {:ok, decoded} -> {:ok, decoded}
-      :error -> {:error, :invalid_base64}
-    end
-  end
 end

--- a/lib/x402/extensions/siwx.ex
+++ b/lib/x402/extensions/siwx.ex
@@ -190,7 +190,7 @@ defmodule X402.Extensions.SIWX do
   """
   @spec decode_header(String.t()) :: {:ok, map()} | {:error, header_decode_error()}
   def decode_header(value) when is_binary(value) do
-    with {:ok, json} <- decode_base64(value),
+    with {:ok, json} <- X402.Utils.decode_base64(value),
          {:ok, decoded} <- Jason.decode(json),
          true <- is_map(decoded),
          {:ok, message} <- fetch_non_empty_binary(decoded, :message),
@@ -479,16 +479,6 @@ defmodule X402.Extensions.SIWX do
     case DateTime.compare(expiration_datetime, issued_at_datetime) do
       :gt -> :ok
       _other -> {:error, {:invalid_field, :expiration_time}}
-    end
-  end
-
-  @spec decode_base64(String.t()) :: {:ok, String.t()} | {:error, :invalid_base64}
-  defp decode_base64(""), do: {:error, :invalid_base64}
-
-  defp decode_base64(value) do
-    case Base.decode64(value) do
-      {:ok, decoded} -> {:ok, decoded}
-      :error -> {:error, :invalid_base64}
     end
   end
 end

--- a/lib/x402/payment_required.ex
+++ b/lib/x402/payment_required.ex
@@ -85,7 +85,7 @@ defmodule X402.PaymentRequired do
   """
   @spec decode(String.t()) :: {:ok, map()} | {:error, decode_error()}
   def decode(value) when is_binary(value) do
-    with {:ok, json} <- decode_base64(value),
+    with {:ok, json} <- X402.Utils.decode_base64(value),
          {:ok, decoded} <- Jason.decode(json),
          true <- is_map(decoded) do
       result = {:ok, normalize_payload(decoded)}
@@ -125,16 +125,6 @@ defmodule X402.PaymentRequired do
     })
 
     {:error, :invalid_base64}
-  end
-
-  @spec decode_base64(String.t()) :: {:ok, String.t()} | {:error, :invalid_base64}
-  defp decode_base64(""), do: {:error, :invalid_base64}
-
-  defp decode_base64(value) do
-    case Base.decode64(value) do
-      {:ok, decoded} -> {:ok, decoded}
-      :error -> {:error, :invalid_base64}
-    end
   end
 
   @spec normalize_payload(map()) :: map()

--- a/lib/x402/payment_response.ex
+++ b/lib/x402/payment_response.ex
@@ -75,7 +75,7 @@ defmodule X402.PaymentResponse do
   """
   @spec decode(String.t()) :: {:ok, map()} | {:error, decode_error()}
   def decode(value) when is_binary(value) do
-    with {:ok, json} <- decode_base64(value),
+    with {:ok, json} <- X402.Utils.decode_base64(value),
          {:ok, decoded} <- Jason.decode(json),
          true <- is_map(decoded) do
       result = {:ok, decoded}
@@ -115,15 +115,5 @@ defmodule X402.PaymentResponse do
     })
 
     {:error, :invalid_base64}
-  end
-
-  @spec decode_base64(String.t()) :: {:ok, String.t()} | {:error, :invalid_base64}
-  defp decode_base64(""), do: {:error, :invalid_base64}
-
-  defp decode_base64(value) do
-    case Base.decode64(value) do
-      {:ok, decoded} -> {:ok, decoded}
-      :error -> {:error, :invalid_base64}
-    end
   end
 end

--- a/lib/x402/payment_signature.ex
+++ b/lib/x402/payment_signature.ex
@@ -58,7 +58,7 @@ defmodule X402.PaymentSignature do
   """
   @spec decode(String.t()) :: {:ok, map()} | {:error, decode_error()}
   def decode(value) when is_binary(value) do
-    with {:ok, json} <- decode_base64(value),
+    with {:ok, json} <- X402.Utils.decode_base64(value),
          {:ok, decoded} <- Jason.decode(json),
          true <- is_map(decoded) do
       result = {:ok, decoded}
@@ -209,16 +209,6 @@ defmodule X402.PaymentSignature do
   def decode_and_validate(_value, _requirements) do
     Telemetry.emit(:payment_signature, :decode_and_validate, :error, %{reason: :invalid_payload})
     {:error, :invalid_payload}
-  end
-
-  @spec decode_base64(String.t()) :: {:ok, String.t()} | {:error, :invalid_base64}
-  defp decode_base64(""), do: {:error, :invalid_base64}
-
-  defp decode_base64(value) do
-    case Base.decode64(value) do
-      {:ok, decoded} -> {:ok, decoded}
-      :error -> {:error, :invalid_base64}
-    end
   end
 
   @spec missing_fields(map()) :: [String.t()]

--- a/lib/x402/utils.ex
+++ b/lib/x402/utils.ex
@@ -1,0 +1,18 @@
+defmodule X402.Utils do
+  @moduledoc false
+
+  @doc """
+  Decodes a Base64 string.
+
+  Returns `{:error, :invalid_base64}` if the string is empty or invalid Base64.
+  """
+  @spec decode_base64(String.t()) :: {:ok, String.t()} | {:error, :invalid_base64}
+  def decode_base64(""), do: {:error, :invalid_base64}
+
+  def decode_base64(value) do
+    case Base.decode64(value) do
+      {:ok, decoded} -> {:ok, decoded}
+      :error -> {:error, :invalid_base64}
+    end
+  end
+end


### PR DESCRIPTION
🧹 **Refactor: Centralize Base64 Decoding Logic**

### 🎯 What
Extracted the duplicated `decode_base64/1` helper function from 5 modules into a new shared utility module `X402.Utils`.

### 💡 Why
The `decode_base64/1` function was copy-pasted across:
- `X402.PaymentRequired`
- `X402.PaymentSignature`
- `X402.PaymentResponse`
- `X402.Extensions.PaymentIdentifier`
- `X402.Extensions.SIWX`

Centralizing this logic reduces code duplication and ensures consistent behavior for Base64 decoding across the codebase.

### ✅ Verification
- Verified that all 5 modules now call `X402.Utils.decode_base64/1`.
- Verified that the logic in `X402.Utils.decode_base64/1` matches the original implementation exactly (handling empty strings and Base.decode64 results).
- Tests could not be run due to environment limitations (missing `mix`/`elixir`), but the refactor is a direct extraction of existing logic.

### ✨ Result
Codebase is cleaner and follows the DRY (Don't Repeat Yourself) principle. `X402.Utils` is marked `@moduledoc false` to keep it internal.

---
*PR created automatically by Jules for task [3900985498256960668](https://jules.google.com/task/3900985498256960668) started by @cardotrejos*