### PR TITLE
test: Add coverage for invalid requirements in PaymentSignature

### DIFF
--- a/test/x402/payment_signature_test.exs
+++ b/test/x402/payment_signature_test.exs
@@ -191,5 +191,10 @@ defmodule X402.PaymentSignatureTest do
       assert PaymentSignature.decode_and_validate(encoded, requirements) ==
                {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
     end
+
+    test "returns invalid_payload for non-map requirements" do
+      encoded = "payload"
+      assert PaymentSignature.decode_and_validate(encoded, :invalid) == {:error, :invalid_payload}
+    end
   end
 end


### PR DESCRIPTION
Adds a unit test to `X402.PaymentSignatureTest` to verify that `decode_and_validate/2` handles invalid (non-map) requirements by returning `{:error, :invalid_payload}`. This covers the catch-all clause in the implementation.

---
*PR created automatically by Jules for task [12374902226834714020](https://jules.google.com/task/12374902226834714020) started by @cardotrejos*