### PR TITLE
fix: TLS peer verification and PAYMENT-SIGNATURE size cap

### DIFF
--- a/lib/x402/facilitator/http.ex
+++ b/lib/x402/facilitator/http.ex
@@ -41,7 +41,10 @@ defmodule X402.Facilitator.HTTP do
 
   Without proper TLS configuration, your application is vulnerable to MITM
   attacks on facilitator responses.
+
+  See `secure_pool_opts/0` for a ready-to-use configuration.
   """
+
   @doc since: "0.1.0"
   @spec request(finch_name(), String.t(), String.t(), map(), keyword()) :: response()
   def request(finch_name, base_url, path, payload, opts \\ [])
@@ -77,6 +80,32 @@ defmodule X402.Facilitator.HTTP do
   end
 
   # Bundles retry-related context to keep function arity ≤ 8.
+  @doc """
+  Returns recommended Finch pool options with TLS peer verification enabled.
+
+  Use these when starting your Finch pool to ensure facilitator connections
+  are verified against the system CA store:
+
+      Finch.start_link(
+        name: MyFinch,
+        pools: %{default: X402.Facilitator.HTTP.secure_pool_opts()}
+      )
+
+  Requires OTP 25+ for `:public_key.cacerts_get/0`.
+  """
+  @doc since: "0.3.2"
+  @spec secure_pool_opts() :: keyword()
+  def secure_pool_opts do
+    [
+      conn_opts: [
+        transport_opts: [
+          verify: :verify_peer,
+          cacerts: :public_key.cacerts_get()
+        ]
+      ]
+    ]
+  end
+
   defp do_request(%{} = ctx, attempt, max_attempts) do
     result = perform_request(ctx, attempt)
     maybe_retry(result, ctx, attempt, max_attempts)

--- a/lib/x402/facilitator/http.ex
+++ b/lib/x402/facilitator/http.ex
@@ -19,16 +19,33 @@ defmodule X402.Facilitator.HTTP do
   - `:max_retries` (default: `2`)
   - `:retry_backoff_ms` (default: `100`)
   - `:receive_timeout_ms` (default: `5_000`)
-  - `:verify_tls` (default: `true`) — when `true`, enforces TLS peer
-    verification using system CA certs. Set to `false` only in
-    development/test environments; never in production.
+
+  ## TLS Verification
+
+  TLS peer verification must be configured when starting your Finch pool,
+  not per-request. Example:
+
+      Finch.start_link(
+        name: MyFinch,
+        pools: %{
+          default: [
+            conn_opts: [
+              transport_opts: [
+                verify: :verify_peer,
+                cacerts: :public_key.cacerts_get()
+              ]
+            ]
+          ]
+        }
+      )
+
+  Without proper TLS configuration, your application is vulnerable to MITM
+  attacks on facilitator responses.
   """
   @doc since: "0.1.0"
   @spec request(finch_name(), String.t(), String.t(), map(), keyword()) :: response()
   def request(finch_name, base_url, path, payload, opts \\ [])
       when is_binary(base_url) and is_binary(path) and is_map(payload) and is_list(opts) do
-    verify_tls = Keyword.get(opts, :verify_tls, true)
-
     with {:ok, max_retries} <- fetch_non_negative_integer(opts, :max_retries, 2),
          {:ok, retry_backoff_ms} <- fetch_non_negative_integer(opts, :retry_backoff_ms, 100),
          {:ok, receive_timeout_ms} <- fetch_non_negative_integer(opts, :receive_timeout_ms, 5_000),
@@ -40,8 +57,7 @@ defmodule X402.Facilitator.HTTP do
         url: join_url(base_url, path),
         payload: encoded_payload,
         receive_timeout_ms: receive_timeout_ms,
-        retry_backoff_ms: retry_backoff_ms,
-        verify_tls: verify_tls
+        retry_backoff_ms: retry_backoff_ms
       }
 
       do_request(ctx, 1, max_retries + 1)
@@ -72,23 +88,12 @@ defmodule X402.Facilitator.HTTP do
            finch_name: finch_name,
            url: url,
            payload: encoded_payload,
-           receive_timeout_ms: receive_timeout_ms,
-           verify_tls: verify_tls
+           receive_timeout_ms: receive_timeout_ms
          },
          attempt
        ) do
     request = finch_module.build(:post, url, @json_headers, encoded_payload)
-
-    finch_opts =
-      [receive_timeout: receive_timeout_ms] ++
-        if verify_tls do
-          # Enforce TLS peer verification using the system CA bundle.
-          # Without this, a MITM could intercept facilitator responses
-          # and inject fraudulent payment approval.
-          [transport_opts: [verify: :verify_peer, cacerts: :public_key.cacerts_get()]]
-        else
-          []
-        end
+    finch_opts = [receive_timeout: receive_timeout_ms]
 
     response =
       try do

--- a/lib/x402/facilitator/http.ex
+++ b/lib/x402/facilitator/http.ex
@@ -19,11 +19,16 @@ defmodule X402.Facilitator.HTTP do
   - `:max_retries` (default: `2`)
   - `:retry_backoff_ms` (default: `100`)
   - `:receive_timeout_ms` (default: `5_000`)
+  - `:verify_tls` (default: `true`) — when `true`, enforces TLS peer
+    verification using system CA certs. Set to `false` only in
+    development/test environments; never in production.
   """
   @doc since: "0.1.0"
   @spec request(finch_name(), String.t(), String.t(), map(), keyword()) :: response()
   def request(finch_name, base_url, path, payload, opts \\ [])
       when is_binary(base_url) and is_binary(path) and is_map(payload) and is_list(opts) do
+    verify_tls = Keyword.get(opts, :verify_tls, true)
+
     with {:ok, max_retries} <- fetch_non_negative_integer(opts, :max_retries, 2),
          {:ok, retry_backoff_ms} <- fetch_non_negative_integer(opts, :retry_backoff_ms, 100),
          {:ok, receive_timeout_ms} <- fetch_non_negative_integer(opts, :receive_timeout_ms, 5_000),
@@ -35,7 +40,8 @@ defmodule X402.Facilitator.HTTP do
         url: join_url(base_url, path),
         payload: encoded_payload,
         receive_timeout_ms: receive_timeout_ms,
-        retry_backoff_ms: retry_backoff_ms
+        retry_backoff_ms: retry_backoff_ms,
+        verify_tls: verify_tls
       }
 
       do_request(ctx, 1, max_retries + 1)
@@ -66,15 +72,27 @@ defmodule X402.Facilitator.HTTP do
            finch_name: finch_name,
            url: url,
            payload: encoded_payload,
-           receive_timeout_ms: receive_timeout_ms
+           receive_timeout_ms: receive_timeout_ms,
+           verify_tls: verify_tls
          },
          attempt
        ) do
     request = finch_module.build(:post, url, @json_headers, encoded_payload)
 
+    finch_opts =
+      [receive_timeout: receive_timeout_ms] ++
+        if verify_tls do
+          # Enforce TLS peer verification using the system CA bundle.
+          # Without this, a MITM could intercept facilitator responses
+          # and inject fraudulent payment approval.
+          [transport_opts: [verify: :verify_peer, cacerts: :public_key.cacerts_get()]]
+        else
+          []
+        end
+
     response =
       try do
-        finch_module.request(request, finch_name, receive_timeout: receive_timeout_ms)
+        finch_module.request(request, finch_name, finch_opts)
       catch
         :exit, reason -> {:error, reason}
       end

--- a/lib/x402/facilitator/http.ex
+++ b/lib/x402/facilitator/http.ex
@@ -22,8 +22,10 @@ defmodule X402.Facilitator.HTTP do
 
   ## TLS Verification
 
-  TLS peer verification must be configured when starting your Finch pool,
-  not per-request. Example:
+  **REQUIRED**: TLS peer verification must be configured when starting your Finch pool.
+  Failure to do so leaves your application vulnerable to MITM attacks.
+
+  Example configuration:
 
       Finch.start_link(
         name: MyFinch,
@@ -32,15 +34,13 @@ defmodule X402.Facilitator.HTTP do
             conn_opts: [
               transport_opts: [
                 verify: :verify_peer,
+                # Note: requires OTP 25+, see https://www.erlang.org/doc/apps/public_key/public_key.html#cacerts_get/0
                 cacerts: :public_key.cacerts_get()
               ]
             ]
           ]
         }
       )
-
-  Without proper TLS configuration, your application is vulnerable to MITM
-  attacks on facilitator responses.
 
   See `secure_pool_opts/0` for a ready-to-use configuration.
   """

--- a/lib/x402/facilitator/http.ex
+++ b/lib/x402/facilitator/http.ex
@@ -79,7 +79,6 @@ defmodule X402.Facilitator.HTTP do
     end
   end
 
-  # Bundles retry-related context to keep function arity ≤ 8.
   @doc """
   Returns recommended Finch pool options with TLS peer verification enabled.
 
@@ -106,6 +105,7 @@ defmodule X402.Facilitator.HTTP do
     ]
   end
 
+  # Bundles retry-related context to keep function arity ≤ 8.
   defp do_request(%{} = ctx, attempt, max_attempts) do
     result = perform_request(ctx, attempt)
     maybe_retry(result, ctx, attempt, max_attempts)

--- a/lib/x402/payment_signature.ex
+++ b/lib/x402/payment_signature.ex
@@ -15,7 +15,13 @@ defmodule X402.PaymentSignature do
 
   @required_fields ~w(transactionHash network scheme payerWallet)
 
-  @type decode_error :: :invalid_base64 | :invalid_json
+  # Maximum byte size of the PAYMENT-SIGNATURE header value before decoding.
+  # A valid payment signature is a small JSON object — 8 KB is generous.
+  # Rejecting oversized input before Base64 decode prevents memory exhaustion
+  # under load when many concurrent large payloads hit Jason.decode/1.
+  @max_header_bytes 8_192
+
+  @type decode_error :: :invalid_base64 | :invalid_json | :payload_too_large
   @type upto_validation_error ::
           :missing_max_price
           | :missing_payment_value
@@ -58,6 +64,19 @@ defmodule X402.PaymentSignature do
   """
   @spec decode(String.t()) :: {:ok, map()} | {:error, decode_error()}
   def decode(value) when is_binary(value) do
+    if byte_size(value) > @max_header_bytes do
+      Telemetry.emit(:payment_signature, :decode, :error, %{
+        reason: :payload_too_large,
+        header: header_name()
+      })
+
+      {:error, :payload_too_large}
+    else
+      do_decode(value)
+    end
+  end
+
+  defp do_decode(value) do
     with {:ok, json} <- decode_base64(value),
          {:ok, decoded} <- Jason.decode(json),
          true <- is_map(decoded) do

--- a/lib/x402/payment_signature.ex
+++ b/lib/x402/payment_signature.ex
@@ -76,6 +76,15 @@ defmodule X402.PaymentSignature do
     end
   end
 
+  def decode(_value) do
+    Telemetry.emit(:payment_signature, :decode, :error, %{
+      reason: :invalid_base64,
+      header: header_name()
+    })
+
+    {:error, :invalid_base64}
+  end
+
   defp do_decode(value) do
     with {:ok, json} <- decode_base64(value),
          {:ok, decoded} <- Jason.decode(json),
@@ -108,15 +117,6 @@ defmodule X402.PaymentSignature do
 
         {:error, :invalid_json}
     end
-  end
-
-  def decode(_value) do
-    Telemetry.emit(:payment_signature, :decode, :error, %{
-      reason: :invalid_base64,
-      header: header_name()
-    })
-
-    {:error, :invalid_base64}
   end
 
   @doc since: "0.1.0", group: :verification

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -474,6 +474,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     defp rejection_error(:invalid_payment_header), do: "invalid payment header"
     defp rejection_error(:invalid_base64), do: "invalid payment header"
     defp rejection_error(:invalid_json), do: "invalid payment header"
+    defp rejection_error(:payload_too_large), do: "invalid payment header"
     defp rejection_error(:invalid_payload), do: "invalid payment payload"
     defp rejection_error(:already_exists), do: "payment already processed"
     defp rejection_error({:missing_fields, _fields}), do: "invalid payment payload"

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule X402.MixProject do
     [
       app: :x402,
       version: @version,
-      elixir: "~> 1.15",
+      elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),

--- a/test/x402/payment_signature_test.exs
+++ b/test/x402/payment_signature_test.exs
@@ -36,6 +36,12 @@ defmodule X402.PaymentSignatureTest do
       assert PaymentSignature.decode(invalid_json) == {:error, :invalid_json}
     end
 
+    test "returns payload_too_large for oversized headers" do
+      # @max_header_bytes is 8_192
+      oversized = String.duplicate("A", 8_193) |> Base.encode64()
+      assert PaymentSignature.decode(oversized) == {:error, :payload_too_large}
+    end
+
     test "returns invalid_json when decoded json is not a map" do
       encoded_array = Base.encode64("[1,2,3]")
       assert PaymentSignature.decode(encoded_array) == {:error, :invalid_json}

--- a/test/x402/payment_signature_test.exs
+++ b/test/x402/payment_signature_test.exs
@@ -36,9 +36,16 @@ defmodule X402.PaymentSignatureTest do
       assert PaymentSignature.decode(invalid_json) == {:error, :invalid_json}
     end
 
-    test "returns payload_too_large for oversized headers" do
-      # @max_header_bytes is 8_192
-      oversized = String.duplicate("A", 8_193) |> Base.encode64()
+    test "accepts headers at exactly the size limit" do
+      # @max_header_bytes is 8_192 — check is on raw input byte_size
+      at_limit = String.duplicate("A", 8_192)
+      # Should NOT return :payload_too_large (will fail for other reasons)
+      refute PaymentSignature.decode(at_limit) == {:error, :payload_too_large}
+    end
+
+    test "returns payload_too_large for headers exceeding size limit" do
+      # @max_header_bytes is 8_192 — one byte over triggers rejection
+      oversized = String.duplicate("A", 8_193)
       assert PaymentSignature.decode(oversized) == {:error, :payload_too_large}
     end
 


### PR DESCRIPTION
## Changes

### PAYMENT-SIGNATURE size cap
- Rejects headers > 8KB (`@max_header_bytes 8_192`) before Base64 decoding
- Returns `{:error, :payload_too_large}` with telemetry event
- Explicit clause in `PaymentGate.rejection_error/1`

### TLS peer verification helper
- Added `secure_pool_opts/0` — returns Finch pool config with `:verify_peer` + system CA store
- TLS must be configured at Finch pool startup (not per-request — Finch ignores per-request transport_opts)
- Documented usage in moduledoc

### Elixir version
- Bumped minimum to `~> 1.17` (requires OTP 25+ for `:public_key.cacerts_get/0`)
- Separate PR #33 bumps to `~> 1.19` to match CI matrix

### Tests
- Exact boundary tests: 8,192 bytes accepted, 8,193 bytes rejected
- 184 tests, 0 failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive areas (TLS configuration guidance for facilitator HTTP and input-size limiting on a request header); behavior change may reject previously-accepted oversized headers and requires consumers to configure Finch pools correctly.
> 
> **Overview**
> **Security hardening for facilitator HTTP and payment header handling.** `X402.Facilitator.HTTP` now documents *required* TLS peer verification for Finch pools and adds `secure_pool_opts/0` to provide a ready-to-use `verify: :verify_peer` + system CA configuration (plus minor refactor to pass request opts via a variable).
> 
> `X402.PaymentSignature.decode/1` now rejects `PAYMENT-SIGNATURE` header values over 8KB before Base64/JSON decoding, emitting telemetry and returning `{:error, :payload_too_large}`; `PaymentGate` maps this to an “invalid payment header” rejection, and tests add boundary coverage for the size limit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb1da276d9eaa4a5a7efd7f9bfb1f4528df1bc2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->