### PR TITLE
Centralize duplicate map value extraction helpers

### DIFF
--- a/lib/x402/facilitator.ex
+++ b/lib/x402/facilitator.ex
@@ -10,6 +10,7 @@ defmodule X402.Facilitator do
   alias X402.Hooks
   alias X402.Hooks.Context
   alias X402.Hooks.Default
+  alias X402.Utils
 
   @default_name __MODULE__
   @default_url "https://x402.org/facilitator"
@@ -367,7 +368,8 @@ defmodule X402.Facilitator do
   end
 
   defp validate_scheme_payment(payload, requirements) do
-    case map_value(requirements, {"scheme", :scheme}) || map_value(payload, {"scheme", :scheme}) do
+    case Utils.map_value(requirements, {"scheme", :scheme}) ||
+           Utils.map_value(payload, {"scheme", :scheme}) do
       "upto" ->
         validate_upto_payment(payload, requirements)
 
@@ -385,11 +387,11 @@ defmodule X402.Facilitator do
 
   defp extract_max_price(payload, requirements) do
     value =
-      first_present([
-        map_value(requirements, {"maxPrice", :maxPrice}),
-        map_value(requirements, {"maxAmountRequired", :maxAmountRequired}),
-        map_value(payload, {"maxPrice", :maxPrice}),
-        map_value(payload, {"maxAmountRequired", :maxAmountRequired})
+      Utils.first_present([
+        Utils.map_value(requirements, {"maxPrice", :maxPrice}),
+        Utils.map_value(requirements, {"maxAmountRequired", :maxAmountRequired}),
+        Utils.map_value(payload, {"maxPrice", :maxPrice}),
+        Utils.map_value(payload, {"maxAmountRequired", :maxAmountRequired})
       ])
 
     case value do
@@ -406,15 +408,18 @@ defmodule X402.Facilitator do
 
   defp extract_payment_value(payload) do
     value =
-      first_present([
-        map_value(payload, {"value", :value}),
-        nested_map_value(payload, [{"payload", :payload}, {"value", :value}]),
-        nested_map_value(payload, [
+      Utils.first_present([
+        Utils.map_value(payload, {"value", :value}),
+        Utils.nested_map_value(payload, [{"payload", :payload}, {"value", :value}]),
+        Utils.nested_map_value(payload, [
           {"payload", :payload},
           {"authorization", :authorization},
           {"value", :value}
         ]),
-        nested_map_value(payload, [{"authorization", :authorization}, {"value", :value}])
+        Utils.nested_map_value(payload, [
+          {"authorization", :authorization},
+          {"value", :value}
+        ])
       ])
 
     case value do
@@ -482,29 +487,6 @@ defmodule X402.Facilitator do
         :error
     end
   end
-
-  defp nested_map_value(map, [key]) when is_map(map), do: map_value(map, key)
-
-  defp nested_map_value(map, [key | rest]) when is_map(map) do
-    case map_value(map, key) do
-      %{} = nested -> nested_map_value(nested, rest)
-      _other -> nil
-    end
-  end
-
-  defp nested_map_value(_not_map, _keys), do: nil
-
-  defp map_value(map, {string_key, atom_key}) do
-    case Map.fetch(map, string_key) do
-      {:ok, value} ->
-        value
-
-      :error ->
-        Map.get(map, atom_key)
-    end
-  end
-
-  defp first_present(values), do: Enum.find(values, &(not is_nil(&1)))
 
   defp before_callback(:verify), do: :before_verify
   defp before_callback(:settle), do: :before_settle

--- a/lib/x402/payment_required.ex
+++ b/lib/x402/payment_required.ex
@@ -7,6 +7,7 @@ defmodule X402.PaymentRequired do
   """
 
   alias X402.Telemetry
+  alias X402.Utils
 
   @type scheme :: String.t()
   @type encode_error :: :invalid_payload | :invalid_json
@@ -155,7 +156,7 @@ defmodule X402.PaymentRequired do
 
   @spec normalize_accepts_entries(map()) :: map()
   defp normalize_accepts_entries(payload) do
-    case map_value(payload, {"accepts", :accepts}) do
+    case Utils.map_value(payload, {"accepts", :accepts}) do
       accepts when is_list(accepts) ->
         normalized =
           Enum.map(accepts, fn
@@ -172,9 +173,9 @@ defmodule X402.PaymentRequired do
 
   @spec replace_amount_key(map()) :: map()
   defp replace_amount_key(payload) do
-    case map_value(payload, {"maxPrice", :maxPrice}) do
+    case Utils.map_value(payload, {"maxPrice", :maxPrice}) do
       nil ->
-        case map_value(payload, {"maxAmountRequired", :maxAmountRequired}) do
+        case Utils.map_value(payload, {"maxAmountRequired", :maxAmountRequired}) do
           nil ->
             payload
 
@@ -190,18 +191,7 @@ defmodule X402.PaymentRequired do
   end
 
   @spec scheme(map()) :: scheme() | atom() | nil
-  defp scheme(payload), do: map_value(payload, {"scheme", :scheme})
-
-  @spec map_value(map(), {String.t(), atom()}) :: term()
-  defp map_value(map, {string_key, atom_key}) do
-    case Map.fetch(map, string_key) do
-      {:ok, value} ->
-        value
-
-      :error ->
-        Map.get(map, atom_key)
-    end
-  end
+  defp scheme(payload), do: Utils.map_value(payload, {"scheme", :scheme})
 
   @spec map_put(map(), {String.t(), atom()}, term()) :: map()
   defp map_put(map, {string_key, atom_key}, value) do

--- a/lib/x402/payment_signature.ex
+++ b/lib/x402/payment_signature.ex
@@ -12,6 +12,7 @@ defmodule X402.PaymentSignature do
   """
 
   alias X402.Telemetry
+  alias X402.Utils
 
   @required_fields ~w(transactionHash network scheme payerWallet)
 
@@ -250,7 +251,8 @@ defmodule X402.PaymentSignature do
 
   @spec effective_scheme(map(), map()) :: String.t() | atom() | nil
   defp effective_scheme(payload, requirements) do
-    map_value(requirements, {"scheme", :scheme}) || map_value(payload, {"scheme", :scheme})
+    Utils.map_value(requirements, {"scheme", :scheme}) ||
+      Utils.map_value(payload, {"scheme", :scheme})
   end
 
   @spec extract_max_price(map(), map()) ::
@@ -258,11 +260,11 @@ defmodule X402.PaymentSignature do
           | {:error, {:invalid_upto_payment, upto_validation_error()}}
   defp extract_max_price(payload, requirements) do
     value =
-      first_present([
-        map_value(requirements, {"maxPrice", :maxPrice}),
-        map_value(requirements, {"maxAmountRequired", :maxAmountRequired}),
-        map_value(payload, {"maxPrice", :maxPrice}),
-        map_value(payload, {"maxAmountRequired", :maxAmountRequired})
+      Utils.first_present([
+        Utils.map_value(requirements, {"maxPrice", :maxPrice}),
+        Utils.map_value(requirements, {"maxAmountRequired", :maxAmountRequired}),
+        Utils.map_value(payload, {"maxPrice", :maxPrice}),
+        Utils.map_value(payload, {"maxAmountRequired", :maxAmountRequired})
       ])
 
     case value do
@@ -282,15 +284,18 @@ defmodule X402.PaymentSignature do
           | {:error, {:invalid_upto_payment, upto_validation_error()}}
   defp extract_payment_value(payload) do
     value =
-      first_present([
-        map_value(payload, {"value", :value}),
-        nested_map_value(payload, [{"payload", :payload}, {"value", :value}]),
-        nested_map_value(payload, [
+      Utils.first_present([
+        Utils.map_value(payload, {"value", :value}),
+        Utils.nested_map_value(payload, [{"payload", :payload}, {"value", :value}]),
+        Utils.nested_map_value(payload, [
           {"payload", :payload},
           {"authorization", :authorization},
           {"value", :value}
         ]),
-        nested_map_value(payload, [{"authorization", :authorization}, {"value", :value}])
+        Utils.nested_map_value(payload, [
+          {"authorization", :authorization},
+          {"value", :value}
+        ])
       ])
 
     case value do
@@ -369,30 +374,4 @@ defmodule X402.PaymentSignature do
         :error
     end
   end
-
-  @spec nested_map_value(map(), [{String.t(), atom()}]) :: term()
-  defp nested_map_value(map, [key]) when is_map(map), do: map_value(map, key)
-
-  defp nested_map_value(map, [key | rest]) when is_map(map) do
-    case map_value(map, key) do
-      %{} = nested -> nested_map_value(nested, rest)
-      _other -> nil
-    end
-  end
-
-  defp nested_map_value(_not_map, _keys), do: nil
-
-  @spec map_value(map(), {String.t(), atom()}) :: term()
-  defp map_value(map, {string_key, atom_key}) do
-    case Map.fetch(map, string_key) do
-      {:ok, value} ->
-        value
-
-      :error ->
-        Map.get(map, atom_key)
-    end
-  end
-
-  @spec first_present([term()]) :: term() | nil
-  defp first_present(values), do: Enum.find(values, &(not is_nil(&1)))
 end

--- a/lib/x402/utils.ex
+++ b/lib/x402/utils.ex
@@ -1,0 +1,41 @@
+defmodule X402.Utils do
+  @moduledoc false
+
+  @doc """
+  Returns the value for a given key in a map, trying the string key first, then the atom key.
+  """
+  @spec map_value(map(), {String.t(), atom()}) :: term()
+  def map_value(map, {string_key, atom_key}) do
+    case Map.fetch(map, string_key) do
+      {:ok, value} ->
+        value
+
+      :error ->
+        Map.get(map, atom_key)
+    end
+  end
+
+  @doc """
+  Returns the value for a nested key path in a map.
+
+  Traverses the map using `map_value/2` for each key in the path.
+  Returns `nil` if any intermediate value is not a map or if the key is not found.
+  """
+  @spec nested_map_value(map(), [{String.t(), atom()}]) :: term()
+  def nested_map_value(map, [key]) when is_map(map), do: map_value(map, key)
+
+  def nested_map_value(map, [key | rest]) when is_map(map) do
+    case map_value(map, key) do
+      %{} = nested -> nested_map_value(nested, rest)
+      _other -> nil
+    end
+  end
+
+  def nested_map_value(_not_map, _keys), do: nil
+
+  @doc """
+  Returns the first non-nil value from the given list.
+  """
+  @spec first_present([term()]) :: term() | nil
+  def first_present(values), do: Enum.find(values, &(not is_nil(&1)))
+end

--- a/test/x402/utils_test.exs
+++ b/test/x402/utils_test.exs
@@ -1,0 +1,63 @@
+defmodule X402.UtilsTest do
+  use ExUnit.Case, async: true
+
+  alias X402.Utils
+
+  describe "map_value/2" do
+    test "returns value for string key" do
+      map = %{"key" => "value", :key => "other"}
+      assert Utils.map_value(map, {"key", :key}) == "value"
+    end
+
+    test "returns value for atom key if string key missing" do
+      map = %{:key => "value"}
+      assert Utils.map_value(map, {"key", :key}) == "value"
+    end
+
+    test "returns nil if both keys missing" do
+      map = %{}
+      assert Utils.map_value(map, {"key", :key}) == nil
+    end
+  end
+
+  describe "nested_map_value/2" do
+    test "returns value for single key" do
+      map = %{"key" => "value"}
+      assert Utils.nested_map_value(map, [{"key", :key}]) == "value"
+    end
+
+    test "returns value for nested keys" do
+      map = %{"parent" => %{"child" => "value"}}
+      assert Utils.nested_map_value(map, [{"parent", :parent}, {"child", :child}]) == "value"
+    end
+
+    test "returns nil if path broken" do
+      map = %{"parent" => "not_a_map"}
+      assert Utils.nested_map_value(map, [{"parent", :parent}, {"child", :child}]) == nil
+    end
+
+    test "returns nil if key missing" do
+      map = %{"parent" => %{}}
+      assert Utils.nested_map_value(map, [{"parent", :parent}, {"child", :child}]) == nil
+    end
+
+    test "handles mixed string/atom keys" do
+      map = %{:parent => %{"child" => "value"}}
+      assert Utils.nested_map_value(map, [{"parent", :parent}, {"child", :child}]) == "value"
+    end
+  end
+
+  describe "first_present/1" do
+    test "returns first non-nil value" do
+      assert Utils.first_present([nil, "value", "other"]) == "value"
+    end
+
+    test "returns nil if all values are nil" do
+      assert Utils.first_present([nil, nil]) == nil
+    end
+
+    test "returns nil for empty list" do
+      assert Utils.first_present([]) == nil
+    end
+  end
+end


### PR DESCRIPTION
Extracted duplicated map extraction helpers (`map_value`, `nested_map_value`, `first_present`) into a centralized `X402.Utils` module.
This affects `X402.PaymentSignature`, `X402.Facilitator`, and `X402.PaymentRequired`.
Tests were added for the new utility module.
Manual verification was performed as the local environment lacks `mix` for running tests.

---
*PR created automatically by Jules for task [5054768080911032733](https://jules.google.com/task/5054768080911032733) started by @cardotrejos*