### PR TITLE
⚡ Optimize decimal parsing and centralize utilities

### DIFF
--- a/lib/x402/facilitator.ex
+++ b/lib/x402/facilitator.ex
@@ -10,6 +10,7 @@ defmodule X402.Facilitator do
   alias X402.Hooks
   alias X402.Hooks.Context
   alias X402.Hooks.Default
+  alias X402.Utils
 
   @default_name __MODULE__
   @default_url "https://x402.org/facilitator"
@@ -367,7 +368,8 @@ defmodule X402.Facilitator do
   end
 
   defp validate_scheme_payment(payload, requirements) do
-    case map_value(requirements, {"scheme", :scheme}) || map_value(payload, {"scheme", :scheme}) do
+    case Utils.map_value(requirements, {"scheme", :scheme}) ||
+           Utils.map_value(payload, {"scheme", :scheme}) do
       "upto" ->
         validate_upto_payment(payload, requirements)
 
@@ -385,11 +387,11 @@ defmodule X402.Facilitator do
 
   defp extract_max_price(payload, requirements) do
     value =
-      first_present([
-        map_value(requirements, {"maxPrice", :maxPrice}),
-        map_value(requirements, {"maxAmountRequired", :maxAmountRequired}),
-        map_value(payload, {"maxPrice", :maxPrice}),
-        map_value(payload, {"maxAmountRequired", :maxAmountRequired})
+      Utils.first_present([
+        Utils.map_value(requirements, {"maxPrice", :maxPrice}),
+        Utils.map_value(requirements, {"maxAmountRequired", :maxAmountRequired}),
+        Utils.map_value(payload, {"maxPrice", :maxPrice}),
+        Utils.map_value(payload, {"maxAmountRequired", :maxAmountRequired})
       ])
 
     case value do
@@ -397,7 +399,7 @@ defmodule X402.Facilitator do
         {:error, {:invalid_upto_payment, :missing_max_price}}
 
       max_price ->
-        case parse_decimal(max_price) do
+        case Utils.parse_decimal(max_price) do
           {:ok, parsed} -> {:ok, parsed}
           :error -> {:error, {:invalid_upto_payment, :invalid_max_price}}
         end
@@ -406,15 +408,15 @@ defmodule X402.Facilitator do
 
   defp extract_payment_value(payload) do
     value =
-      first_present([
-        map_value(payload, {"value", :value}),
-        nested_map_value(payload, [{"payload", :payload}, {"value", :value}]),
-        nested_map_value(payload, [
+      Utils.first_present([
+        Utils.map_value(payload, {"value", :value}),
+        Utils.nested_map_value(payload, [{"payload", :payload}, {"value", :value}]),
+        Utils.nested_map_value(payload, [
           {"payload", :payload},
           {"authorization", :authorization},
           {"value", :value}
         ]),
-        nested_map_value(payload, [{"authorization", :authorization}, {"value", :value}])
+        Utils.nested_map_value(payload, [{"authorization", :authorization}, {"value", :value}])
       ])
 
     case value do
@@ -422,7 +424,7 @@ defmodule X402.Facilitator do
         {:error, {:invalid_upto_payment, :missing_payment_value}}
 
       payment_value ->
-        case parse_decimal(payment_value) do
+        case Utils.parse_decimal(payment_value) do
           {:ok, parsed} -> {:ok, parsed}
           :error -> {:error, {:invalid_upto_payment, :invalid_payment_value}}
         end
@@ -430,81 +432,11 @@ defmodule X402.Facilitator do
   end
 
   defp ensure_not_exceeds(payment_value, max_price) do
-    case compare_decimal(payment_value, max_price) do
+    case Utils.compare_decimal(payment_value, max_price) do
       :gt -> {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
       _comparison -> :ok
     end
   end
-
-  defp compare_decimal({left_value, left_scale}, {right_value, right_scale})
-       when left_scale == right_scale do
-    compare_integer(left_value, right_value)
-  end
-
-  defp compare_decimal({left_value, left_scale}, {right_value, right_scale})
-       when left_scale > right_scale do
-    compare_integer(left_value, right_value * Integer.pow(10, left_scale - right_scale))
-  end
-
-  defp compare_decimal({left_value, left_scale}, {right_value, right_scale}) do
-    compare_integer(left_value * Integer.pow(10, right_scale - left_scale), right_value)
-  end
-
-  defp compare_integer(left, right) when left < right, do: :lt
-  defp compare_integer(left, right) when left > right, do: :gt
-  defp compare_integer(_left, _right), do: :eq
-
-  defp parse_decimal(value) when is_integer(value) and value >= 0, do: {:ok, {value, 0}}
-  defp parse_decimal(value) when is_binary(value), do: parse_decimal_string(String.trim(value))
-  defp parse_decimal(_value), do: :error
-
-  defp parse_decimal_string(""), do: :error
-
-  defp parse_decimal_string(value) do
-    cond do
-      Regex.match?(~r/^\d+$/, value) ->
-        {:ok, {String.to_integer(value), 0}}
-
-      Regex.match?(~r/^\d+\.\d+$/, value) ->
-        [whole, fraction] = String.split(value, ".", parts: 2)
-        normalized_fraction = String.trim_trailing(fraction, "0")
-
-        case normalized_fraction do
-          "" ->
-            {:ok, {String.to_integer(whole), 0}}
-
-          fraction_digits ->
-            digits = whole <> fraction_digits
-            {:ok, {String.to_integer(digits), String.length(fraction_digits)}}
-        end
-
-      true ->
-        :error
-    end
-  end
-
-  defp nested_map_value(map, [key]) when is_map(map), do: map_value(map, key)
-
-  defp nested_map_value(map, [key | rest]) when is_map(map) do
-    case map_value(map, key) do
-      %{} = nested -> nested_map_value(nested, rest)
-      _other -> nil
-    end
-  end
-
-  defp nested_map_value(_not_map, _keys), do: nil
-
-  defp map_value(map, {string_key, atom_key}) do
-    case Map.fetch(map, string_key) do
-      {:ok, value} ->
-        value
-
-      :error ->
-        Map.get(map, atom_key)
-    end
-  end
-
-  defp first_present(values), do: Enum.find(values, &(not is_nil(&1)))
 
   defp before_callback(:verify), do: :before_verify
   defp before_callback(:settle), do: :before_settle

--- a/lib/x402/payment_required.ex
+++ b/lib/x402/payment_required.ex
@@ -7,6 +7,7 @@ defmodule X402.PaymentRequired do
   """
 
   alias X402.Telemetry
+  alias X402.Utils
 
   # Single source of truth for the 8 KB decode guard — see X402.Header.
   @max_header_bytes X402.Header.max_header_bytes()
@@ -97,7 +98,7 @@ defmodule X402.PaymentRequired do
 
       {:error, :payload_too_large}
     else
-      with {:ok, json} <- decode_base64(value),
+      with {:ok, json} <- Utils.decode_base64(value),
            {:ok, decoded} <- Jason.decode(json),
            true <- is_map(decoded) do
         result = {:ok, normalize_payload(decoded)}
@@ -140,16 +141,6 @@ defmodule X402.PaymentRequired do
     {:error, :invalid_base64}
   end
 
-  @spec decode_base64(String.t()) :: {:ok, String.t()} | {:error, :invalid_base64}
-  defp decode_base64(""), do: {:error, :invalid_base64}
-
-  defp decode_base64(value) do
-    case Base.decode64(value, padding: false) do
-      {:ok, decoded} -> {:ok, decoded}
-      :error -> {:error, :invalid_base64}
-    end
-  end
-
   @spec normalize_payload(map()) :: map()
   defp normalize_payload(payload) do
     payload
@@ -168,7 +159,7 @@ defmodule X402.PaymentRequired do
 
   @spec normalize_accepts_entries(map()) :: map()
   defp normalize_accepts_entries(payload) do
-    case map_value(payload, {"accepts", :accepts}) do
+    case Utils.map_value(payload, {"accepts", :accepts}) do
       accepts when is_list(accepts) ->
         normalized =
           Enum.map(accepts, fn
@@ -176,7 +167,7 @@ defmodule X402.PaymentRequired do
             other -> other
           end)
 
-        map_put(payload, {"accepts", :accepts}, normalized)
+        Utils.map_put(payload, {"accepts", :accepts}, normalized)
 
       _other ->
         payload
@@ -185,16 +176,16 @@ defmodule X402.PaymentRequired do
 
   @spec replace_amount_key(map()) :: map()
   defp replace_amount_key(payload) do
-    case map_value(payload, {"maxPrice", :maxPrice}) do
+    case Utils.map_value(payload, {"maxPrice", :maxPrice}) do
       nil ->
-        case map_value(payload, {"maxAmountRequired", :maxAmountRequired}) do
+        case Utils.map_value(payload, {"maxAmountRequired", :maxAmountRequired}) do
           nil ->
             payload
 
           legacy_max_amount ->
             payload
-            |> map_put({"maxPrice", :maxPrice}, legacy_max_amount)
-            |> map_delete({"maxAmountRequired", :maxAmountRequired})
+            |> Utils.map_put({"maxPrice", :maxPrice}, legacy_max_amount)
+            |> Utils.map_delete({"maxAmountRequired", :maxAmountRequired})
         end
 
       _max_price ->
@@ -203,37 +194,5 @@ defmodule X402.PaymentRequired do
   end
 
   @spec scheme(map()) :: scheme() | atom() | nil
-  defp scheme(payload), do: map_value(payload, {"scheme", :scheme})
-
-  @spec map_value(map(), {String.t(), atom()}) :: term()
-  defp map_value(map, {string_key, atom_key}) do
-    case Map.fetch(map, string_key) do
-      {:ok, value} ->
-        value
-
-      :error ->
-        Map.get(map, atom_key)
-    end
-  end
-
-  @spec map_put(map(), {String.t(), atom()}, term()) :: map()
-  defp map_put(map, {string_key, atom_key}, value) do
-    cond do
-      Map.has_key?(map, string_key) ->
-        Map.put(map, string_key, value)
-
-      Map.has_key?(map, atom_key) ->
-        Map.put(map, atom_key, value)
-
-      true ->
-        Map.put(map, string_key, value)
-    end
-  end
-
-  @spec map_delete(map(), {String.t(), atom()}) :: map()
-  defp map_delete(map, {string_key, atom_key}) do
-    map
-    |> Map.delete(string_key)
-    |> Map.delete(atom_key)
-  end
+  defp scheme(payload), do: Utils.map_value(payload, {"scheme", :scheme})
 end

--- a/lib/x402/payment_response.ex
+++ b/lib/x402/payment_response.ex
@@ -7,6 +7,7 @@ defmodule X402.PaymentResponse do
   """
 
   alias X402.Telemetry
+  alias X402.Utils
 
   # Single source of truth for the 8 KB decode guard — see X402.Header.
   @max_header_bytes X402.Header.max_header_bytes()
@@ -90,7 +91,7 @@ defmodule X402.PaymentResponse do
 
       {:error, :payload_too_large}
     else
-      with {:ok, json} <- decode_base64(value),
+      with {:ok, json} <- Utils.decode_base64(value),
            {:ok, decoded} <- Jason.decode(json),
            true <- is_map(decoded) do
         result = {:ok, decoded}
@@ -131,15 +132,5 @@ defmodule X402.PaymentResponse do
     })
 
     {:error, :invalid_base64}
-  end
-
-  @spec decode_base64(String.t()) :: {:ok, String.t()} | {:error, :invalid_base64}
-  defp decode_base64(""), do: {:error, :invalid_base64}
-
-  defp decode_base64(value) do
-    case Base.decode64(value, padding: false) do
-      {:ok, decoded} -> {:ok, decoded}
-      :error -> {:error, :invalid_base64}
-    end
   end
 end

--- a/lib/x402/payment_signature.ex
+++ b/lib/x402/payment_signature.ex
@@ -12,6 +12,7 @@ defmodule X402.PaymentSignature do
   """
 
   alias X402.Telemetry
+  alias X402.Utils
 
   @required_fields ~w(transactionHash network scheme payerWallet)
 
@@ -83,7 +84,7 @@ defmodule X402.PaymentSignature do
   end
 
   defp do_decode(value) do
-    with {:ok, json} <- decode_base64(value),
+    with {:ok, json} <- Utils.decode_base64(value),
          {:ok, decoded} <- Jason.decode(json),
          true <- is_map(decoded) do
       result = {:ok, decoded}
@@ -227,16 +228,6 @@ defmodule X402.PaymentSignature do
     {:error, :invalid_payload}
   end
 
-  @spec decode_base64(String.t()) :: {:ok, String.t()} | {:error, :invalid_base64}
-  defp decode_base64(""), do: {:error, :invalid_base64}
-
-  defp decode_base64(value) do
-    case Base.decode64(value, padding: false) do
-      {:ok, decoded} -> {:ok, decoded}
-      :error -> {:error, :invalid_base64}
-    end
-  end
-
   @spec missing_fields(map()) :: [String.t()]
   defp missing_fields(payload) do
     payload_keys = Map.keys(payload)
@@ -266,7 +257,7 @@ defmodule X402.PaymentSignature do
 
   @spec effective_scheme(map(), map()) :: String.t() | atom() | nil
   defp effective_scheme(payload, requirements) do
-    map_value(requirements, {"scheme", :scheme}) || map_value(payload, {"scheme", :scheme})
+    Utils.map_value(requirements, {"scheme", :scheme}) || Utils.map_value(payload, {"scheme", :scheme})
   end
 
   @spec extract_max_price(map(), map()) ::
@@ -274,11 +265,11 @@ defmodule X402.PaymentSignature do
           | {:error, {:invalid_upto_payment, upto_validation_error()}}
   defp extract_max_price(payload, requirements) do
     value =
-      first_present([
-        map_value(requirements, {"maxPrice", :maxPrice}),
-        map_value(requirements, {"maxAmountRequired", :maxAmountRequired}),
-        map_value(payload, {"maxPrice", :maxPrice}),
-        map_value(payload, {"maxAmountRequired", :maxAmountRequired})
+      Utils.first_present([
+        Utils.map_value(requirements, {"maxPrice", :maxPrice}),
+        Utils.map_value(requirements, {"maxAmountRequired", :maxAmountRequired}),
+        Utils.map_value(payload, {"maxPrice", :maxPrice}),
+        Utils.map_value(payload, {"maxAmountRequired", :maxAmountRequired})
       ])
 
     case value do
@@ -286,7 +277,7 @@ defmodule X402.PaymentSignature do
         {:error, {:invalid_upto_payment, :missing_max_price}}
 
       max_price ->
-        case parse_decimal(max_price) do
+        case Utils.parse_decimal(max_price) do
           {:ok, parsed} -> {:ok, parsed}
           :error -> {:error, {:invalid_upto_payment, :invalid_max_price}}
         end
@@ -298,15 +289,15 @@ defmodule X402.PaymentSignature do
           | {:error, {:invalid_upto_payment, upto_validation_error()}}
   defp extract_payment_value(payload) do
     value =
-      first_present([
-        map_value(payload, {"value", :value}),
-        nested_map_value(payload, [{"payload", :payload}, {"value", :value}]),
-        nested_map_value(payload, [
+      Utils.first_present([
+        Utils.map_value(payload, {"value", :value}),
+        Utils.nested_map_value(payload, [{"payload", :payload}, {"value", :value}]),
+        Utils.nested_map_value(payload, [
           {"payload", :payload},
           {"authorization", :authorization},
           {"value", :value}
         ]),
-        nested_map_value(payload, [{"authorization", :authorization}, {"value", :value}])
+        Utils.nested_map_value(payload, [{"authorization", :authorization}, {"value", :value}])
       ])
 
     case value do
@@ -314,7 +305,7 @@ defmodule X402.PaymentSignature do
         {:error, {:invalid_upto_payment, :missing_payment_value}}
 
       payment_value ->
-        case parse_decimal(payment_value) do
+        case Utils.parse_decimal(payment_value) do
           {:ok, parsed} -> {:ok, parsed}
           :error -> {:error, {:invalid_upto_payment, :invalid_payment_value}}
         end
@@ -326,89 +317,9 @@ defmodule X402.PaymentSignature do
           {non_neg_integer(), non_neg_integer()}
         ) :: :ok | {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
   defp ensure_not_exceeds(payment_value, max_price) do
-    case compare_decimal(payment_value, max_price) do
+    case Utils.compare_decimal(payment_value, max_price) do
       :gt -> {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
       _comparison -> :ok
     end
   end
-
-  @spec compare_decimal(
-          {non_neg_integer(), non_neg_integer()},
-          {non_neg_integer(), non_neg_integer()}
-        ) :: :lt | :eq | :gt
-  defp compare_decimal({left_value, left_scale}, {right_value, right_scale})
-       when left_scale == right_scale do
-    compare_integer(left_value, right_value)
-  end
-
-  defp compare_decimal({left_value, left_scale}, {right_value, right_scale})
-       when left_scale > right_scale do
-    compare_integer(left_value, right_value * Integer.pow(10, left_scale - right_scale))
-  end
-
-  defp compare_decimal({left_value, left_scale}, {right_value, right_scale}) do
-    compare_integer(left_value * Integer.pow(10, right_scale - left_scale), right_value)
-  end
-
-  @spec compare_integer(non_neg_integer(), non_neg_integer()) :: :lt | :eq | :gt
-  defp compare_integer(left, right) when left < right, do: :lt
-  defp compare_integer(left, right) when left > right, do: :gt
-  defp compare_integer(_left, _right), do: :eq
-
-  @spec parse_decimal(term()) :: {:ok, {non_neg_integer(), non_neg_integer()}} | :error
-  defp parse_decimal(value) when is_integer(value) and value >= 0, do: {:ok, {value, 0}}
-  defp parse_decimal(value) when is_binary(value), do: parse_decimal_string(String.trim(value))
-  defp parse_decimal(_value), do: :error
-
-  @spec parse_decimal_string(String.t()) :: {:ok, {non_neg_integer(), non_neg_integer()}} | :error
-  defp parse_decimal_string(""), do: :error
-
-  defp parse_decimal_string(value) do
-    cond do
-      Regex.match?(~r/^\d+$/, value) ->
-        {:ok, {String.to_integer(value), 0}}
-
-      Regex.match?(~r/^\d+\.\d+$/, value) ->
-        [whole, fraction] = String.split(value, ".", parts: 2)
-        normalized_fraction = String.trim_trailing(fraction, "0")
-
-        case normalized_fraction do
-          "" ->
-            {:ok, {String.to_integer(whole), 0}}
-
-          fraction_digits ->
-            digits = whole <> fraction_digits
-            {:ok, {String.to_integer(digits), String.length(fraction_digits)}}
-        end
-
-      true ->
-        :error
-    end
-  end
-
-  @spec nested_map_value(map(), [{String.t(), atom()}]) :: term()
-  defp nested_map_value(map, [key]) when is_map(map), do: map_value(map, key)
-
-  defp nested_map_value(map, [key | rest]) when is_map(map) do
-    case map_value(map, key) do
-      %{} = nested -> nested_map_value(nested, rest)
-      _other -> nil
-    end
-  end
-
-  defp nested_map_value(_not_map, _keys), do: nil
-
-  @spec map_value(map(), {String.t(), atom()}) :: term()
-  defp map_value(map, {string_key, atom_key}) do
-    case Map.fetch(map, string_key) do
-      {:ok, value} ->
-        value
-
-      :error ->
-        Map.get(map, atom_key)
-    end
-  end
-
-  @spec first_present([term()]) :: term() | nil
-  defp first_present(values), do: Enum.find(values, &(not is_nil(&1)))
 end

--- a/lib/x402/payment_signature.ex
+++ b/lib/x402/payment_signature.ex
@@ -257,7 +257,8 @@ defmodule X402.PaymentSignature do
 
   @spec effective_scheme(map(), map()) :: String.t() | atom() | nil
   defp effective_scheme(payload, requirements) do
-    Utils.map_value(requirements, {"scheme", :scheme}) || Utils.map_value(payload, {"scheme", :scheme})
+    Utils.map_value(requirements, {"scheme", :scheme}) ||
+      Utils.map_value(payload, {"scheme", :scheme})
   end
 
   @spec extract_max_price(map(), map()) ::

--- a/lib/x402/utils.ex
+++ b/lib/x402/utils.ex
@@ -1,9 +1,27 @@
 defmodule X402.Utils do
-  @moduledoc false
+  @moduledoc """
+  Shared utility functions for the X402 library.
+
+  Centralises helpers for Base64 decoding, map access, decimal parsing,
+  and decimal comparison that are used across payment processing modules.
+  """
 
   @doc """
   Decodes a Base64 string with or without padding.
+
+  ## Examples
+
+      iex> X402.Utils.decode_base64("")
+      {:error, :invalid_base64}
+
+      iex> X402.Utils.decode_base64("aGVsbG8=")
+      {:ok, "hello"}
+
+      iex> X402.Utils.decode_base64("not-valid-!!!")
+      {:error, :invalid_base64}
+
   """
+  @doc since: "0.1.0"
   @spec decode_base64(String.t()) :: {:ok, String.t()} | {:error, :invalid_base64}
   def decode_base64(""), do: {:error, :invalid_base64}
 
@@ -16,7 +34,20 @@ defmodule X402.Utils do
 
   @doc """
   Finds the first non-nil value in a list.
+
+  ## Examples
+
+      iex> X402.Utils.first_present([nil, nil, "found"])
+      "found"
+
+      iex> X402.Utils.first_present([nil, nil])
+      nil
+
+      iex> X402.Utils.first_present([false, "other"])
+      false
+
   """
+  @doc since: "0.1.0"
   @spec first_present([term()]) :: term() | nil
   def first_present([]), do: nil
   def first_present([nil | rest]), do: first_present(rest)
@@ -24,7 +55,22 @@ defmodule X402.Utils do
 
   @doc """
   Retrieves a value from a map using either a string or atom key.
+
+  Prefers the string key if present, falls back to atom key.
+
+  ## Examples
+
+      iex> X402.Utils.map_value(%{"key" => "string_val"}, {"key", :key})
+      "string_val"
+
+      iex> X402.Utils.map_value(%{key: "atom_val"}, {"key", :key})
+      "atom_val"
+
+      iex> X402.Utils.map_value(%{}, {"key", :key})
+      nil
+
   """
+  @doc since: "0.1.0"
   @spec map_value(map(), {String.t(), atom()}) :: term()
   def map_value(map, {string_key, atom_key}) do
     case Map.fetch(map, string_key) do
@@ -34,8 +80,9 @@ defmodule X402.Utils do
   end
 
   @doc """
-  Retrieves a nested value from a map.
+  Retrieves a nested value from a map using a list of string/atom key pairs.
   """
+  @doc since: "0.1.0"
   @spec nested_map_value(map(), [{String.t(), atom()}]) :: term()
   def nested_map_value(map, [key]) when is_map(map), do: map_value(map, key)
 
@@ -49,8 +96,9 @@ defmodule X402.Utils do
   def nested_map_value(_not_map, _keys), do: nil
 
   @doc """
-  Puts a value into a map, preferring the existing key type.
+  Puts a value into a map, preferring the existing key type (string over atom).
   """
+  @doc since: "0.1.0"
   @spec map_put(map(), {String.t(), atom()}, term()) :: map()
   def map_put(map, {string_key, atom_key}, value) do
     cond do
@@ -61,16 +109,43 @@ defmodule X402.Utils do
   end
 
   @doc """
-  Deletes both string and atom keys from a map.
+  Deletes both string and atom versions of a key from a map.
   """
+  @doc since: "0.1.0"
   @spec map_delete(map(), {String.t(), atom()}) :: map()
   def map_delete(map, {string_key, atom_key}) do
     map |> Map.delete(string_key) |> Map.delete(atom_key)
   end
 
   @doc """
-  Parses a decimal value (string or integer) into a {value, scale} tuple.
+  Parses a decimal value (integer or string) into a `{value, scale}` tuple
+  where `value / 10^scale` equals the original number.
+
+  Returns `:error` for negative integers, non-numeric strings, or strings
+  without a leading digit (e.g. `".5"`).
+
+  ## Examples
+
+      iex> X402.Utils.parse_decimal(42)
+      {:ok, {42, 0}}
+
+      iex> X402.Utils.parse_decimal("12.50")
+      {:ok, {125, 1}}
+
+      iex> X402.Utils.parse_decimal("0.001")
+      {:ok, {1, 3}}
+
+      iex> X402.Utils.parse_decimal(".5")
+      :error
+
+      iex> X402.Utils.parse_decimal("")
+      :error
+
+      iex> X402.Utils.parse_decimal(-1)
+      :error
+
   """
+  @doc since: "0.1.0"
   @spec parse_decimal(term()) :: {:ok, {non_neg_integer(), non_neg_integer()}} | :error
   def parse_decimal(value) when is_integer(value) and value >= 0, do: {:ok, {value, 0}}
   def parse_decimal(value) when is_binary(value), do: parse_decimal_string(String.trim(value))
@@ -78,6 +153,8 @@ defmodule X402.Utils do
 
   @spec parse_decimal_string(String.t()) :: {:ok, {non_neg_integer(), non_neg_integer()}} | :error
   defp parse_decimal_string(""), do: :error
+  # Reject leading-dot strings like ".5" — require at least one leading digit
+  defp parse_decimal_string("." <> _rest), do: :error
 
   defp parse_decimal_string(value) do
     case parse_whole(value, 0) do
@@ -120,8 +197,23 @@ defmodule X402.Utils do
   defp parse_fraction(_bin, _acc, _len, _last_nonzero_len), do: :error
 
   @doc """
-  Compares two decimal {value, scale} tuples.
+  Compares two `{value, scale}` decimal tuples.
+
+  Returns `:lt`, `:eq`, or `:gt`.
+
+  ## Examples
+
+      iex> X402.Utils.compare_decimal({10, 1}, {1, 0})
+      :eq
+
+      iex> X402.Utils.compare_decimal({5, 1}, {1, 0})
+      :lt
+
+      iex> X402.Utils.compare_decimal({15, 1}, {1, 0})
+      :gt
+
   """
+  @doc since: "0.1.0"
   @spec compare_decimal(
           {non_neg_integer(), non_neg_integer()},
           {non_neg_integer(), non_neg_integer()}

--- a/lib/x402/utils.ex
+++ b/lib/x402/utils.ex
@@ -1,0 +1,146 @@
+defmodule X402.Utils do
+  @moduledoc false
+
+  @doc """
+  Decodes a Base64 string with or without padding.
+  """
+  @spec decode_base64(String.t()) :: {:ok, String.t()} | {:error, :invalid_base64}
+  def decode_base64(""), do: {:error, :invalid_base64}
+
+  def decode_base64(value) do
+    case Base.decode64(value, padding: false) do
+      {:ok, decoded} -> {:ok, decoded}
+      :error -> {:error, :invalid_base64}
+    end
+  end
+
+  @doc """
+  Finds the first non-nil value in a list.
+  """
+  @spec first_present([term()]) :: term() | nil
+  def first_present([]), do: nil
+  def first_present([nil | rest]), do: first_present(rest)
+  def first_present([value | _rest]), do: value
+
+  @doc """
+  Retrieves a value from a map using either a string or atom key.
+  """
+  @spec map_value(map(), {String.t(), atom()}) :: term()
+  def map_value(map, {string_key, atom_key}) do
+    case Map.fetch(map, string_key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, atom_key)
+    end
+  end
+
+  @doc """
+  Retrieves a nested value from a map.
+  """
+  @spec nested_map_value(map(), [{String.t(), atom()}]) :: term()
+  def nested_map_value(map, [key]) when is_map(map), do: map_value(map, key)
+
+  def nested_map_value(map, [key | rest]) when is_map(map) do
+    case map_value(map, key) do
+      %{} = nested -> nested_map_value(nested, rest)
+      _other -> nil
+    end
+  end
+
+  def nested_map_value(_not_map, _keys), do: nil
+
+  @doc """
+  Puts a value into a map, preferring the existing key type.
+  """
+  @spec map_put(map(), {String.t(), atom()}, term()) :: map()
+  def map_put(map, {string_key, atom_key}, value) do
+    cond do
+      Map.has_key?(map, string_key) -> Map.put(map, string_key, value)
+      Map.has_key?(map, atom_key) -> Map.put(map, atom_key, value)
+      true -> Map.put(map, string_key, value)
+    end
+  end
+
+  @doc """
+  Deletes both string and atom keys from a map.
+  """
+  @spec map_delete(map(), {String.t(), atom()}) :: map()
+  def map_delete(map, {string_key, atom_key}) do
+    map |> Map.delete(string_key) |> Map.delete(atom_key)
+  end
+
+  @doc """
+  Parses a decimal value (string or integer) into a {value, scale} tuple.
+  """
+  @spec parse_decimal(term()) :: {:ok, {non_neg_integer(), non_neg_integer()}} | :error
+  def parse_decimal(value) when is_integer(value) and value >= 0, do: {:ok, {value, 0}}
+  def parse_decimal(value) when is_binary(value), do: parse_decimal_string(String.trim(value))
+  def parse_decimal(_value), do: :error
+
+  @spec parse_decimal_string(String.t()) :: {:ok, {non_neg_integer(), non_neg_integer()}} | :error
+  defp parse_decimal_string(""), do: :error
+
+  defp parse_decimal_string(value) do
+    case parse_whole(value, 0) do
+      {whole, ""} ->
+        {:ok, {whole, 0}}
+
+      {whole, "." <> fraction} ->
+        case parse_fraction(fraction, 0, 0, 0) do
+          {:ok, fraction_val, fraction_len} ->
+            scale = fraction_len
+            {:ok, {whole * Integer.pow(10, scale) + fraction_val, scale}}
+
+          :error ->
+            :error
+        end
+
+      _other ->
+        :error
+    end
+  end
+
+  defp parse_whole(<<c, rest::binary>>, acc) when c >= ?0 and c <= ?9,
+    do: parse_whole(rest, acc * 10 + (c - ?0))
+
+  defp parse_whole(rest, acc), do: {acc, rest}
+
+  defp parse_fraction(<<c, rest::binary>>, acc, len, last_nonzero_len) when c >= ?0 and c <= ?9 do
+    digit = c - ?0
+    new_acc = acc * 10 + digit
+    new_len = len + 1
+    new_last_nonzero_len = if digit != 0, do: new_len, else: last_nonzero_len
+    parse_fraction(rest, new_acc, new_len, new_last_nonzero_len)
+  end
+
+  defp parse_fraction("", acc, len, last_nonzero_len) when len > 0 do
+    trimmed_acc = div(acc, Integer.pow(10, len - last_nonzero_len))
+    {:ok, trimmed_acc, last_nonzero_len}
+  end
+
+  defp parse_fraction(_bin, _acc, _len, _last_nonzero_len), do: :error
+
+  @doc """
+  Compares two decimal {value, scale} tuples.
+  """
+  @spec compare_decimal(
+          {non_neg_integer(), non_neg_integer()},
+          {non_neg_integer(), non_neg_integer()}
+        ) :: :lt | :eq | :gt
+  def compare_decimal({left_value, left_scale}, {right_value, right_scale})
+      when left_scale == right_scale do
+    compare_integer(left_value, right_value)
+  end
+
+  def compare_decimal({left_value, left_scale}, {right_value, right_scale})
+      when left_scale > right_scale do
+    compare_integer(left_value, right_value * Integer.pow(10, left_scale - right_scale))
+  end
+
+  def compare_decimal({left_value, left_scale}, {right_value, right_scale}) do
+    compare_integer(left_value * Integer.pow(10, right_scale - left_scale), right_value)
+  end
+
+  defp compare_integer(left, right) when left < right, do: :lt
+  defp compare_integer(left, right) when left > right, do: :gt
+  defp compare_integer(_left, _right), do: :eq
+end

--- a/test/x402/utils_test.exs
+++ b/test/x402/utils_test.exs
@@ -1,0 +1,164 @@
+defmodule X402.UtilsTest do
+  use ExUnit.Case, async: true
+
+  alias X402.Utils
+
+  doctest X402.Utils
+
+  describe "decode_base64/1" do
+    test "returns error for empty string" do
+      assert Utils.decode_base64("") == {:error, :invalid_base64}
+    end
+
+    test "decodes valid base64 with padding" do
+      assert Utils.decode_base64("aGVsbG8=") == {:ok, "hello"}
+    end
+
+    test "decodes valid base64 without padding" do
+      assert Utils.decode_base64("aGVsbG8") == {:ok, "hello"}
+    end
+
+    test "returns error for invalid base64" do
+      assert Utils.decode_base64("not-valid-!!!") == {:error, :invalid_base64}
+    end
+  end
+
+  describe "first_present/1" do
+    test "returns nil for empty list" do
+      assert Utils.first_present([]) == nil
+    end
+
+    test "returns nil when all values are nil" do
+      assert Utils.first_present([nil, nil, nil]) == nil
+    end
+
+    test "returns first non-nil value" do
+      assert Utils.first_present([nil, "found", "other"]) == "found"
+    end
+
+    test "returns false (non-nil falsy value)" do
+      assert Utils.first_present([nil, false, "other"]) == false
+    end
+
+    test "returns first element when no nils" do
+      assert Utils.first_present([1, 2, 3]) == 1
+    end
+  end
+
+  describe "map_value/2" do
+    test "prefers string key over atom key" do
+      assert Utils.map_value(%{"key" => "string", key: "atom"}, {"key", :key}) == "string"
+    end
+
+    test "falls back to atom key when string key absent" do
+      assert Utils.map_value(%{key: "atom_val"}, {"key", :key}) == "atom_val"
+    end
+
+    test "returns nil when neither key present" do
+      assert Utils.map_value(%{}, {"key", :key}) == nil
+    end
+  end
+
+  describe "parse_decimal/1" do
+    test "parses non-negative integer" do
+      assert Utils.parse_decimal(42) == {:ok, {42, 0}}
+    end
+
+    test "parses zero integer" do
+      assert Utils.parse_decimal(0) == {:ok, {0, 0}}
+    end
+
+    test "rejects negative integer" do
+      assert Utils.parse_decimal(-1) == :error
+    end
+
+    test "parses integer string" do
+      assert Utils.parse_decimal("123") == {:ok, {123, 0}}
+    end
+
+    test "parses decimal string" do
+      assert Utils.parse_decimal("12.34") == {:ok, {1234, 2}}
+    end
+
+    test "strips trailing zeros from fraction" do
+      assert Utils.parse_decimal("12.50") == {:ok, {125, 1}}
+    end
+
+    test "strips all-zero fraction" do
+      assert Utils.parse_decimal("12.00") == {:ok, {12, 0}}
+    end
+
+    test "parses leading-zero fraction" do
+      assert Utils.parse_decimal("0.001") == {:ok, {1, 3}}
+    end
+
+    test "trims whitespace before parsing" do
+      assert Utils.parse_decimal("  42  ") == {:ok, {42, 0}}
+    end
+
+    test "rejects empty string" do
+      assert Utils.parse_decimal("") == :error
+    end
+
+    test "rejects leading-dot string like .5" do
+      assert Utils.parse_decimal(".5") == :error
+    end
+
+    test "rejects trailing-dot string like 1." do
+      assert Utils.parse_decimal("1.") == :error
+    end
+
+    test "rejects string with no digits" do
+      assert Utils.parse_decimal("abc") == :error
+    end
+
+    test "rejects mixed alphanumeric" do
+      assert Utils.parse_decimal("1e5") == :error
+    end
+
+    test "rejects multiple dots" do
+      assert Utils.parse_decimal("1.2.3") == :error
+    end
+
+    test "rejects nil" do
+      assert Utils.parse_decimal(nil) == :error
+    end
+
+    test "rejects float" do
+      assert Utils.parse_decimal(1.5) == :error
+    end
+  end
+
+  describe "compare_decimal/2" do
+    test "equal values with same scale" do
+      assert Utils.compare_decimal({10, 1}, {10, 1}) == :eq
+    end
+
+    test "equal values with different scales" do
+      # 1.0 == 1.00
+      assert Utils.compare_decimal({10, 1}, {100, 2}) == :eq
+    end
+
+    test "left less than right" do
+      assert Utils.compare_decimal({5, 1}, {1, 0}) == :lt
+    end
+
+    test "left greater than right" do
+      assert Utils.compare_decimal({15, 1}, {1, 0}) == :gt
+    end
+
+    test "integer equivalent comparison" do
+      assert Utils.compare_decimal({1, 0}, {1, 0}) == :eq
+      assert Utils.compare_decimal({0, 0}, {1, 0}) == :lt
+      assert Utils.compare_decimal({2, 0}, {1, 0}) == :gt
+    end
+
+    test "cross-scale: 1.5 > 1.0" do
+      assert Utils.compare_decimal({15, 1}, {10, 1}) == :gt
+    end
+
+    test "cross-scale: 0.5 < 1" do
+      assert Utils.compare_decimal({5, 1}, {1, 0}) == :lt
+    end
+  end
+end


### PR DESCRIPTION
### 💡 What:
The optimization implemented replaces the inefficient `Regex.match?` and `String.split` based decimal parsing with a high-performance, single-pass recursive binary parser. Additionally, it centralizes common utility functions across the library into a new `X402.Utils` module.

### 🎯 Why:
The previous implementation of `parse_decimal_string` was performing multiple passes over the input string (one for regex validation and another for splitting), leading to unnecessary CPU overhead and memory allocations. Furthermore, identical utility functions were duplicated across several core modules, complicating maintenance.

### 📊 Measured Improvement:
While local benchmarking was impractical due to the lack of an Elixir runtime in the immediate environment, the theoretical performance gain is significant:
- **Zero Regex overhead:** Avoiding the Erlang `:re` module calls for simple digit/decimal validation.
- **Single-pass parsing:** The new recursive parser processes each byte of the binary only once.
- **Reduced allocations:** Eliminating the intermediate list of strings created by `String.split/3`.
- **Improved Maintainability:** Centralizing logic into `X402.Utils` ensures that any future optimizations to these core utilities benefit the entire library simultaneously.


---
*PR created automatically by Jules for task [14471273724617521703](https://jules.google.com/task/14471273724617521703) started by @cardotrejos*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment header decoding and `upto` amount validation by replacing duplicated parsing/comparison logic with new shared utilities; subtle behavior changes in decimal string parsing could reject/accept edge cases differently.
> 
> **Overview**
> Introduces a new `X402.Utils` module to centralize shared helpers (Base64 decode, flexible string/atom map access, nested lookup, and decimal parse/compare).
> 
> Refactors `X402.Facilitator`, `X402.PaymentRequired`, `X402.PaymentResponse`, and `X402.PaymentSignature` to use these utilities, removing duplicated private helper implementations and switching decimal parsing to a new single-pass binary parser.
> 
> Adds `X402.UtilsTest` (plus doctests) to cover the new utility behavior and parsing edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce014fd02cc93b4e66553944dc26dbd341113975. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->