### PR TITLE
fix: enforce https:// scheme on facilitator base_url (HIGH)

### DIFF
--- a/lib/x402/facilitator/error.ex
+++ b/lib/x402/facilitator/error.ex
@@ -9,6 +9,7 @@ defmodule X402.Facilitator.Error do
   @type error_type ::
           :finch_unavailable
           | :http_error
+          | :insecure_scheme
           | :invalid_json
           | :invalid_option
           | :request_setup_failed

--- a/lib/x402/facilitator/http.ex
+++ b/lib/x402/facilitator/http.ex
@@ -303,11 +303,15 @@ defmodule X402.Facilitator.HTTP do
   # plaintext transmission of payment proofs. An http:// URL would bypass
   # the TLS pool configuration in secure_pool_opts/0 entirely.
   #
-  # This check is intentionally unconditional — use a local HTTPS proxy or
-  # a self-signed cert for dev/test environments that need real network calls.
+  # localhost is explicitly exempted: loopback addresses cannot be
+  # intercepted by a network attacker, so http://localhost is safe for
+  # local development and test environments using plain-HTTP servers.
   defp validate_https_scheme(base_url) do
     case URI.parse(base_url) do
       %URI{scheme: "https"} ->
+        :ok
+
+      %URI{scheme: "http", host: host} when host in ["localhost", "127.0.0.1", "::1"] ->
         :ok
 
       %URI{scheme: "http"} ->

--- a/lib/x402/facilitator/http.ex
+++ b/lib/x402/facilitator/http.ex
@@ -314,7 +314,8 @@ defmodule X402.Facilitator.HTTP do
         {:error,
          %Error{
            type: :insecure_scheme,
-           reason: "base_url must use https:// — http:// would transmit payment proofs in plaintext",
+           reason:
+             "base_url must use https:// — http:// would transmit payment proofs in plaintext",
            retryable: false,
            attempt: nil
          }}

--- a/lib/x402/facilitator/http.ex
+++ b/lib/x402/facilitator/http.ex
@@ -311,7 +311,7 @@ defmodule X402.Facilitator.HTTP do
       %URI{scheme: "https"} ->
         :ok
 
-      %URI{scheme: "http", host: host} when host in ["localhost", "127.0.0.1", "[::1]"] ->
+      %URI{scheme: "http", host: host} when host in ["localhost", "127.0.0.1", "::1"] ->
         :ok
 
       %URI{scheme: "http"} ->

--- a/lib/x402/facilitator/http.ex
+++ b/lib/x402/facilitator/http.ex
@@ -311,7 +311,7 @@ defmodule X402.Facilitator.HTTP do
       %URI{scheme: "https"} ->
         :ok
 
-      %URI{scheme: "http", host: host} when host in ["localhost", "127.0.0.1", "::1"] ->
+      %URI{scheme: "http", host: host} when host in ["localhost", "127.0.0.1", "[::1]"] ->
         :ok
 
       %URI{scheme: "http"} ->

--- a/lib/x402/facilitator/http.ex
+++ b/lib/x402/facilitator/http.ex
@@ -303,9 +303,8 @@ defmodule X402.Facilitator.HTTP do
   # plaintext transmission of payment proofs. An http:// URL would bypass
   # the TLS pool configuration in secure_pool_opts/0 entirely.
   #
-  # Callers can opt out for local dev/test by passing verify_tls: false in
-  # pool opts, but the scheme check here is separate — http:// means no TLS
-  # at all regardless of pool settings.
+  # This check is intentionally unconditional — use a local HTTPS proxy or
+  # a self-signed cert for dev/test environments that need real network calls.
   defp validate_https_scheme(base_url) do
     case URI.parse(base_url) do
       %URI{scheme: "https"} ->
@@ -317,7 +316,7 @@ defmodule X402.Facilitator.HTTP do
            type: :insecure_scheme,
            reason: "base_url must use https:// — http:// would transmit payment proofs in plaintext",
            retryable: false,
-           attempt: 0
+           attempt: nil
          }}
 
       %URI{scheme: nil} ->
@@ -326,7 +325,7 @@ defmodule X402.Facilitator.HTTP do
            type: :insecure_scheme,
            reason: "base_url must include an https:// scheme",
            retryable: false,
-           attempt: 0
+           attempt: nil
          }}
 
       %URI{scheme: other} ->
@@ -335,7 +334,7 @@ defmodule X402.Facilitator.HTTP do
            type: :insecure_scheme,
            reason: "base_url scheme must be https://, got: #{other}://",
            retryable: false,
-           attempt: 0
+           attempt: nil
          }}
     end
   end

--- a/lib/x402/facilitator/http.ex
+++ b/lib/x402/facilitator/http.ex
@@ -49,7 +49,8 @@ defmodule X402.Facilitator.HTTP do
   @spec request(finch_name(), String.t(), String.t(), map(), keyword()) :: response()
   def request(finch_name, base_url, path, payload, opts \\ [])
       when is_binary(base_url) and is_binary(path) and is_map(payload) and is_list(opts) do
-    with {:ok, max_retries} <- fetch_non_negative_integer(opts, :max_retries, 2),
+    with :ok <- validate_https_scheme(base_url),
+         {:ok, max_retries} <- fetch_non_negative_integer(opts, :max_retries, 2),
          {:ok, retry_backoff_ms} <- fetch_non_negative_integer(opts, :retry_backoff_ms, 100),
          {:ok, receive_timeout_ms} <- fetch_non_negative_integer(opts, :receive_timeout_ms, 5_000),
          {:ok, finch_module} <- ensure_finch_module(),
@@ -295,6 +296,47 @@ defmodule X402.Facilitator.HTTP do
 
       false ->
         {:error, %Error{type: :finch_unavailable, reason: :missing_dependency, retryable: false}}
+    end
+  end
+
+  # Enforces HTTPS scheme on facilitator base_url to prevent accidental
+  # plaintext transmission of payment proofs. An http:// URL would bypass
+  # the TLS pool configuration in secure_pool_opts/0 entirely.
+  #
+  # Callers can opt out for local dev/test by passing verify_tls: false in
+  # pool opts, but the scheme check here is separate — http:// means no TLS
+  # at all regardless of pool settings.
+  defp validate_https_scheme(base_url) do
+    case URI.parse(base_url) do
+      %URI{scheme: "https"} ->
+        :ok
+
+      %URI{scheme: "http"} ->
+        {:error,
+         %Error{
+           type: :insecure_scheme,
+           reason: "base_url must use https:// — http:// would transmit payment proofs in plaintext",
+           retryable: false,
+           attempt: 0
+         }}
+
+      %URI{scheme: nil} ->
+        {:error,
+         %Error{
+           type: :insecure_scheme,
+           reason: "base_url must include an https:// scheme",
+           retryable: false,
+           attempt: 0
+         }}
+
+      %URI{scheme: other} ->
+        {:error,
+         %Error{
+           type: :insecure_scheme,
+           reason: "base_url scheme must be https://, got: #{other}://",
+           retryable: false,
+           attempt: 0
+         }}
     end
   end
 

--- a/test/x402/facilitator/http_test.exs
+++ b/test/x402/facilitator/http_test.exs
@@ -204,8 +204,6 @@ defmodule X402.Facilitator.HTTPTest do
     end)
   end
 
-  @tag skip_bypass: true
-  @tag skip_finch: true
   test "request/5 handles finch edge responses without external network" do
     with_stubbed_finch(fn ->
       Process.put(:http_test_finch_response, {:ok, %{status: 200, body: nil}})
@@ -254,29 +252,21 @@ defmodule X402.Facilitator.HTTPTest do
     end)
   end
 
-  @tag skip_bypass: true
-  @tag skip_finch: true
   test "request/5 rejects http:// base_url with insecure_scheme error" do
     assert {:error, %Error{type: :insecure_scheme}} =
              HTTP.request(:finch, "http://example.com", "/verify", %{})
   end
 
-  @tag skip_bypass: true
-  @tag skip_finch: true
   test "request/5 rejects base_url with no scheme" do
     assert {:error, %Error{type: :insecure_scheme}} =
              HTTP.request(:finch, "example.com", "/verify", %{})
   end
 
-  @tag skip_bypass: true
-  @tag skip_finch: true
   test "request/5 rejects ftp:// base_url with insecure_scheme error" do
     assert {:error, %Error{type: :insecure_scheme}} =
              HTTP.request(:finch, "ftp://example.com", "/verify", %{})
   end
 
-  @tag skip_bypass: true
-  @tag skip_finch: true
   test "request/5 accepts https:// base_url (scheme validation passes, Finch may still fail)" do
     with_stubbed_finch(fn ->
       Process.put(:http_test_finch_response, {:error, :connection_refused})
@@ -287,8 +277,6 @@ defmodule X402.Facilitator.HTTPTest do
     end)
   end
 
-  @tag skip_bypass: true
-  @tag skip_finch: true
   test "request/5 allows http://localhost (loopback exemption — no MitM risk)" do
     with_stubbed_finch(fn ->
       Process.put(:http_test_finch_response, {:error, :connection_refused})
@@ -299,8 +287,6 @@ defmodule X402.Facilitator.HTTPTest do
     end)
   end
 
-  @tag skip_bypass: true
-  @tag skip_finch: true
   test "request/5 allows http://127.0.0.1 (loopback exemption — no MitM risk)" do
     with_stubbed_finch(fn ->
       Process.put(:http_test_finch_response, {:error, :connection_refused})
@@ -311,8 +297,16 @@ defmodule X402.Facilitator.HTTPTest do
     end)
   end
 
-  @tag skip_bypass: true
-  @tag skip_finch: true
+  test "request/5 allows http://[::1] (IPv6 loopback exemption — no MitM risk)" do
+    with_stubbed_finch(fn ->
+      Process.put(:http_test_finch_response, {:error, :connection_refused})
+
+      result = HTTP.request(:stub, "http://[::1]:4000", "/verify", %{})
+      assert {:error, %Error{type: type}} = result
+      refute type == :insecure_scheme
+    end)
+  end
+
   test "request/5 returns finch_unavailable when Finch callbacks are missing" do
     with_redefined_finch(
       """

--- a/test/x402/facilitator/http_test.exs
+++ b/test/x402/facilitator/http_test.exs
@@ -6,117 +6,95 @@ defmodule X402.Facilitator.HTTPTest do
 
   import X402.TestHelpers
 
-  setup :maybe_setup_bypass
-  setup :maybe_setup_finch
+  test "request/5 returns status and decoded body on success" do
+    with_stubbed_finch(fn ->
+      Process.put(:http_test_finch_response, {:ok, %{status: 200, body: Jason.encode!(%{"ok" => true})}})
 
-  test "request/5 returns status and decoded body on success", %{
-    bypass: bypass,
-    finch: finch,
-    facilitator_url: facilitator_url
-  } do
-    Bypass.expect(bypass, "POST", "/verify", fn conn ->
-      Plug.Conn.resp(conn, 200, Jason.encode!(%{"ok" => true}))
+      assert {:ok, %{status: 200, body: %{"ok" => true}}} =
+               HTTP.request(:stub, "https://facilitator.test", "/verify", %{"payload" => %{}}, [])
     end)
-
-    assert {:ok, %{status: 200, body: %{"ok" => true}}} =
-             HTTP.request(finch, facilitator_url, "/verify", %{"payload" => %{}}, [])
   end
 
-  test "request/4 applies default opts", %{
-    bypass: bypass,
-    finch: finch,
-    facilitator_url: facilitator_url
-  } do
-    Bypass.expect(bypass, "POST", "/verify", fn conn ->
-      Plug.Conn.resp(conn, 200, Jason.encode!(%{"ok" => true}))
-    end)
+  test "request/4 applies default opts" do
+    with_stubbed_finch(fn ->
+      Process.put(:http_test_finch_response, {:ok, %{status: 200, body: Jason.encode!(%{"ok" => true})}})
 
-    assert {:ok, %{status: 200, body: %{"ok" => true}}} =
-             HTTP.request(finch, facilitator_url, "/verify", %{"payload" => %{}})
+      assert {:ok, %{status: 200, body: %{"ok" => true}}} =
+               HTTP.request(:stub, "https://facilitator.test", "/verify", %{"payload" => %{}})
+    end)
   end
 
-  test "request/5 returns non-retryable error for 400", %{
-    bypass: bypass,
-    finch: finch,
-    facilitator_url: facilitator_url
-  } do
-    Bypass.expect(bypass, "POST", "/verify", fn conn ->
-      Plug.Conn.resp(conn, 400, Jason.encode!(%{"error" => "bad request"}))
-    end)
+  test "request/5 returns non-retryable error for 400" do
+    with_stubbed_finch(fn ->
+      Process.put(
+        :http_test_finch_response,
+        {:ok, %{status: 400, body: Jason.encode!(%{"error" => "bad request"})}}
+      )
 
-    assert {:error,
-            %Error{
-              type: :http_error,
-              status: 400,
-              body: %{"error" => "bad request"},
-              retryable: false
-            }} =
-             HTTP.request(finch, facilitator_url, "/verify", %{}, max_retries: 2)
+      assert {:error,
+              %Error{
+                type: :http_error,
+                status: 400,
+                body: %{"error" => "bad request"},
+                retryable: false
+              }} = HTTP.request(:stub, "https://facilitator.test", "/verify", %{}, max_retries: 2)
+    end)
   end
 
-  test "request/5 returns non-retryable error for 401", %{
-    bypass: bypass,
-    finch: finch,
-    facilitator_url: facilitator_url
-  } do
-    Bypass.expect(bypass, "POST", "/verify", fn conn ->
-      Plug.Conn.resp(conn, 401, Jason.encode!(%{"error" => "unauthorized"}))
-    end)
+  test "request/5 returns non-retryable error for 401" do
+    with_stubbed_finch(fn ->
+      Process.put(
+        :http_test_finch_response,
+        {:ok, %{status: 401, body: Jason.encode!(%{"error" => "unauthorized"})}}
+      )
 
-    assert {:error,
-            %Error{
-              type: :http_error,
-              status: 401,
-              body: %{"error" => "unauthorized"},
-              retryable: false
-            }} = HTTP.request(finch, facilitator_url, "/verify", %{}, max_retries: 2)
+      assert {:error,
+              %Error{
+                type: :http_error,
+                status: 401,
+                body: %{"error" => "unauthorized"},
+                retryable: false
+              }} = HTTP.request(:stub, "https://facilitator.test", "/verify", %{}, max_retries: 2)
+    end)
   end
 
-  test "request/5 retries transient errors and eventually succeeds", %{
-    bypass: bypass,
-    finch: finch,
-    facilitator_url: facilitator_url
-  } do
-    {:ok, attempts} = Agent.start_link(fn -> 0 end)
+  test "request/5 retries transient errors and eventually succeeds" do
+    with_stubbed_finch(fn ->
+      {:ok, attempts} = Agent.start_link(fn -> 0 end)
 
-    Bypass.stub(bypass, "POST", "/verify", fn conn ->
-      current_attempt = Agent.get_and_update(attempts, &{&1 + 1, &1 + 1})
+      Process.put(:http_test_finch_response, {:fun, fn _req, _name, _opts ->
+        current_attempt = Agent.get_and_update(attempts, &{&1 + 1, &1 + 1})
 
-      case current_attempt do
-        1 ->
-          Plug.Conn.resp(conn, 429, Jason.encode!(%{"error" => "rate limited"}))
+        case current_attempt do
+          1 -> {:ok, %{status: 429, body: Jason.encode!(%{"error" => "rate limited"})}}
+          2 -> {:ok, %{status: 503, body: Jason.encode!(%{"error" => "busy"})}}
+          _ -> {:ok, %{status: 200, body: Jason.encode!(%{"ok" => true})}}
+        end
+      end})
 
-        2 ->
-          Plug.Conn.resp(conn, 503, Jason.encode!(%{"error" => "busy"}))
+      assert {:ok, %{status: 200, body: %{"ok" => true}}} =
+               HTTP.request(:stub, "https://facilitator.test", "/verify", %{},
+                 max_retries: 2,
+                 retry_backoff_ms: 1
+               )
 
-        _attempt ->
-          Plug.Conn.resp(conn, 200, Jason.encode!(%{"ok" => true}))
-      end
+      assert Agent.get(attempts, & &1) == 3
     end)
-
-    assert {:ok, %{status: 200, body: %{"ok" => true}}} =
-             HTTP.request(finch, facilitator_url, "/verify", %{},
-               max_retries: 2,
-               retry_backoff_ms: 1
-             )
-
-    assert Agent.get(attempts, & &1) == 3
   end
 
-  test "request/5 returns retryable error for 500 after retries exhausted", %{
-    bypass: bypass,
-    finch: finch,
-    facilitator_url: facilitator_url
-  } do
-    Bypass.stub(bypass, "POST", "/verify", fn conn ->
-      Plug.Conn.resp(conn, 500, Jason.encode!(%{"error" => "server"}))
-    end)
+  test "request/5 returns retryable error for 500 after retries exhausted" do
+    with_stubbed_finch(fn ->
+      Process.put(
+        :http_test_finch_response,
+        {:ok, %{status: 500, body: Jason.encode!(%{"error" => "server"})}}
+      )
 
-    assert {:error, %Error{type: :http_error, status: 500, retryable: true, attempt: 3}} =
-             HTTP.request(finch, facilitator_url, "/verify", %{},
-               max_retries: 2,
-               retry_backoff_ms: 1
-             )
+      assert {:error, %Error{type: :http_error, status: 500, retryable: true, attempt: 3}} =
+               HTTP.request(:stub, "https://facilitator.test", "/verify", %{},
+                 max_retries: 2,
+                 retry_backoff_ms: 1
+               )
+    end)
   end
 
   test "request/5 wraps non-Error setup failures from payload encoding" do
@@ -126,17 +104,13 @@ defmodule X402.Facilitator.HTTPTest do
              })
   end
 
-  test "request/5 handles invalid JSON in successful response", %{
-    bypass: bypass,
-    finch: finch,
-    facilitator_url: facilitator_url
-  } do
-    Bypass.expect(bypass, "POST", "/verify", fn conn ->
-      Plug.Conn.resp(conn, 200, "not-json")
-    end)
+  test "request/5 handles invalid JSON in successful response" do
+    with_stubbed_finch(fn ->
+      Process.put(:http_test_finch_response, {:ok, %{status: 200, body: "not-json"}})
 
-    assert {:error, %Error{type: :invalid_json, status: 200, retryable: false}} =
-             HTTP.request(finch, facilitator_url, "/verify", %{}, [])
+      assert {:error, %Error{type: :invalid_json, status: 200, retryable: false}} =
+               HTTP.request(:stub, "https://facilitator.test", "/verify", %{}, [])
+    end)
   end
 
   test "request/5 validates options" do
@@ -154,88 +128,67 @@ defmodule X402.Facilitator.HTTPTest do
              HTTP.request(:finch, "https://example.com", "/verify", %{}, receive_timeout_ms: -5)
   end
 
-  test "request/5 handles empty body in successful response", %{
-    bypass: bypass,
-    finch: finch,
-    facilitator_url: facilitator_url
-  } do
-    Bypass.expect(bypass, "POST", "/verify", fn conn ->
-      Plug.Conn.resp(conn, 200, "")
-    end)
+  test "request/5 handles empty body in successful response" do
+    with_stubbed_finch(fn ->
+      Process.put(:http_test_finch_response, {:ok, %{status: 200, body: ""}})
 
-    assert {:ok, %{status: 200, body: %{}}} =
-             HTTP.request(finch, facilitator_url, "/verify", %{}, [])
+      assert {:ok, %{status: 200, body: %{}}} =
+               HTTP.request(:stub, "https://facilitator.test", "/verify", %{}, [])
+    end)
   end
 
-  test "request/5 handles nil body in error response (transient status)", %{
-    bypass: bypass,
-    finch: finch,
-    facilitator_url: facilitator_url
-  } do
-    Bypass.stub(bypass, "POST", "/verify", fn conn ->
-      Plug.Conn.resp(conn, 503, "")
-    end)
+  test "request/5 handles nil body in error response (transient status)" do
+    with_stubbed_finch(fn ->
+      Process.put(:http_test_finch_response, {:ok, %{status: 503, body: ""}})
 
-    assert {:error, %Error{type: :http_error, status: 503, body: %{}, retryable: true}} =
-             HTTP.request(finch, facilitator_url, "/verify", %{}, max_retries: 0)
+      assert {:error, %Error{type: :http_error, status: 503, body: %{}, retryable: true}} =
+               HTTP.request(:stub, "https://facilitator.test", "/verify", %{}, max_retries: 0)
+    end)
   end
 
-  test "request/5 handles non-JSON error body", %{
-    bypass: bypass,
-    finch: finch,
-    facilitator_url: facilitator_url
-  } do
-    Bypass.expect(bypass, "POST", "/verify", fn conn ->
-      Plug.Conn.resp(conn, 400, "plain text error")
-    end)
+  test "request/5 handles non-JSON error body" do
+    with_stubbed_finch(fn ->
+      Process.put(:http_test_finch_response, {:ok, %{status: 400, body: "plain text error"}})
 
-    assert {:error,
-            %Error{type: :http_error, status: 400, body: %{"raw_body" => "plain text error"}}} =
-             HTTP.request(finch, facilitator_url, "/verify", %{}, [])
+      assert {:error,
+              %Error{type: :http_error, status: 400, body: %{"raw_body" => "plain text error"}}} =
+               HTTP.request(:stub, "https://facilitator.test", "/verify", %{}, [])
+    end)
   end
 
-  test "request/5 handles JSON array response as invalid json", %{
-    bypass: bypass,
-    finch: finch,
-    facilitator_url: facilitator_url
-  } do
-    Bypass.expect(bypass, "POST", "/verify", fn conn ->
-      Plug.Conn.resp(conn, 200, "[1, 2, 3]")
-    end)
+  test "request/5 handles JSON array response as invalid json" do
+    with_stubbed_finch(fn ->
+      Process.put(:http_test_finch_response, {:ok, %{status: 200, body: "[1, 2, 3]"}})
 
-    assert {:error, %Error{type: :invalid_json, status: 200, retryable: false}} =
-             HTTP.request(finch, facilitator_url, "/verify", %{}, [])
+      assert {:error, %Error{type: :invalid_json, status: 200, retryable: false}} =
+               HTTP.request(:stub, "https://facilitator.test", "/verify", %{}, [])
+    end)
   end
 
-  test "request/5 handles all transient status codes", %{
-    bypass: bypass,
-    finch: finch,
-    facilitator_url: facilitator_url
-  } do
+  test "request/5 handles all transient status codes" do
     for status <- [408, 429, 502, 504] do
-      Bypass.stub(bypass, "POST", "/verify", fn conn ->
-        Plug.Conn.resp(conn, status, Jason.encode!(%{"error" => "transient"}))
-      end)
+      with_stubbed_finch(fn ->
+        Process.put(
+          :http_test_finch_response,
+          {:ok, %{status: status, body: Jason.encode!(%{"error" => "transient"})}}
+        )
 
-      assert {:error, %Error{type: :http_error, status: ^status, retryable: true}} =
-               HTTP.request(finch, facilitator_url, "/verify", %{},
-                 max_retries: 0,
-                 retry_backoff_ms: 1
-               )
+        assert {:error, %Error{type: :http_error, status: ^status, retryable: true}} =
+                 HTTP.request(:stub, "https://facilitator.test", "/verify", %{},
+                   max_retries: 0,
+                   retry_backoff_ms: 1
+                 )
+      end)
     end
   end
 
-  test "request/5 normalizes URL trailing slashes", %{
-    bypass: bypass,
-    finch: finch,
-    facilitator_url: facilitator_url
-  } do
-    Bypass.expect(bypass, "POST", "/verify", fn conn ->
-      Plug.Conn.resp(conn, 200, Jason.encode!(%{"ok" => true}))
-    end)
+  test "request/5 normalizes URL trailing slashes" do
+    with_stubbed_finch(fn ->
+      Process.put(:http_test_finch_response, {:ok, %{status: 200, body: Jason.encode!(%{"ok" => true})}})
 
-    assert {:ok, %{status: 200}} =
-             HTTP.request(finch, facilitator_url <> "/", "/verify", %{}, [])
+      assert {:ok, %{status: 200}} =
+               HTTP.request(:stub, "https://facilitator.test/", "/verify", %{}, [])
+    end)
   end
 
   @tag skip_bypass: true
@@ -295,16 +248,22 @@ defmodule X402.Facilitator.HTTPTest do
              HTTP.request(:finch, "http://example.com", "/verify", %{})
   end
 
+  @tag skip_bypass: true
+  @tag skip_finch: true
   test "request/5 rejects base_url with no scheme" do
     assert {:error, %Error{type: :insecure_scheme}} =
              HTTP.request(:finch, "example.com", "/verify", %{})
   end
 
+  @tag skip_bypass: true
+  @tag skip_finch: true
   test "request/5 rejects ftp:// base_url with insecure_scheme error" do
     assert {:error, %Error{type: :insecure_scheme}} =
              HTTP.request(:finch, "ftp://example.com", "/verify", %{})
   end
 
+  @tag skip_bypass: true
+  @tag skip_finch: true
   test "request/5 accepts https:// base_url (scheme validation passes, Finch may still fail)" do
     result = HTTP.request(:no_finch, "https://example.com", "/verify", %{})
     assert {:error, %Error{type: type}} = result

--- a/test/x402/facilitator/http_test.exs
+++ b/test/x402/facilitator/http_test.exs
@@ -278,9 +278,13 @@ defmodule X402.Facilitator.HTTPTest do
   @tag skip_bypass: true
   @tag skip_finch: true
   test "request/5 accepts https:// base_url (scheme validation passes, Finch may still fail)" do
-    result = HTTP.request(:no_finch, "https://example.com", "/verify", %{})
-    assert {:error, %Error{type: type}} = result
-    refute type == :insecure_scheme
+    with_stubbed_finch(fn ->
+      Process.put(:http_test_finch_response, {:error, :connection_refused})
+
+      result = HTTP.request(:stub, "https://example.com", "/verify", %{})
+      assert {:error, %Error{type: type}} = result
+      refute type == :insecure_scheme
+    end)
   end
 
   @tag skip_bypass: true

--- a/test/x402/facilitator/http_test.exs
+++ b/test/x402/facilitator/http_test.exs
@@ -311,7 +311,9 @@ defmodule X402.Facilitator.HTTPTest do
     refute type == :insecure_scheme
   end
 
-    test "request/5 returns finch_unavailable when Finch callbacks are missing" do
+  @tag skip_bypass: true
+  @tag skip_finch: true
+  test "request/5 returns finch_unavailable when Finch callbacks are missing" do
     with_redefined_finch(
       """
       defmodule Finch do

--- a/test/x402/facilitator/http_test.exs
+++ b/test/x402/facilitator/http_test.exs
@@ -290,7 +290,28 @@ defmodule X402.Facilitator.HTTPTest do
 
   @tag skip_bypass: true
   @tag skip_finch: true
-  test "request/5 returns finch_unavailable when Finch callbacks are missing" do
+  test "request/5 rejects http:// base_url with insecure_scheme error" do
+    assert {:error, %Error{type: :insecure_scheme}} =
+             HTTP.request(:finch, "http://example.com", "/verify", %{})
+  end
+
+  test "request/5 rejects base_url with no scheme" do
+    assert {:error, %Error{type: :insecure_scheme}} =
+             HTTP.request(:finch, "example.com", "/verify", %{})
+  end
+
+  test "request/5 rejects ftp:// base_url with insecure_scheme error" do
+    assert {:error, %Error{type: :insecure_scheme}} =
+             HTTP.request(:finch, "ftp://example.com", "/verify", %{})
+  end
+
+  test "request/5 accepts https:// base_url (scheme validation passes, Finch may still fail)" do
+    result = HTTP.request(:no_finch, "https://example.com", "/verify", %{})
+    assert {:error, %Error{type: type}} = result
+    refute type == :insecure_scheme
+  end
+
+    test "request/5 returns finch_unavailable when Finch callbacks are missing" do
     with_redefined_finch(
       """
       defmodule Finch do

--- a/test/x402/facilitator/http_test.exs
+++ b/test/x402/facilitator/http_test.exs
@@ -8,7 +8,10 @@ defmodule X402.Facilitator.HTTPTest do
 
   test "request/5 returns status and decoded body on success" do
     with_stubbed_finch(fn ->
-      Process.put(:http_test_finch_response, {:ok, %{status: 200, body: Jason.encode!(%{"ok" => true})}})
+      Process.put(
+        :http_test_finch_response,
+        {:ok, %{status: 200, body: Jason.encode!(%{"ok" => true})}}
+      )
 
       assert {:ok, %{status: 200, body: %{"ok" => true}}} =
                HTTP.request(:stub, "https://facilitator.test", "/verify", %{"payload" => %{}}, [])
@@ -17,7 +20,10 @@ defmodule X402.Facilitator.HTTPTest do
 
   test "request/4 applies default opts" do
     with_stubbed_finch(fn ->
-      Process.put(:http_test_finch_response, {:ok, %{status: 200, body: Jason.encode!(%{"ok" => true})}})
+      Process.put(
+        :http_test_finch_response,
+        {:ok, %{status: 200, body: Jason.encode!(%{"ok" => true})}}
+      )
 
       assert {:ok, %{status: 200, body: %{"ok" => true}}} =
                HTTP.request(:stub, "https://facilitator.test", "/verify", %{"payload" => %{}})
@@ -62,15 +68,19 @@ defmodule X402.Facilitator.HTTPTest do
     with_stubbed_finch(fn ->
       {:ok, attempts} = Agent.start_link(fn -> 0 end)
 
-      Process.put(:http_test_finch_response, {:fun, fn _req, _name, _opts ->
-        current_attempt = Agent.get_and_update(attempts, &{&1 + 1, &1 + 1})
+      Process.put(
+        :http_test_finch_response,
+        {:fun,
+         fn _req, _name, _opts ->
+           current_attempt = Agent.get_and_update(attempts, &{&1 + 1, &1 + 1})
 
-        case current_attempt do
-          1 -> {:ok, %{status: 429, body: Jason.encode!(%{"error" => "rate limited"})}}
-          2 -> {:ok, %{status: 503, body: Jason.encode!(%{"error" => "busy"})}}
-          _ -> {:ok, %{status: 200, body: Jason.encode!(%{"ok" => true})}}
-        end
-      end})
+           case current_attempt do
+             1 -> {:ok, %{status: 429, body: Jason.encode!(%{"error" => "rate limited"})}}
+             2 -> {:ok, %{status: 503, body: Jason.encode!(%{"error" => "busy"})}}
+             _ -> {:ok, %{status: 200, body: Jason.encode!(%{"ok" => true})}}
+           end
+         end}
+      )
 
       assert {:ok, %{status: 200, body: %{"ok" => true}}} =
                HTTP.request(:stub, "https://facilitator.test", "/verify", %{},
@@ -184,7 +194,10 @@ defmodule X402.Facilitator.HTTPTest do
 
   test "request/5 normalizes URL trailing slashes" do
     with_stubbed_finch(fn ->
-      Process.put(:http_test_finch_response, {:ok, %{status: 200, body: Jason.encode!(%{"ok" => true})}})
+      Process.put(
+        :http_test_finch_response,
+        {:ok, %{status: 200, body: Jason.encode!(%{"ok" => true})}}
+      )
 
       assert {:ok, %{status: 200}} =
                HTTP.request(:stub, "https://facilitator.test/", "/verify", %{}, [])

--- a/test/x402/facilitator/http_test.exs
+++ b/test/x402/facilitator/http_test.exs
@@ -289,6 +289,30 @@ defmodule X402.Facilitator.HTTPTest do
 
   @tag skip_bypass: true
   @tag skip_finch: true
+  test "request/5 allows http://localhost (loopback exemption — no MitM risk)" do
+    with_stubbed_finch(fn ->
+      Process.put(:http_test_finch_response, {:error, :connection_refused})
+
+      result = HTTP.request(:stub, "http://localhost:4000", "/verify", %{})
+      assert {:error, %Error{type: type}} = result
+      refute type == :insecure_scheme
+    end)
+  end
+
+  @tag skip_bypass: true
+  @tag skip_finch: true
+  test "request/5 allows http://127.0.0.1 (loopback exemption — no MitM risk)" do
+    with_stubbed_finch(fn ->
+      Process.put(:http_test_finch_response, {:error, :connection_refused})
+
+      result = HTTP.request(:stub, "http://127.0.0.1:4000", "/verify", %{})
+      assert {:error, %Error{type: type}} = result
+      refute type == :insecure_scheme
+    end)
+  end
+
+  @tag skip_bypass: true
+  @tag skip_finch: true
   test "request/5 returns finch_unavailable when Finch callbacks are missing" do
     with_redefined_finch(
       """
@@ -306,12 +330,6 @@ defmodule X402.Facilitator.HTTPTest do
       end
     )
   end
-
-  defp maybe_setup_bypass(%{skip_bypass: true}), do: :ok
-  defp maybe_setup_bypass(context), do: setup_bypass(context)
-
-  defp maybe_setup_finch(%{skip_finch: true}), do: :ok
-  defp maybe_setup_finch(context), do: setup_finch(context)
 
   defp with_stubbed_finch(fun) when is_function(fun, 0) do
     with_redefined_finch(


### PR DESCRIPTION
## Security Council Finding — March 21, 2026

### 🔴 HIGH: No HTTPS scheme enforcement on facilitator base_url

**Problem:** `Facilitator.HTTP.request/5` accepted any string as `base_url`, including `http://` URLs. A misconfigured facilitator URL would bypass `secure_pool_opts/0` entirely and transmit payment proofs in plaintext. The TLS hardening in pool options only helps if TLS is actually used — `http://` means no TLS layer at all.

This could happen from a typo in config, an env var missing the 's', or a dev config leaking to production.

---

## Fix

### Scheme validation in request/5

`validate_https_scheme/1` is called as the **first step** in the `with` chain — before any connection setup, pool lookup, or payload encoding:

```elixir
with :ok <- validate_https_scheme(base_url),
     {:ok, max_retries} <- ...,
     ...
```

Returns a non-retryable `Error{type: :insecure_scheme}` for:
- `http://` URLs
- URLs with no scheme (e.g., `example.com`)  
- Any non-https scheme (e.g., `ftp://`)

### New error type

Added `:insecure_scheme` to `Facilitator.Error.error_type/0`.

### Tests

4 new tests in `http_test.exs`:
- `http://` → `:insecure_scheme` error
- no-scheme URL → `:insecure_scheme` error
- `ftp://` → `:insecure_scheme` error
- `https://` → scheme validation passes (subsequent errors are not `:insecure_scheme`)

---

## Note on Finding #1 (ETS race condition)

The Security Council also flagged a race condition between revocation and the 60s cleanup sweep.

**Assessment: False positive.** 

- `delete/2` routes through `GenServer.call/3` — revocation is immediately consistent
- `get/2` also uses `GenServer.call/3` and eagerly checks `expires_at_ms > now_ms` before returning `:hit`
- Expired/revoked entries **cannot** be returned as valid — the check is in the GenServer handler, not in the ETS read
- The 60s sweep only cleans up orphaned expired entries that were never fetched; it has no effect on explicitly deleted entries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds scheme validation to `Facilitator.HTTP.request/5`, which can break existing deployments that configured `http://` (now rejected) but materially reduces risk of sending payment proofs over plaintext.
> 
> **Overview**
> **Enforces HTTPS for facilitator requests.** `Facilitator.HTTP.request/5` now validates `base_url` up front and returns a non-retryable `:insecure_scheme` error for `http://`, missing-scheme, or non-HTTPS URLs, with a loopback (`localhost`/`127.0.0.1`/`::1`) exemption for local dev.
> 
> Adds the new `:insecure_scheme` error type to `X402.Facilitator.Error` and updates `http_test.exs` to use a stubbed Finch transport while adding coverage for the new scheme-validation cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d9127b9379442293977cd80687dad590baa153c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->