### PR TITLE
fix: ETSStorage read consistency, backoff jitter, Base.decode64 padding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# AGENTS.md — x402 Elixir SDK
+
+## What This Is
+The Elixir SDK for the x402 HTTP payment protocol — published on Hex.pm. A **library**, not an app. Zero-lock-in: works with any facilitator, chain, or framework.
+
+## Quick Context
+- **Language:** Elixir (OTP)
+- **Published:** Hex.pm (`x402 ~> 0.3`)
+- **CI:** GitHub Actions → `mix test --cover`
+- **Docs:** Generated via ExDoc, hosted on hexdocs.pm
+
+## Module Map
+```
+lib/x402.ex                    — Top-level convenience API
+lib/x402/payment_required.ex   — PAYMENT-REQUIRED header encode/decode
+lib/x402/payment_signature.ex  — PAYMENT-SIGNATURE header decode/validate
+lib/x402/payment_response.ex   — PAYMENT-RESPONSE header encode
+lib/x402/facilitator.ex        — Facilitator GenServer (verify/settle)
+lib/x402/facilitator/http.ex   — HTTP transport layer
+lib/x402/plug/payment_gate.ex  — Plug middleware for Phoenix/Plug apps
+lib/x402/wallet.ex             — EVM + Solana address validation
+lib/x402/telemetry.ex          — Telemetry event definitions
+```
+
+## Key Commands
+```bash
+mix test                   # Run test suite
+mix test --cover           # With coverage (target >90%)
+mix dialyzer               # Type checking
+mix docs                   # Generate ExDoc
+MIX_ENV=test mix coveralls # ExCoveralls report
+mix compile --no-optional-deps  # Must compile without Finch
+```
+
+## Code Standards (Dashbit-level)
+- `@spec` on ALL public functions — no exceptions
+- `@moduledoc` on ALL public modules
+- `@doc` on ALL public functions, with doctests for pure return values
+- `{:ok, result} | {:error, atom}` — never raise for expected failures
+- Flat module naming: `X402.Wallet` not `X402.Utils.Validators.Wallet`
+- Behaviours for extensibility (`@callback`), not app env config
+- No GenServer unless stateful (only Facilitator uses it)
+
+## Testing Rules
+- Unit test per source file: `test/x402/foo_test.exs` ↔ `lib/x402/foo.ex`
+- `doctest X402.ModuleName` in every test file
+- Mox for behaviour mocking (`X402.Facilitator.HTTPBehaviour`)
+- Bypass for HTTP tests — never hit real services
+- >90% line coverage required
+
+## Protocol Reference
+- Headers: `PAYMENT-REQUIRED`, `PAYMENT-SIGNATURE`, `PAYMENT-RESPONSE` (all Base64-encoded JSON)
+- Facilitator endpoints: `POST /verify`, `POST /settle`
+- Network format: CAIP-2 (e.g., `"eip155:8453"` for Base)
+- Schemes: `"exact"`, `"upto"`
+- Spec: https://docs.x402.org
+
+## What NOT To Do
+- Don't add Ecto, Phoenix, or other heavy deps
+- Don't make Finch required — it's optional
+- Don't raise for expected failures (bad base64, invalid address, etc.)
+- Don't add runtime deps on optional libraries

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,93 @@
+# Architecture — x402 Elixir SDK
+
+> Last updated: 2026-02-25
+
+## Overview
+
+A pure Elixir library implementing the x402 HTTP payment protocol. Ships as a Hex package; no web server, no database, no external services required by default.
+
+## Design Philosophy
+
+- **Zero lock-in**: works with any facilitator, chain, or framework
+- **Minimal deps**: only `jason` and `nimble_options` are required
+- **Behaviours over config**: extensibility via `@callback`, not application environment
+- **Flat modules**: short, discoverable names (`X402.Wallet`, not `X402.Utils.Validators.Wallet`)
+
+## Module Structure
+
+```
+X402                         # Top-level convenience API (delegates to submodules)
+├── PaymentRequired          # Encode/decode PAYMENT-REQUIRED header (Base64 JSON)
+├── PaymentSignature         # Decode and validate PAYMENT-SIGNATURE header
+├── PaymentResponse          # Encode PAYMENT-RESPONSE header
+├── Facilitator              # GenServer — HTTP client for /verify + /settle
+│   └── HTTP                 # Transport implementation (uses Finch, optional)
+├── Plug
+│   └── PaymentGate          # Drop-in Plug middleware for Phoenix/Plug pipelines
+├── Wallet                   # EVM (secp256k1) + Solana (ed25519) address validation
+├── Hooks                    # Behaviour: before_verify / after_verify / on_failure
+├── Telemetry                # Telemetry event definitions and metadata
+└── Extensions
+    ├── PaymentIdentifier    # Idempotency — pluggable cache (ETS default)
+    └── SIWX                 # Sign-In-With-X (wallet-authenticated repeat access)
+```
+
+## Payment Flow (SDK perspective)
+
+```
+Incoming HTTP request
+        │
+        ▼
+X402.Plug.PaymentGate
+        │
+        ├─ No PAYMENT-SIGNATURE header? → 402 response (PAYMENT-REQUIRED header)
+        │
+        └─ Signature present?
+                │
+                ├─ Call X402.Facilitator.verify/2
+                │       └─ POST /verify to facilitator URL
+                │
+                ├─ Verify OK? → Call X402.Facilitator.settle/2
+                │                       └─ POST /settle to facilitator URL
+                │
+                ├─ Hooks: before_verify → after_verify → on_failure
+                │
+                └─ Pass through to app handler (conn)
+```
+
+## Optional Dependencies
+
+| Dep | When Required |
+|-----|--------------|
+| `finch` | HTTP calls to facilitator (`X402.Facilitator`) |
+| `ex_secp256k1` | SIWX signature verification (EVM) |
+| `ex_keccak` | SIWX keccak hashing |
+
+All optional deps are guarded by compile-time checks. Must `mix compile --no-optional-deps` successfully.
+
+## Data Formats
+
+All x402 headers carry **Base64-encoded JSON payloads**:
+
+- `PAYMENT-REQUIRED`: `{scheme, network, maxAmountRequired, payTo, asset, extra}`
+- `PAYMENT-SIGNATURE`: `{x402Version, scheme, network, payload, authorization}`
+- `PAYMENT-RESPONSE`: `{success, transaction, networkId, errorReason?}`
+
+Network IDs use CAIP-2 format: `"eip155:8453"` (Base mainnet), `"eip155:84532"` (Base Sepolia).
+
+## Error Handling Convention
+
+All fallible public functions return `{:ok, result} | {:error, atom_reason}`.  
+Structured atoms, never string reasons: `{:error, :invalid_base64}` not `{:error, "bad base64"}`.  
+Only raise on programmer errors (wrong type passed to function, etc.).
+
+## Telemetry Events
+
+```
+[:x402, :verify, :start]
+[:x402, :verify, :stop]
+[:x402, :verify, :exception]
+[:x402, :settle, :start]
+[:x402, :settle, :stop]
+[:x402, :settle, :exception]
+```

--- a/docs/golden-principles.md
+++ b/docs/golden-principles.md
@@ -1,0 +1,53 @@
+# Golden Principles — x402 Elixir SDK
+
+> These are non-negotiable. Every PR is judged against them.
+
+## 1. Zero Lock-In
+The library never forces a specific facilitator, chain, HTTP client, or framework. Users bring their own `Finch` process. Any facilitator URL is accepted. Any CAIP-2 network is valid.
+
+**Violation:** Hardcoding Coinbase's facilitator URL. Requiring a specific HTTP client at compile time.
+
+## 2. Typespecs Are Not Optional
+Every public function has `@spec`. Every public module has `@moduledoc`. Every public function has `@doc`. Dialyzer must pass with zero warnings.
+
+**Violation:** Merging a new public function without `@spec` and `@doc`.
+
+## 3. Structured Errors, Never Strings
+`{:error, :invalid_base64}` — always atoms, never string messages. No exceptions for expected failures (bad input, network error, invalid payment). Only raise for programmer errors.
+
+**Violation:** `{:error, "invalid base64 encoding"}` or `raise "payment failed"` in a public function.
+
+## 4. Minimal Dependencies
+Required deps: only `jason` and `nimble_options`. Everything else is optional. The library must compile and work without `finch`, `ex_secp256k1`, or `ex_keccak` installed.
+
+**Violation:** Adding a new required dependency without explicit discussion and justification.
+
+## 5. Flat Module Hierarchy
+`X402.Wallet`, not `X402.Utils.Validators.WalletHelper`. One level of nesting maximum except for `X402.Plug.*` and `X402.Facilitator.*` sub-namespaces.
+
+**Violation:** Creating `X402.Internal.Helpers.Parser` or any 3+ level nesting.
+
+## 6. Tests Mirror Source
+Every `lib/x402/foo.ex` has `test/x402/foo_test.exs`. Test file structure mirrors source structure. No orphan test files. No untested source files.
+
+**Violation:** Adding a new module without a corresponding test file.
+
+## 7. Doctests Are Executable Documentation
+Pure functions get doctests. They must be real, runnable examples. No `iex> # ...` placeholders. Doctests run in CI.
+
+**Violation:** Merging a pure function without a working doctest.
+
+## 8. Behaviours Over App Config
+Extensibility is via `@behaviour` and callback injection, not `Application.get_env/3`. This keeps the library testable, composable, and free of global state.
+
+**Violation:** Using `Application.get_env` for user-configurable logic that should be a behaviour callback.
+
+## 9. No HTTP in Unit Tests
+Unit tests use Bypass or Mox. Real HTTP calls are forbidden in test suite. CI never touches the live facilitator or any external service.
+
+**Violation:** A test that makes a real `POST /verify` request to `x402-facilitator-app.fly.dev`.
+
+## 10. Coverage Never Goes Below 90%
+If a PR drops coverage below 90%, it is not merged. Period. Coverage is a floor, not a vanity metric.
+
+**Violation:** Merging a PR with coverage at 88% "because it's close enough".

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -1,0 +1,43 @@
+# Quality Status — x402 Elixir SDK
+
+> Last updated: 2026-02-25
+
+## Current Grades
+
+| Area | Grade | Notes |
+|------|-------|-------|
+| Tests | A- | >89% line coverage (ExCoveralls), doctests on all pure functions |
+| Architecture | A | Flat modules, behaviours, minimal deps — Dashbit-level |
+| Docs | A | hexdocs published, @moduledoc + @doc + @spec on all publics |
+| Type Safety | A | Dialyzer-clean, full typespecs |
+| Security | B+ | No secrets stored, wallet validation tested, SIWX needs more fuzz |
+| Optional Deps | A | Compiles cleanly with `--no-optional-deps` |
+
+## Coverage Target
+- **Hard minimum:** 90% line coverage via ExCoveralls
+- Run: `MIX_ENV=test mix coveralls`
+- CI enforces this — PRs that drop below 90% are blocked
+
+## Known Debt
+
+- [ ] Property-based tests (StreamData) for PaymentRequired encode/decode
+- [ ] SIWX fuzzing — edge cases in EVM signature recovery
+- [ ] Benchmark idempotency cache under high concurrency (bench_ets_cache.exs exists but not in CI)
+- [ ] Facilitator retry/backoff not implemented — single attempt only
+- [ ] "upto" scheme: bidding logic validation is minimal
+
+## Testing Stack
+
+- ExUnit (standard)
+- ExCoveralls (coverage)
+- Bypass (HTTP mocking for facilitator tests)
+- Mox (behaviour mocking via `X402.Facilitator.HTTPBehaviour`)
+- Doctests enabled on all public modules
+
+## CI Checks (GitHub Actions)
+
+1. `mix compile --warnings-as-errors`
+2. `mix test --cover` (must be ≥90%)
+3. `mix dialyzer`
+4. `mix compile --no-optional-deps` (optional-dep safety)
+5. `mix format --check-formatted`

--- a/lib/x402/extensions/siwx/ets_storage.ex
+++ b/lib/x402/extensions/siwx/ets_storage.ex
@@ -171,7 +171,7 @@ defmodule X402.Extensions.SIWX.ETSStorage do
 
   @impl true
   @spec handle_call(term(), GenServer.from(), state()) ::
-          {:reply, :ok | {:error, term()}, state()}
+          {:reply, :ok | {:ok, X402.Extensions.SIWX.Storage.access_record()} | {:error, term()}, state()}
   def handle_call({:get, address, resource}, _from, state) do
     key = {address, resource}
     now = now_ms()

--- a/lib/x402/extensions/siwx/ets_storage.ex
+++ b/lib/x402/extensions/siwx/ets_storage.ex
@@ -173,7 +173,7 @@ defmodule X402.Extensions.SIWX.ETSStorage do
   @spec handle_call(term(), GenServer.from(), state()) ::
           {:reply, :ok | {:error, term()}, state()}
   def handle_call({:get, address, resource}, _from, state) do
-    key = {String.downcase(address), resource}
+    key = {address, resource}
     now = now_ms()
 
     reply =

--- a/lib/x402/extensions/siwx/ets_storage.ex
+++ b/lib/x402/extensions/siwx/ets_storage.ex
@@ -5,8 +5,8 @@ defmodule X402.Extensions.SIWX.ETSStorage do
   Records are stored in an ETS table keyed by `{address, resource}` and cleaned
   up periodically by the GenServer process.
 
-  Reads bypass the GenServer and go directly to ETS for better concurrency.
-  Writes are serialized through the GenServer to ensure consistency.
+  Reads are serialized through the GenServer to ensure consistency with
+  concurrent deletes (e.g., session revocation).
   """
 
   use GenServer

--- a/lib/x402/extensions/siwx/ets_storage.ex
+++ b/lib/x402/extensions/siwx/ets_storage.ex
@@ -85,32 +85,26 @@ defmodule X402.Extensions.SIWX.ETSStorage do
   @impl true
   @spec get(String.t(), String.t()) ::
           {:ok, X402.Extensions.SIWX.Storage.access_record()} | {:error, :not_found}
-  def get(address, resource), do: get(@default_table, address, resource)
+  def get(address, resource), do: get(@default_name, address, resource)
 
   @doc since: "0.3.0"
   @doc """
-  Fetches an access record from a specific storage table.
+  Fetches an access record from a specific storage server.
 
-  Reads bypass the GenServer and go directly to ETS for better concurrency
-  under high read load.
+  Routes through the GenServer to ensure reads are serialised with
+  concurrent deletes (e.g., session revocation). A direct ETS read on a
+  `:protected` table sees the table state at read-time, which may be before
+  a queued-but-not-yet-processed `delete` is applied — meaning a revoked
+  session can appear valid until the next cleanup sweep.
   """
-  @spec get(atom(), String.t(), String.t()) ::
+  @spec get(server(), String.t(), String.t()) ::
           {:ok, X402.Extensions.SIWX.Storage.access_record()} | {:error, :not_found}
-  def get(table, address, resource)
-      when is_atom(table) and is_binary(address) and is_binary(resource) do
-    key = {address, resource}
-    now = now_ms()
-
-    case :ets.lookup(table, key) do
-      [{^key, payment_proof, expires_at_ms}] when expires_at_ms > now ->
-        {:ok, %{payment_proof: payment_proof, expires_at_ms: expires_at_ms}}
-
-      _other ->
-        {:error, :not_found}
-    end
+  def get(server, address, resource)
+      when is_binary(address) and is_binary(resource) do
+    GenServer.call(server, {:get, address, resource})
   end
 
-  def get(_table, _address, _resource), do: {:error, :not_found}
+  def get(_server, _address, _resource), do: {:error, :not_found}
 
   @doc since: "0.3.0"
   @doc """
@@ -178,6 +172,22 @@ defmodule X402.Extensions.SIWX.ETSStorage do
   @impl true
   @spec handle_call(term(), GenServer.from(), state()) ::
           {:reply, :ok | {:error, term()}, state()}
+  def handle_call({:get, address, resource}, _from, state) do
+    key = {String.downcase(address), resource}
+    now = now_ms()
+
+    reply =
+      case :ets.lookup(state.table, key) do
+        [{^key, payment_proof, expires_at_ms}] when expires_at_ms > now ->
+          {:ok, %{payment_proof: payment_proof, expires_at_ms: expires_at_ms}}
+
+        _other ->
+          {:error, :not_found}
+      end
+
+    {:reply, reply, state}
+  end
+
   def handle_call({:put, address, resource, payment_proof, ttl_ms}, _from, state) do
     key = {address, resource}
     expires_at_ms = now_ms() + ttl_ms

--- a/lib/x402/extensions/siwx/ets_storage.ex
+++ b/lib/x402/extensions/siwx/ets_storage.ex
@@ -171,7 +171,8 @@ defmodule X402.Extensions.SIWX.ETSStorage do
 
   @impl true
   @spec handle_call(term(), GenServer.from(), state()) ::
-          {:reply, :ok | {:ok, X402.Extensions.SIWX.Storage.access_record()} | {:error, term()}, state()}
+          {:reply, :ok | {:ok, X402.Extensions.SIWX.Storage.access_record()} | {:error, term()},
+           state()}
   def handle_call({:get, address, resource}, _from, state) do
     key = {address, resource}
     now = now_ms()

--- a/lib/x402/facilitator/http.ex
+++ b/lib/x402/facilitator/http.ex
@@ -208,7 +208,7 @@ defmodule X402.Facilitator.HTTP do
   # Full-jitter exponential backoff (capped exponential with uniform jitter).
   # Without jitter, all concurrent callers retry at the same instant —
   # thundering-herd — amplifying load on the facilitator under pressure.
-  # With full jitter each caller sleeps for a random value in [0, cap], which
+  # With full jitter each caller sleeps for a random value in [1, cap], which
   # spreads retries evenly across the window.
   defp backoff_ms(retry_backoff_ms, attempt) do
     cap = retry_backoff_ms * trunc(:math.pow(2, attempt - 1))

--- a/lib/x402/facilitator/http.ex
+++ b/lib/x402/facilitator/http.ex
@@ -205,8 +205,14 @@ defmodule X402.Facilitator.HTTP do
   defp timeout_reason?(%{reason: {:timeout, _details}}), do: true
   defp timeout_reason?(_reason), do: false
 
+  # Full-jitter exponential backoff (capped exponential with uniform jitter).
+  # Without jitter, all concurrent callers retry at the same instant —
+  # thundering-herd — amplifying load on the facilitator under pressure.
+  # With full jitter each caller sleeps for a random value in [0, cap], which
+  # spreads retries evenly across the window.
   defp backoff_ms(retry_backoff_ms, attempt) do
-    retry_backoff_ms * trunc(:math.pow(2, attempt - 1))
+    cap = retry_backoff_ms * trunc(:math.pow(2, attempt - 1))
+    :rand.uniform(max(cap, 1))
   end
 
   defp fetch_non_negative_integer(opts, key, default) do

--- a/lib/x402/payment_required.ex
+++ b/lib/x402/payment_required.ex
@@ -131,7 +131,7 @@ defmodule X402.PaymentRequired do
   defp decode_base64(""), do: {:error, :invalid_base64}
 
   defp decode_base64(value) do
-    case Base.decode64(value) do
+    case Base.decode64(value, padding: false) do
       {:ok, decoded} -> {:ok, decoded}
       :error -> {:error, :invalid_base64}
     end

--- a/lib/x402/payment_signature.ex
+++ b/lib/x402/payment_signature.ex
@@ -215,7 +215,7 @@ defmodule X402.PaymentSignature do
   defp decode_base64(""), do: {:error, :invalid_base64}
 
   defp decode_base64(value) do
-    case Base.decode64(value) do
+    case Base.decode64(value, padding: false) do
       {:ok, decoded} -> {:ok, decoded}
       :error -> {:error, :invalid_base64}
     end

--- a/test/x402/extensions/siwx/ets_storage_test.exs
+++ b/test/x402/extensions/siwx/ets_storage_test.exs
@@ -27,15 +27,15 @@ defmodule X402.Extensions.SIWX.ETSStorageTest do
 
       assert :ok = ETSStorage.put(storage, "0xabc", "/paid/resource", %{"tx" => "0x1"}, 5_000)
 
-      assert {:ok, record} = ETSStorage.get(table, "0xabc", "/paid/resource")
+      assert {:ok, record} = ETSStorage.get(storage, "0xabc", "/paid/resource")
       assert record.payment_proof == %{"tx" => "0x1"}
       assert is_integer(record.expires_at_ms)
     end
 
     test "returns not_found for missing records" do
-      {_storage, table} = start_storage()
+      {storage, _table} = start_storage()
 
-      assert ETSStorage.get(table, "0xmissing", "/paid/resource") == {:error, :not_found}
+      assert ETSStorage.get(storage, "0xmissing", "/paid/resource") == {:error, :not_found}
     end
 
     test "deletes records" do
@@ -43,7 +43,7 @@ defmodule X402.Extensions.SIWX.ETSStorageTest do
 
       assert :ok = ETSStorage.put(storage, "0xabc", "/paid/resource", %{"tx" => "0x1"}, 5_000)
       assert :ok = ETSStorage.delete(storage, "0xabc", "/paid/resource")
-      assert ETSStorage.get(table, "0xabc", "/paid/resource") == {:error, :not_found}
+      assert ETSStorage.get(storage, "0xabc", "/paid/resource") == {:error, :not_found}
     end
 
     test "returns invalid_arguments for malformed put inputs" do
@@ -64,7 +64,7 @@ defmodule X402.Extensions.SIWX.ETSStorageTest do
       assert :ok = ETSStorage.put(storage, "0xabc", "/paid/resource", %{"tx" => "0x1"}, 5)
       Process.sleep(25)
 
-      assert ETSStorage.get(table, "0xabc", "/paid/resource") == {:error, :not_found}
+      assert ETSStorage.get(storage, "0xabc", "/paid/resource") == {:error, :not_found}
     end
 
     test "periodic cleanup removes expired entries" do


### PR DESCRIPTION
## Security Council Findings — Mar 1, 2026

### 🔴 HIGH: `SIWX.ETSStorage` reads bypassed GenServer (stale auth state)

**Problem:** `get/3` read directly from the ETS `:protected` table, bypassing the GenServer. A concurrent `delete/3` (session revocation) is a `GenServer.call` — synchronous for the *caller*, but the ETS delete doesn't happen until the GenServer processes the message. A direct ETS read between when `delete` enqueues the message and when the GenServer processes it returns the old (revoked) session as valid.

**Fix:** Routed `get` through `GenServer.call` so reads are serialised with writes and deletes. Added `handle_call({:get, address, resource})` clause. Updated `get/2` to use `@default_name` (GenServer) instead of `@default_table` (ETS table). Updated `get/3` arity to accept a `server()` instead of `atom()`.

**Trade-off:** Slightly lower read concurrency (GenServer serialises reads+writes). For session auth state, correctness > throughput.

### 🔴 HIGH: Retry backoff has no jitter (thundering herd)

**Problem:** `backoff_ms/2` returned a deterministic exponential value: `base_ms * 2^(attempt-1)`. Under load, all concurrent callers hitting the same transient error wake up and retry at identical instants — thundering herd — amplifying pressure on the facilitator.

**Fix:** Replaced with full-jitter exponential: `:rand.uniform(max(cap, 1))`, where `cap = base_ms * 2^(attempt-1)`. Each caller sleeps a uniformly random value in `[1, cap]`, spreading retries across the backoff window. This is the AWS-recommended approach for distributed retry jitter.

### 🟢 LOW: `Base.decode64` called without `padding: false`

**Problem:** Both `PaymentSignature` and `PaymentRequired` called `Base.decode64(value)` without `padding: false`. Padded base64 input that passes downstream length/format checks could partially decode in unexpected ways.

**Fix:** Added `padding: false` to both callsites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth/session storage semantics and HTTP retry behavior; while changes are small and targeted, they affect correctness under concurrency and can alter retry timing/load patterns in production.
> 
> **Overview**
> Improves SIWX session revocation correctness by routing `X402.Extensions.SIWX.ETSStorage.get/2` and `get/3` through the GenServer (new `handle_call({:get, ...})`), preventing stale reads during concurrent deletes; tests were updated to call `get/3` with the storage server instead of the ETS table.
> 
> Updates facilitator retries to use **full-jitter exponential backoff** in `X402.Facilitator.HTTP.backoff_ms/2` to avoid thundering-herd retries under load.
> 
> Hardens header parsing by decoding `PAYMENT-REQUIRED` and `PAYMENT-SIGNATURE` base64 with `padding: false`, rejecting padded/ambiguous input. 
> 
> Adds internal documentation files (`AGENTS.md` and docs on architecture/principles/quality`) without changing runtime behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37672d8b9de66c1c90371ca0abdcada2e549f58d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->