### PR TITLE
chore: bump minimum Elixir to ~> 1.19

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule X402.MixProject do
     [
       app: :x402,
       version: @version,
-      elixir: "~> 1.15",
+      elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),


### PR DESCRIPTION
Bumps minimum Elixir requirement from `~> 1.15` to `~> 1.19` to align with CI matrix (Elixir 1.19.5 / OTP 27).

**Changes:**
- `mix.exs`: `elixir: "~> 1.19"`

**Why:**
- CI already only tests on Elixir 1.19 / OTP 27
- Simplifies reliance on OTP 25+ features
- 232 tests pass, 0 failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only raises the declared minimum Elixir version in `mix.exs`, affecting compatibility/installation for users on older Elixir versions but not runtime behavior.
> 
> **Overview**
> Updates `mix.exs` to require Elixir `~> 1.19` instead of `~> 1.15`, dropping support for older Elixir versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67d122a3275baec2907fe68ad8c01a8d5903ee59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->