### PR TITLE
fix: safe cache eviction and atomic payment claim to prevent double-settle

### DIFF
--- a/lib/x402/extensions/payment_identifier/ets_cache.ex
+++ b/lib/x402/extensions/payment_identifier/ets_cache.ex
@@ -282,18 +282,19 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCache do
 
       first_key ->
         [{_, _, first_exp}] = :ets.lookup(table, first_key)
-
-        {_min_exp, oldest_key} =
-          :ets.foldl(
-            fn {key, _val, expires}, {min_exp, min_key} ->
-              if expires < min_exp, do: {expires, key}, else: {min_exp, min_key}
-            end,
-            {first_exp, first_key},
-            table
-          )
-
+        {_min_exp, oldest_key} = :ets.foldl(&pick_soonest_expiry/2, {first_exp, first_key}, table)
         :ets.delete(table, oldest_key)
     end
+  end
+
+  # Accumulator for foldl — keeps track of the entry with the smallest expiry.
+  # Extracted to avoid nesting depth violations in Credo strict mode.
+  @spec pick_soonest_expiry(
+          {term(), term(), non_neg_integer()},
+          {non_neg_integer(), term()}
+        ) :: {non_neg_integer(), term()}
+  defp pick_soonest_expiry({key, _val, expires}, {min_exp, min_key}) do
+    if expires < min_exp, do: {expires, key}, else: {min_exp, min_key}
   end
 
   @spec delete_expired_entries(:ets.tid() | atom(), non_neg_integer()) :: non_neg_integer()

--- a/lib/x402/extensions/payment_identifier/ets_cache.ex
+++ b/lib/x402/extensions/payment_identifier/ets_cache.ex
@@ -227,7 +227,24 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCache do
   end
 
   def handle_call({:put_new, payment_id, value}, _from, state) do
-    expires_at_ms = now_ms() + state.ttl_ms
+    now = now_ms()
+    expires_at_ms = now + state.ttl_ms
+
+    # Delete expired entries with the same key before attempting insert_new.
+    # ets.insert_new returns false for any existing entry regardless of expiry,
+    # which would incorrectly block legitimate retries until the cleanup timer
+    # fires (up to @default_cleanup_interval_ms = 1 minute by default).
+    case :ets.lookup(state.table, payment_id) do
+      [{^payment_id, _val, exp}] when exp <= now -> :ets.delete(state.table, payment_id)
+      _ -> :ok
+    end
+
+    # Enforce max_size — unlike `put`, the original put_new had no capacity
+    # check, allowing the cache to grow without bound under concurrent load.
+    if :ets.info(state.table, :size) >= state.max_size and
+         not :ets.member(state.table, payment_id) do
+      evict_soonest_expiry(state.table)
+    end
 
     # ets.insert_new is atomic — only one concurrent process wins the race.
     case :ets.insert_new(state.table, {payment_id, value, expires_at_ms}) do

--- a/lib/x402/extensions/payment_identifier/ets_cache.ex
+++ b/lib/x402/extensions/payment_identifier/ets_cache.ex
@@ -132,6 +132,25 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCache do
 
   def put(_cache, _payment_id, _value), do: {:error, :invalid_payment_id}
 
+  @doc since: "0.4.0"
+  @doc """
+  Atomically inserts a payment identifier only if it does not already exist.
+
+  Returns `:ok` if the entry was inserted, or `{:error, :already_exists}` if
+  a non-expired entry for `payment_id` is already present. This is used to
+  prevent concurrent requests from double-settling the same payment proof.
+  """
+  @spec put_new(server(), Cache.key(), Cache.value()) ::
+          :ok | {:error, :already_exists | :invalid_cache_value}
+  def put_new(cache, payment_id, value) when is_binary(payment_id) do
+    case valid_value?(value) do
+      true -> GenServer.call(cache, {:put_new, payment_id, value})
+      false -> {:error, :invalid_cache_value}
+    end
+  end
+
+  def put_new(_cache, _payment_id, _value), do: {:error, :invalid_payment_id}
+
   @doc since: "0.1.0"
   @doc """
   Deletes a payment identifier entry from the cache.
@@ -196,15 +215,25 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCache do
   def handle_call({:put, payment_id, value}, _from, state) do
     if :ets.info(state.table, :size) >= state.max_size and
          not :ets.member(state.table, payment_id) do
-      case :ets.first(state.table) do
-        :"$end_of_table" -> :ok
-        key -> :ets.delete(state.table, key)
-      end
+      # Evict the entry nearest to expiry (not ets.first, which is hash-order
+      # and effectively random — an attacker could flood with unique IDs to
+      # evict legitimate in-flight records and reopen replay windows).
+      evict_soonest_expiry(state.table)
     end
 
     expires_at_ms = now_ms() + state.ttl_ms
     true = :ets.insert(state.table, {payment_id, value, expires_at_ms})
     {:reply, :ok, state}
+  end
+
+  def handle_call({:put_new, payment_id, value}, _from, state) do
+    expires_at_ms = now_ms() + state.ttl_ms
+
+    # ets.insert_new is atomic — only one concurrent process wins the race.
+    case :ets.insert_new(state.table, {payment_id, value, expires_at_ms}) do
+      true -> {:reply, :ok, state}
+      false -> {:reply, {:error, :already_exists}, state}
+    end
   end
 
   def handle_call({:delete, payment_id}, _from, state) do
@@ -224,6 +253,30 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCache do
   @spec schedule_cleanup(pos_integer()) :: reference()
   defp schedule_cleanup(cleanup_interval_ms) do
     Process.send_after(self(), :cleanup, cleanup_interval_ms)
+  end
+
+  @spec evict_soonest_expiry(:ets.tid() | atom()) :: true
+  defp evict_soonest_expiry(table) do
+    # Find the key whose TTL expires soonest and evict it. O(n) but eviction
+    # is rare (only at max_size) and prevents cache-flooding attacks.
+    case :ets.first(table) do
+      :"$end_of_table" ->
+        true
+
+      first_key ->
+        [{_, _, first_exp}] = :ets.lookup(table, first_key)
+
+        {_min_exp, oldest_key} =
+          :ets.foldl(
+            fn {key, _val, expires}, {min_exp, min_key} ->
+              if expires < min_exp, do: {expires, key}, else: {min_exp, min_key}
+            end,
+            {first_exp, first_key},
+            table
+          )
+
+        :ets.delete(table, oldest_key)
+    end
   end
 
   @spec delete_expired_entries(:ets.tid() | atom(), non_neg_integer()) :: non_neg_integer()

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -11,6 +11,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
 
     @behaviour Plug
 
+    alias X402.Extensions.PaymentIdentifier.ETSCache
     alias X402.Facilitator
     alias X402.Facilitator.Error
     alias X402.Hooks
@@ -71,6 +72,16 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
         default: Default,
         doc: "Lifecycle hook module implementing `X402.Hooks`."
       ],
+      payment_identifier_cache: [
+        type: {:or, [:atom, :pid, :any]},
+        default: nil,
+        doc: """
+        Optional `ETSCache` server pid/name used for idempotency. When set,
+        the plug performs an atomic claim (via `put_new`) on the payment proof
+        hash before settling, preventing concurrent requests from double-settling
+        the same payment.
+        """
+      ],
       routes: [
         type: {:list, {:map, @route_schema}},
         required: true,
@@ -82,6 +93,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     @type options :: %{
             facilitator: Facilitator.server(),
             hooks: module(),
+            payment_identifier_cache: ETSCache.server() | nil,
             routes: [compiled_route()]
           }
 
@@ -113,6 +125,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
       %{
         facilitator: Keyword.fetch!(validated_opts, :facilitator),
         hooks: Keyword.fetch!(validated_opts, :hooks),
+        payment_identifier_cache: Keyword.get(validated_opts, :payment_identifier_cache),
         routes:
           validated_opts
           |> Keyword.fetch!(:routes)
@@ -125,7 +138,12 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     Gates matching requests behind x402 payment verification.
     """
     @spec call(Plug.Conn.t(), options()) :: Plug.Conn.t()
-    def call(%Plug.Conn{} = conn, %{facilitator: facilitator, hooks: hooks, routes: routes}) do
+    def call(%Plug.Conn{} = conn, %{
+          facilitator: facilitator,
+          hooks: hooks,
+          payment_identifier_cache: payment_identifier_cache,
+          routes: routes
+        }) do
       request_path = normalize_path(conn.request_path)
       request_method = normalize_method(conn.method)
 
@@ -135,7 +153,15 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
           conn
 
         route ->
-          handle_payment_gate(conn, facilitator, hooks, route, request_method, request_path)
+          handle_payment_gate(
+            conn,
+            facilitator,
+            hooks,
+            payment_identifier_cache,
+            route,
+            request_method,
+            request_path
+          )
       end
     end
 
@@ -143,11 +169,20 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
             Plug.Conn.t(),
             Facilitator.server(),
             module(),
+            ETSCache.server() | nil,
             compiled_route(),
             atom(),
             String.t()
           ) :: Plug.Conn.t()
-    defp handle_payment_gate(conn, facilitator, hooks, route, request_method, request_path) do
+    defp handle_payment_gate(
+           conn,
+           facilitator,
+           hooks,
+           payment_identifier_cache,
+           route,
+           request_method,
+           request_path
+         ) do
       case payment_header(conn) do
         :missing ->
           emit(:payment_required, %{method: request_method, path: request_path, route: route.path})
@@ -159,6 +194,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
             conn,
             facilitator,
             hooks,
+            payment_identifier_cache,
             route,
             request_method,
             request_path,
@@ -181,18 +217,33 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
             Plug.Conn.t(),
             Facilitator.server(),
             module(),
+            ETSCache.server() | nil,
             compiled_route(),
             atom(),
             String.t(),
             String.t()
           ) :: Plug.Conn.t()
-    defp verify_and_settle(conn, facilitator, hooks, route, request_method, request_path, header) do
+    defp verify_and_settle(
+           conn,
+           facilitator,
+           hooks,
+           payment_identifier_cache,
+           route,
+           request_method,
+           request_path,
+           header
+         ) do
       requirements = facilitator_requirements(route, request_path)
+
+      # Derive a stable idempotency key from the raw payment header. Two
+      # concurrent requests carrying the same proof produce the same key.
+      payment_id = :crypto.hash(:sha256, header) |> Base.encode16(case: :lower)
 
       with {:ok, payment_payload} <- PaymentSignature.decode_and_validate(header, requirements),
            {:ok, verify_response} <-
              facilitator_verify(facilitator, payment_payload, requirements, hooks),
            :ok <- ensure_success_status(verify_response),
+           :ok <- claim_payment(payment_identifier_cache, payment_id),
            {:ok, settle_response} <-
              facilitator_settle(facilitator, payment_payload, requirements, hooks),
            :ok <- ensure_success_status(settle_response) do
@@ -209,6 +260,16 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
 
           payment_required_response(conn, route, request_path, rejection_error(reason))
       end
+    end
+
+    # Atomically claims a payment ID to prevent concurrent double-settlement.
+    # When no cache is configured, the check is skipped (opt-in behaviour).
+    @spec claim_payment(ETSCache.server() | nil, String.t()) ::
+            :ok | {:error, :already_exists}
+    defp claim_payment(nil, _payment_id), do: :ok
+
+    defp claim_payment(cache, payment_id) do
+      ETSCache.put_new(cache, payment_id, :verified)
     end
 
     @spec facilitator_verify(Facilitator.server(), map(), map(), module()) ::
@@ -381,6 +442,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     defp rejection_error(:invalid_base64), do: "invalid payment header"
     defp rejection_error(:invalid_json), do: "invalid payment header"
     defp rejection_error(:invalid_payload), do: "invalid payment payload"
+    defp rejection_error(:already_exists), do: "payment already processed"
     defp rejection_error({:missing_fields, _fields}), do: "invalid payment payload"
     defp rejection_error({:invalid_upto_payment, _reason}), do: "invalid payment payload"
 

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -250,9 +250,8 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
         # the user unable to retry with the same proof.
         settle_result =
           with {:ok, settle_response} <-
-                 facilitator_settle(facilitator, payment_payload, requirements, hooks),
-               :ok <- ensure_success_status(settle_response) do
-            :ok
+                 facilitator_settle(facilitator, payment_payload, requirements, hooks) do
+            ensure_success_status(settle_response)
           end
 
         case settle_result do

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -243,12 +243,40 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
            {:ok, verify_response} <-
              facilitator_verify(facilitator, payment_payload, requirements, hooks),
            :ok <- ensure_success_status(verify_response),
-           :ok <- claim_payment(payment_identifier_cache, payment_id),
-           {:ok, settle_response} <-
-             facilitator_settle(facilitator, payment_payload, requirements, hooks),
-           :ok <- ensure_success_status(settle_response) do
-        emit(:payment_verified, %{method: request_method, path: request_path, route: route.path})
-        conn
+           :ok <- claim_payment(payment_identifier_cache, payment_id) do
+        # Claim succeeded. Attempt settlement separately so we can release the
+        # claim if settlement fails — otherwise a transient network error or
+        # facilitator timeout would permanently block the payment ID, leaving
+        # the user unable to retry with the same proof.
+        settle_result =
+          with {:ok, settle_response} <-
+                 facilitator_settle(facilitator, payment_payload, requirements, hooks),
+               :ok <- ensure_success_status(settle_response) do
+            :ok
+          end
+
+        case settle_result do
+          :ok ->
+            emit(:payment_verified, %{
+              method: request_method,
+              path: request_path,
+              route: route.path
+            })
+
+            conn
+
+          {:error, reason} ->
+            release_claim(payment_identifier_cache, payment_id)
+
+            emit(:payment_rejected, %{
+              method: request_method,
+              path: request_path,
+              route: route.path,
+              reason: reason
+            })
+
+            payment_required_response(conn, route, request_path, rejection_error(reason))
+        end
       else
         {:error, reason} ->
           emit(:payment_rejected, %{
@@ -271,6 +299,12 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     defp claim_payment(cache, payment_id) do
       ETSCache.put_new(cache, payment_id, :verified)
     end
+
+    # Releases a previously claimed payment ID. Called when settlement fails
+    # after a successful claim, so the caller can retry with a fresh proof.
+    @spec release_claim(ETSCache.server() | nil, String.t()) :: :ok | {:error, term()}
+    defp release_claim(nil, _payment_id), do: :ok
+    defp release_claim(cache, payment_id), do: ETSCache.delete(cache, payment_id)
 
     @spec facilitator_verify(Facilitator.server(), map(), map(), module()) ::
             Facilitator.response()

--- a/test/x402/extensions/payment_identifier/ets_cache_test.exs
+++ b/test/x402/extensions/payment_identifier/ets_cache_test.exs
@@ -63,6 +63,47 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCacheTest do
     assert %{id: :custom_cache} = ETSCache.child_spec(name: :custom_cache)
   end
 
+  test "put_new/3 inserts a new entry and returns :ok" do
+    cache = start_cache(ttl_ms: 1_000)
+
+    assert :ok = ETSCache.put_new(cache, "payment-1", :verified)
+    assert {:hit, :verified} = ETSCache.get(cache, "payment-1")
+  end
+
+  test "put_new/3 returns :already_exists for a duplicate live entry" do
+    cache = start_cache(ttl_ms: 1_000)
+
+    assert :ok = ETSCache.put_new(cache, "payment-1", :verified)
+    assert {:error, :already_exists} = ETSCache.put_new(cache, "payment-1", :verified)
+  end
+
+  test "put_new/3 allows re-insert after the entry has expired" do
+    # Expired entries must not block legitimate retries until the cleanup
+    # timer fires. put_new should atomically clean up and re-insert.
+    cache = start_cache(ttl_ms: 10, cleanup_interval_ms: 60_000)
+
+    assert :ok = ETSCache.put_new(cache, "payment-1", :verified)
+    Process.sleep(20)
+
+    # Entry is expired but cleanup hasn't run — put_new must still succeed.
+    assert :ok = ETSCache.put_new(cache, "payment-1", :verified)
+    assert {:hit, :verified} = ETSCache.get(cache, "payment-1")
+  end
+
+  test "put_new/3 evicts the soonest-expiring entry when at max_size" do
+    cache = start_cache(ttl_ms: 1_000, max_size: 2)
+
+    assert :ok = ETSCache.put_new(cache, "payment-1", :verified)
+    assert :ok = ETSCache.put_new(cache, "payment-2", :verified)
+
+    # Adding a third entry must succeed (evicts one of the existing entries).
+    assert :ok = ETSCache.put_new(cache, "payment-3", :verified)
+
+    %{table: table} = :sys.get_state(cache)
+    assert :ets.info(table, :size) == 2
+    assert {:hit, :verified} = ETSCache.get(cache, "payment-3")
+  end
+
   defp start_cache(opts) do
     name = String.to_atom("ets_cache_#{System.unique_integer([:positive, :monotonic])}")
     options = Keyword.merge([name: name, cleanup_interval_ms: 50], opts)


### PR DESCRIPTION
## Security Council Findings — Feb 27, 2026

### 🔴 HIGH: ETSCache eviction uses `:ets.first/1` (undefined order)

**Problem:** At `max_size`, the cache evicted whichever key happened to be first in ETS's internal hash ordering — effectively random. An attacker flooding the cache with unique payment IDs could deterministically evict legitimate in-flight records and reopen replay windows.

**Fix:** Replaced the `:ets.first` eviction with `evict_soonest_expiry/1`, which folds over the table to find and evict the entry with the smallest `expires_at_ms`. O(n), but eviction only runs when the cache is at capacity — acceptable for the 10k default.

### 🔴 HIGH: PaymentGate concurrent double-settle race

**Problem:** `verify_and_settle/7` called verify then settle sequentially with no idempotency guard. Two concurrent requests carrying the same payment proof both passed verify (cache not written yet), then both called settle — double-settling the same proof.

**Fix:**
1. **`ETSCache.put_new/3`** — new public API using `:ets.insert_new` (atomic at ETS level, serialized through GenServer). Returns `:ok` on first claim, `{:error, :already_exists}` for any subsequent attempt with the same key.
2. **`payment_identifier_cache` option** — optional field on `PaymentGate` options (default `nil`, backward compatible). When set, `claim_payment/2` atomically claims a SHA-256 hash of the raw payment header before calling settle. The hash is stable — two requests with the same proof produce the same key.
3. **`rejection_error(:already_exists)`** — returns `"payment already processed"` to the client.

**Usage:**
```elixir
plug X402.Plug.PaymentGate,
  facilitator: MyFacilitator,
  payment_identifier_cache: X402.Extensions.PaymentIdentifier.ETSCache,
  routes: [...]
```

**Breaking changes:** None. `payment_identifier_cache` is opt-in.