### PR TITLE
fix: tighten Solana address validation and warn on missing idempotency cache

### DIFF
--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -18,6 +18,8 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     alias X402.Hooks.Default
     alias X402.PaymentSignature
 
+    require Logger
+
     import Plug.Conn, only: [get_req_header: 2, halt: 1, put_resp_content_type: 2, send_resp: 3]
 
     @http_methods [:any, :delete, :get, :head, :options, :patch, :post, :put, :trace]
@@ -423,27 +425,16 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     defp ensure_success_status(%{status: status}),
       do: {:error, {:unexpected_facilitator_status, status}}
 
-    @spec facilitator_requirements(compiled_route(), String.t()) :: map()
     # Emits a Logger.warning exactly once per node when payment_identifier_cache
-    # is not configured.  Uses :ets.insert_new/2, which is atomic, to avoid the
-    # TOCTOU race of a check-then-put pattern under concurrent startup traffic.
+    # is not configured. Uses :persistent_term to survive request-process deaths —
+    # an ETS named table is owned by its creating process and would be destroyed
+    # when a short-lived request process exits, causing the warning to re-fire on
+    # every subsequent request.
     defp warn_no_idempotency_cache_once do
-      table =
-        case :ets.whereis(__MODULE__) do
-          :undefined ->
-            try do
-              :ets.new(__MODULE__, [:named_table, :set, :public])
-            rescue
-              # Another process created the table concurrently; use theirs.
-              ArgumentError -> :ets.whereis(__MODULE__)
-            end
+      key = {__MODULE__, :no_idempotency_cache_warned}
 
-          tid ->
-            tid
-        end
-
-      if :ets.insert_new(table, {:no_idempotency_cache_warned, true}) do
-        require Logger
+      unless :persistent_term.get(key, false) do
+        :persistent_term.put(key, true)
 
         Logger.warning(
           "[X402.Plug.PaymentGate] payment_identifier_cache is not configured. " <>
@@ -454,6 +445,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
       end
     end
 
+    @spec facilitator_requirements(compiled_route(), String.t()) :: map()
     defp facilitator_requirements(route, request_path) do
       %{
         "scheme" => route.scheme,

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -425,17 +425,17 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     defp ensure_success_status(%{status: status}),
       do: {:error, {:unexpected_facilitator_status, status}}
 
-    # Atomic "fire once" flag — created at module-load time and shared across
-    # all scheduler threads. :atomics.compare_exchange/4 is a CAS operation:
-    # only the first caller to flip 0→1 emits the warning; all concurrent
-    # callers that lose the race see a non-:ok return and skip it.
-    @no_idempotency_cache_warned :atomics.new(1, [])
-
     # Emits a Logger.warning at most once per node when payment_identifier_cache
-    # is not configured. Uses an :atomics CAS to guarantee the warning fires
-    # exactly once even under concurrent initial requests.
+    # is not configured. Uses :persistent_term as a lightweight flag so the
+    # warning fires only on the first request, not on every call.
+    # Minor: two concurrent first-requests may both log before the flag is set;
+    # this is acceptable — the consequence is a duplicate log line, not a bug.
     defp warn_no_idempotency_cache_once do
-      if :atomics.compare_exchange(@no_idempotency_cache_warned, 1, 0, 1) == :ok do
+      key = {__MODULE__, :no_idempotency_cache_warned}
+
+      unless :persistent_term.get(key, false) do
+        :persistent_term.put(key, true)
+
         Logger.warning(
           "[X402.Plug.PaymentGate] payment_identifier_cache is not configured. " <>
             "Duplicate payment proofs will NOT be detected — your deployment is " <>

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -425,17 +425,17 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     defp ensure_success_status(%{status: status}),
       do: {:error, {:unexpected_facilitator_status, status}}
 
-    # Emits a Logger.warning exactly once per node when payment_identifier_cache
-    # is not configured. Uses :persistent_term to survive request-process deaths —
-    # an ETS named table is owned by its creating process and would be destroyed
-    # when a short-lived request process exits, causing the warning to re-fire on
-    # every subsequent request.
+    # Atomic "fire once" flag — created at module-load time and shared across
+    # all scheduler threads. :atomics.compare_exchange/4 is a CAS operation:
+    # only the first caller to flip 0→1 emits the warning; all concurrent
+    # callers that lose the race see a non-:ok return and skip it.
+    @no_idempotency_cache_warned :atomics.new(1, [])
+
+    # Emits a Logger.warning at most once per node when payment_identifier_cache
+    # is not configured. Uses an :atomics CAS to guarantee the warning fires
+    # exactly once even under concurrent initial requests.
     defp warn_no_idempotency_cache_once do
-      key = {__MODULE__, :no_idempotency_cache_warned}
-
-      unless :persistent_term.get(key, false) do
-        :persistent_term.put(key, true)
-
+      if :atomics.compare_exchange(@no_idempotency_cache_warned, 1, 0, 1) == :ok do
         Logger.warning(
           "[X402.Plug.PaymentGate] payment_identifier_cache is not configured. " <>
             "Duplicate payment proofs will NOT be detected — your deployment is " <>

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -122,10 +122,31 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     def init(opts) when is_list(opts) do
       validated_opts = NimbleOptions.validate!(opts, @options_schema)
 
+      cache = Keyword.get(validated_opts, :payment_identifier_cache)
+
+      if is_nil(cache) do
+        # Emit a warning at init time so operators notice the missing protection.
+        # Without an idempotency cache, the same payment proof can be replayed
+        # across concurrent requests — each passes the facilitator verify step
+        # before any can record the result, resulting in double-settlement.
+        #
+        # This is intentionally opt-in (not all deployments need ETS), but it
+        # is a meaningful security gap in any production deployment that calls
+        # real on-chain settlement.
+        require Logger
+
+        Logger.warning(
+          "[X402.Plug.PaymentGate] payment_identifier_cache is not configured. " <>
+            "Duplicate payment proofs will NOT be detected — your deployment is " <>
+            "vulnerable to double-settlement of concurrent identical requests. " <>
+            "Pass `payment_identifier_cache: pid_or_name` to enable idempotency."
+        )
+      end
+
       %{
         facilitator: Keyword.fetch!(validated_opts, :facilitator),
         hooks: Keyword.fetch!(validated_opts, :hooks),
-        payment_identifier_cache: Keyword.get(validated_opts, :payment_identifier_cache),
+        payment_identifier_cache: cache,
         routes:
           validated_opts
           |> Keyword.fetch!(:routes)

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -125,21 +125,24 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
       cache = Keyword.get(validated_opts, :payment_identifier_cache)
 
       if is_nil(cache) do
-        # Emit a warning at init time so operators notice the missing protection.
+        # Emit a compile-time / pipeline-init warning so operators notice the
+        # missing protection during development and CI builds.
         # Without an idempotency cache, the same payment proof can be replayed
         # across concurrent requests — each passes the facilitator verify step
         # before any can record the result, resulting in double-settlement.
         #
-        # This is intentionally opt-in (not all deployments need ETS), but it
-        # is a meaningful security gap in any production deployment that calls
-        # real on-chain settlement.
-        require Logger
-
-        Logger.warning(
+        # NOTE: in module-based Plug pipelines (Phoenix router `plug/2`),
+        # `init/1` is evaluated at compile time. For pre-built production
+        # releases the warning below fires only during the build, not at
+        # application boot.  A separate :persistent_term-gated runtime warning
+        # is emitted on the first `call/2` invocation so that production
+        # operators always see it in their application logs.
+        IO.warn(
           "[X402.Plug.PaymentGate] payment_identifier_cache is not configured. " <>
             "Duplicate payment proofs will NOT be detected — your deployment is " <>
             "vulnerable to double-settlement of concurrent identical requests. " <>
-            "Pass `payment_identifier_cache: pid_or_name` to enable idempotency."
+            "Pass `payment_identifier_cache: pid_or_name` to enable idempotency.",
+          []
         )
       end
 
@@ -165,6 +168,26 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
           payment_identifier_cache: payment_identifier_cache,
           routes: routes
         }) do
+      # Emit a one-time runtime warning when the idempotency cache is not
+      # configured.  This complements the compile-time IO.warn in init/1:
+      # pre-built releases never execute init/1 at boot, so this ensures
+      # production application logs always surface the double-settlement risk.
+      if is_nil(payment_identifier_cache) do
+        key = {__MODULE__, :no_idempotency_cache_warned}
+
+        unless :persistent_term.get(key, false) do
+          :persistent_term.put(key, true)
+          require Logger
+
+          Logger.warning(
+            "[X402.Plug.PaymentGate] payment_identifier_cache is not configured. " <>
+              "Duplicate payment proofs will NOT be detected — your deployment is " <>
+              "vulnerable to double-settlement of concurrent identical requests. " <>
+              "Pass `payment_identifier_cache: pid_or_name` to enable idempotency."
+          )
+        end
+      end
+
       request_path = normalize_path(conn.request_path)
       request_method = normalize_method(conn.method)
 

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -142,7 +142,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
             "Duplicate payment proofs will NOT be detected — your deployment is " <>
             "vulnerable to double-settlement of concurrent identical requests. " <>
             "Pass `payment_identifier_cache: pid_or_name` to enable idempotency.",
-          []
+          __ENV__
         )
       end
 
@@ -172,21 +172,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
       # configured.  This complements the compile-time IO.warn in init/1:
       # pre-built releases never execute init/1 at boot, so this ensures
       # production application logs always surface the double-settlement risk.
-      if is_nil(payment_identifier_cache) do
-        key = {__MODULE__, :no_idempotency_cache_warned}
-
-        unless :persistent_term.get(key, false) do
-          :persistent_term.put(key, true)
-          require Logger
-
-          Logger.warning(
-            "[X402.Plug.PaymentGate] payment_identifier_cache is not configured. " <>
-              "Duplicate payment proofs will NOT be detected — your deployment is " <>
-              "vulnerable to double-settlement of concurrent identical requests. " <>
-              "Pass `payment_identifier_cache: pid_or_name` to enable idempotency."
-          )
-        end
-      end
+      if is_nil(payment_identifier_cache), do: warn_no_idempotency_cache_once()
 
       request_path = normalize_path(conn.request_path)
       request_method = normalize_method(conn.method)
@@ -438,6 +424,36 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
       do: {:error, {:unexpected_facilitator_status, status}}
 
     @spec facilitator_requirements(compiled_route(), String.t()) :: map()
+    # Emits a Logger.warning exactly once per node when payment_identifier_cache
+    # is not configured.  Uses :ets.insert_new/2, which is atomic, to avoid the
+    # TOCTOU race of a check-then-put pattern under concurrent startup traffic.
+    defp warn_no_idempotency_cache_once do
+      table =
+        case :ets.whereis(__MODULE__) do
+          :undefined ->
+            try do
+              :ets.new(__MODULE__, [:named_table, :set, :public])
+            rescue
+              # Another process created the table concurrently; use theirs.
+              ArgumentError -> :ets.whereis(__MODULE__)
+            end
+
+          tid ->
+            tid
+        end
+
+      if :ets.insert_new(table, {:no_idempotency_cache_warned, true}) do
+        require Logger
+
+        Logger.warning(
+          "[X402.Plug.PaymentGate] payment_identifier_cache is not configured. " <>
+            "Duplicate payment proofs will NOT be detected — your deployment is " <>
+            "vulnerable to double-settlement of concurrent identical requests. " <>
+            "Pass `payment_identifier_cache: pid_or_name` to enable idempotency."
+        )
+      end
+    end
+
     defp facilitator_requirements(route, request_path) do
       %{
         "scheme" => route.scheme,

--- a/lib/x402/wallet.ex
+++ b/lib/x402/wallet.ex
@@ -7,7 +7,14 @@ defmodule X402.Wallet do
   """
 
   @evm_regex ~r/^0x[0-9a-fA-F]{40}$/
-  @solana_regex ~r/^[1-9A-HJ-NP-Za-km-z]{32,44}$/
+  # Solana addresses are 32-byte Ed25519 public keys encoded in base58.
+  # base58(32 bytes) always produces 43 or 44 characters — never shorter.
+  # The original range [32,44] was too permissive; tightened to [43,44].
+  #
+  # Note: Solana does NOT use Bitcoin's Base58Check format (no checksum byte).
+  # This regex is a structural guard only; the facilitator performs full
+  # on-chain key validation.
+  @solana_regex ~r/^[1-9A-HJ-NP-Za-km-z]{43,44}$/
 
   @doc since: "0.1.0"
   @doc """
@@ -42,7 +49,7 @@ defmodule X402.Wallet do
 
   @doc since: "0.1.0"
   @doc """
-  Returns `true` for Base58 strings with length from 32 to 44.
+  Returns `true` for Base58 strings with length 43 or 44 (the valid range for 32-byte Solana public keys).
 
   ## Examples
 

--- a/test/x402/wallet_test.exs
+++ b/test/x402/wallet_test.exs
@@ -32,8 +32,8 @@ defmodule X402.WalletTest do
       refute Wallet.valid_solana?(String.duplicate("3", 32))
       refute Wallet.valid_solana?(String.duplicate("3", 42))
       refute Wallet.valid_solana?(String.duplicate("4", 45))
-      refute Wallet.valid_solana?("0" <> String.duplicate("1", 31))
-      refute Wallet.valid_solana?("O" <> String.duplicate("1", 31))
+      refute Wallet.valid_solana?("0" <> String.duplicate("1", 42))
+      refute Wallet.valid_solana?("O" <> String.duplicate("1", 42))
       refute Wallet.valid_solana?(nil)
     end
   end

--- a/test/x402/wallet_test.exs
+++ b/test/x402/wallet_test.exs
@@ -21,14 +21,16 @@ defmodule X402.WalletTest do
   end
 
   describe "valid_solana?/1" do
-    test "accepts base58 strings from 32 to 44 chars" do
-      assert Wallet.valid_solana?(String.duplicate("1", 32))
+    test "accepts base58 strings of 43 or 44 chars" do
+      assert Wallet.valid_solana?(String.duplicate("1", 43))
       assert Wallet.valid_solana?(String.duplicate("2", 44))
       assert Wallet.valid_solana?("9xQeWvG816bUx9EPfQmQTYnC16hHhV6bQf8kX6y4YB9")
     end
 
     test "rejects out-of-range lengths and invalid characters" do
       refute Wallet.valid_solana?(String.duplicate("3", 31))
+      refute Wallet.valid_solana?(String.duplicate("3", 32))
+      refute Wallet.valid_solana?(String.duplicate("3", 42))
       refute Wallet.valid_solana?(String.duplicate("4", 45))
       refute Wallet.valid_solana?("0" <> String.duplicate("1", 31))
       refute Wallet.valid_solana?("O" <> String.duplicate("1", 31))


### PR DESCRIPTION
## Security Council Findings — March 23, 2026

### 🟡 MEDIUM: Solana address length range too permissive

**Problem:** `valid_solana?/1` accepted strings 32–44 chars long. Real Solana addresses are 32-byte Ed25519 public keys in base58, which always encode to **43 or 44 characters** — never shorter.

Strings 32–42 chars long cannot be valid Solana addresses. The old regex was accepting them.

**Note on Security Council finding:** The finding described "Base58Check checksum verification" — this was incorrect. Solana does **not** use Bitcoin's Base58Check format. There is no checksum to verify. The regex is a structural guard; the facilitator does the actual on-chain validation.

**Fix:** Tightened `@solana_regex` from `{32,44}` to `{43,44}` with explanatory comment.

---

### 🟡 MEDIUM: No warning when idempotency cache is unconfigured

**Problem:** `PaymentGate.init/1` silently skipped duplicate payment detection when `payment_identifier_cache: nil` (the default). Without ETS cache, concurrent requests with the same payment proof can all pass `Facilitator.verify` before any records the result → double-settlement.

**Fix:** Added `Logger.warning/1` at `init/1` time when cache is nil. Operators see the gap at startup, not after an incident.

The opt-in design is preserved — this is a **warning, not an error**. Not all deployments need ETS.

---

### 🟢 LOW: TLS peer verification not enforced

**Assessment: False positive.** `secure_pool_opts/0` already sets `verify: :verify_peer` and is documented. Consumers who don't use it are making an explicit choice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces stricter Solana address validation (may reject previously accepted inputs) and adds new warnings around missing payment idempotency caching in `PaymentGate`, which touches payment/settlement safety but does not change settlement behavior itself.
> 
> **Overview**
> **Hardens input validation and operational visibility around payments.** Solana wallet validation is tightened to only accept base58 strings of length **43–44** (matching 32-byte public keys), with corresponding test updates.
> 
> `X402.Plug.PaymentGate` now emits warnings when `payment_identifier_cache` is unset: an `IO.warn/2` during `init/1` and a one-time `Logger.warning/1` at runtime (gated via `:persistent_term`) to highlight double-settlement risk when idempotency is not enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56fe308e944eeef7afc99bde947a857c500de95a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->