### PR TITLE
fix: payment signature format validation and SIWX ETS size cap

### DIFF
--- a/lib/x402.ex
+++ b/lib/x402.ex
@@ -52,7 +52,7 @@ defmodule X402 do
   ## Examples
 
       iex> payload = %{
-      ...>   "transactionHash" => "0xabc",
+      ...>   "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       ...>   "network" => "eip155:8453",
       ...>   "scheme" => "exact",
       ...>   "payerWallet" => "0x1111111111111111111111111111111111111111"
@@ -73,7 +73,7 @@ defmodule X402 do
   ## Examples
 
       iex> X402.validate_payment_signature(%{
-      ...>   "transactionHash" => "0xabc",
+      ...>   "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       ...>   "network" => "eip155:8453",
       ...>   "scheme" => "exact",
       ...>   "payerWallet" => "0x1111111111111111111111111111111111111111"
@@ -82,7 +82,7 @@ defmodule X402 do
         "network" => "eip155:8453",
         "payerWallet" => "0x1111111111111111111111111111111111111111",
         "scheme" => "exact",
-        "transactionHash" => "0xabc"
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       }}
   """
   @spec validate_payment_signature(map()) ::
@@ -100,7 +100,7 @@ defmodule X402 do
   ## Examples
 
       iex> payload = %{
-      ...>   "transactionHash" => "0xabc",
+      ...>   "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       ...>   "network" => "eip155:8453",
       ...>   "scheme" => "exact",
       ...>   "payerWallet" => "0x1111111111111111111111111111111111111111"

--- a/lib/x402/extensions/siwx/ets_storage.ex
+++ b/lib/x402/extensions/siwx/ets_storage.ex
@@ -38,7 +38,8 @@ defmodule X402.Extensions.SIWX.ETSStorage do
     max_size: [
       type: :pos_integer,
       default: @default_max_size,
-      doc: "Maximum number of {address, resource} entries to keep in the ETS table. When reached, new `put/4` calls return `{:error, :storage_full}` until the next cleanup sweep evicts expired records. Prevents unbounded memory growth under spam attacks."
+      doc:
+        "Maximum number of {address, resource} entries to keep in the ETS table. When reached, new `put/4` calls return `{:error, :storage_full}` until the next cleanup sweep evicts expired records. Prevents unbounded memory growth under spam attacks."
     ]
   ]
 

--- a/lib/x402/extensions/siwx/ets_storage.ex
+++ b/lib/x402/extensions/siwx/ets_storage.ex
@@ -17,6 +17,8 @@ defmodule X402.Extensions.SIWX.ETSStorage do
   @default_table :x402_siwx_storage
   @default_cleanup_interval_ms 60_000
 
+  @default_max_size 100_000
+
   @start_link_options_schema [
     name: [
       type: :any,
@@ -32,6 +34,11 @@ defmodule X402.Extensions.SIWX.ETSStorage do
       type: :pos_integer,
       default: @default_cleanup_interval_ms,
       doc: "Interval in milliseconds between cleanup sweeps."
+    ],
+    max_size: [
+      type: :pos_integer,
+      default: @default_max_size,
+      doc: "Maximum number of {address, resource} entries to keep in the ETS table. When reached, new `put/4` calls return `{:error, :storage_full}` until the next cleanup sweep evicts expired records. Prevents unbounded memory growth under spam attacks."
     ]
   ]
 
@@ -40,7 +47,8 @@ defmodule X402.Extensions.SIWX.ETSStorage do
 
   @type state :: %{
           table: atom(),
-          cleanup_interval_ms: pos_integer()
+          cleanup_interval_ms: pos_integer(),
+          max_size: pos_integer()
         }
 
   @doc """
@@ -152,6 +160,7 @@ defmodule X402.Extensions.SIWX.ETSStorage do
   def init(opts) do
     table = Keyword.fetch!(opts, :table)
     cleanup_interval_ms = Keyword.fetch!(opts, :cleanup_interval_ms)
+    max_size = Keyword.fetch!(opts, :max_size)
 
     :ets.new(table, [
       :named_table,
@@ -165,7 +174,8 @@ defmodule X402.Extensions.SIWX.ETSStorage do
     {:ok,
      %{
        table: table,
-       cleanup_interval_ms: cleanup_interval_ms
+       cleanup_interval_ms: cleanup_interval_ms,
+       max_size: max_size
      }}
   end
 
@@ -191,11 +201,22 @@ defmodule X402.Extensions.SIWX.ETSStorage do
 
   def handle_call({:put, address, resource, payment_proof, ttl_ms}, _from, state) do
     key = {address, resource}
-    expires_at_ms = now_ms() + ttl_ms
+    current_size = :ets.info(state.table, :size)
 
-    true = :ets.insert(state.table, {key, payment_proof, expires_at_ms})
+    # Enforce size cap to prevent unbounded ETS memory growth under spam attacks.
+    # An attacker who generates unique (address, resource) pairs would grow the
+    # table without limit until the node OOMs.  We check if the key already
+    # exists (an update never grows the table) and only reject genuinely new
+    # insertions that would push us over the limit.
+    already_exists = :ets.member(state.table, key)
 
-    {:reply, :ok, state}
+    if not already_exists and current_size >= state.max_size do
+      {:reply, {:error, :storage_full}, state}
+    else
+      expires_at_ms = now_ms() + ttl_ms
+      true = :ets.insert(state.table, {key, payment_proof, expires_at_ms})
+      {:reply, :ok, state}
+    end
   end
 
   def handle_call({:delete, address, resource}, _from, state) do

--- a/lib/x402/payment_signature.ex
+++ b/lib/x402/payment_signature.ex
@@ -67,7 +67,7 @@ defmodule X402.PaymentSignature do
 
   ## Examples
 
-      iex> payload = %{"transactionHash" => "0xabc", "network" => "eip155:8453", "scheme" => "exact", "payerWallet" => "0x1111111111111111111111111111111111111111"}
+      iex> payload = %{"transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "network" => "eip155:8453", "scheme" => "exact", "payerWallet" => "0x1111111111111111111111111111111111111111"}
       iex> value = payload |> Jason.encode!() |> Base.encode64()
       iex> X402.PaymentSignature.decode(value)
       {:ok, payload}
@@ -139,7 +139,7 @@ defmodule X402.PaymentSignature do
   ## Examples
 
       iex> payload = %{
-      ...>   "transactionHash" => "0xabc",
+      ...>   "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       ...>   "network" => "eip155:8453",
       ...>   "scheme" => "exact",
       ...>   "payerWallet" => "0x1111111111111111111111111111111111111111"
@@ -167,47 +167,51 @@ defmodule X402.PaymentSignature do
   """
   @spec validate(map(), map()) :: {:ok, map()} | {:error, validate_error()}
   def validate(payload, requirements) when is_map(payload) and is_map(requirements) do
-    missing = missing_fields(payload)
+    with :ok <- check_missing_fields(payload),
+         :ok <- check_field_formats(payload) do
+      case validate_scheme(payload, requirements) do
+        :ok ->
+          Telemetry.emit(:payment_signature, :validate, :ok, %{required_fields: @required_fields})
+          {:ok, payload}
 
-    case missing do
+        {:error, {:invalid_upto_payment, reason}} = error ->
+          Telemetry.emit(:payment_signature, :validate, :error, %{
+            reason: :invalid_upto_payment,
+            detail: reason
+          })
+
+          error
+      end
+    end
+  end
+
+  defp check_missing_fields(payload) do
+    case missing_fields(payload) do
       [] ->
-        case validate_field_formats(payload) do
-          [] ->
-            case validate_scheme(payload, requirements) do
-              :ok ->
-                result = {:ok, payload}
+        :ok
 
-                Telemetry.emit(:payment_signature, :validate, :ok, %{
-                  required_fields: @required_fields
-                })
-
-                result
-
-              {:error, {:invalid_upto_payment, reason}} = error ->
-                Telemetry.emit(:payment_signature, :validate, :error, %{
-                  reason: :invalid_upto_payment,
-                  detail: reason
-                })
-
-                error
-            end
-
-          format_errors ->
-            Telemetry.emit(:payment_signature, :validate, :error, %{
-              reason: :invalid_format,
-              fields: Enum.map(format_errors, &elem(&1, 0))
-            })
-
-            {:error, {:invalid_format, format_errors}}
-        end
-
-      _ ->
+      missing ->
         Telemetry.emit(:payment_signature, :validate, :error, %{
           reason: :missing_fields,
           fields: missing
         })
 
         {:error, {:missing_fields, missing}}
+    end
+  end
+
+  defp check_field_formats(payload) do
+    case validate_field_formats(payload) do
+      [] ->
+        :ok
+
+      format_errors ->
+        Telemetry.emit(:payment_signature, :validate, :error, %{
+          reason: :invalid_format,
+          fields: Enum.map(format_errors, &elem(&1, 0))
+        })
+
+        {:error, {:invalid_format, format_errors}}
     end
   end
 
@@ -222,7 +226,7 @@ defmodule X402.PaymentSignature do
 
   ## Examples
 
-      iex> payload = %{"transactionHash" => "0xabc", "network" => "eip155:8453", "scheme" => "exact", "payerWallet" => "0x1111111111111111111111111111111111111111"}
+      iex> payload = %{"transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "network" => "eip155:8453", "scheme" => "exact", "payerWallet" => "0x1111111111111111111111111111111111111111"}
       iex> value = payload |> Jason.encode!() |> Base.encode64()
       iex> X402.PaymentSignature.decode_and_validate(value)
       {:ok, payload}

--- a/lib/x402/payment_signature.ex
+++ b/lib/x402/payment_signature.ex
@@ -185,6 +185,11 @@ defmodule X402.PaymentSignature do
     end
   end
 
+  def validate(_payload, _requirements) do
+    Telemetry.emit(:payment_signature, :validate, :error, %{reason: :invalid_payload})
+    {:error, :invalid_payload}
+  end
+
   defp check_missing_fields(payload) do
     case missing_fields(payload) do
       [] ->
@@ -213,11 +218,6 @@ defmodule X402.PaymentSignature do
 
         {:error, {:invalid_format, format_errors}}
     end
-  end
-
-  def validate(_payload, _requirements) do
-    Telemetry.emit(:payment_signature, :validate, :error, %{reason: :invalid_payload})
-    {:error, :invalid_payload}
   end
 
   @doc since: "0.1.0", group: :verification

--- a/lib/x402/payment_signature.ex
+++ b/lib/x402/payment_signature.ex
@@ -28,7 +28,7 @@ defmodule X402.PaymentSignature do
   @solana_tx_sig_regex ~r/^[1-9A-HJ-NP-Za-km-z]{87,88}$/
 
   # Solana wallet address: base58, 32-44 characters.
-  @solana_address_regex ~r/^[1-9A-HJ-NP-Za-km-z]{32,44}$/
+  @solana_address_regex ~r/^[1-9A-HJ-NP-Za-km-z]{43,44}$/
 
   # Single source of truth for the 8 KB decode guard — see X402.Header.
   @max_header_bytes X402.Header.max_header_bytes()

--- a/lib/x402/payment_signature.ex
+++ b/lib/x402/payment_signature.ex
@@ -16,6 +16,20 @@ defmodule X402.PaymentSignature do
 
   @required_fields ~w(transactionHash network scheme payerWallet)
 
+  # EIP-55 Ethereum address: 0x followed by exactly 40 hex characters (case-insensitive).
+  # We accept mixed-case (checksummed) and lower-case (normalised) addresses.
+  @eth_address_regex ~r/^0x[0-9a-fA-F]{40}$/
+
+  # Transaction hash: 0x followed by exactly 64 hex characters (256-bit hash).
+  # Solana tx IDs are base58, 87-88 chars — we detect them by absence of "0x" prefix.
+  @eth_tx_hash_regex ~r/^0x[0-9a-fA-F]{64}$/
+
+  # Solana base-58 transaction signature (87–88 characters of base58 alphabet).
+  @solana_tx_sig_regex ~r/^[1-9A-HJ-NP-Za-km-z]{87,88}$/
+
+  # Solana wallet address: base58, 32-44 characters.
+  @solana_address_regex ~r/^[1-9A-HJ-NP-Za-km-z]{32,44}$/
+
   # Single source of truth for the 8 KB decode guard — see X402.Header.
   @max_header_bytes X402.Header.max_header_bytes()
 
@@ -31,6 +45,7 @@ defmodule X402.PaymentSignature do
           :invalid_payload
           | {:missing_fields, [String.t()]}
           | {:invalid_upto_payment, upto_validation_error()}
+          | {:invalid_format, [{field :: String.t(), reason :: atom()}]}
 
   @type decode_and_validate_error :: decode_error() | validate_error()
 
@@ -156,23 +171,34 @@ defmodule X402.PaymentSignature do
 
     case missing do
       [] ->
-        case validate_scheme(payload, requirements) do
-          :ok ->
-            result = {:ok, payload}
+        case validate_field_formats(payload) do
+          [] ->
+            case validate_scheme(payload, requirements) do
+              :ok ->
+                result = {:ok, payload}
 
-            Telemetry.emit(:payment_signature, :validate, :ok, %{
-              required_fields: @required_fields
-            })
+                Telemetry.emit(:payment_signature, :validate, :ok, %{
+                  required_fields: @required_fields
+                })
 
-            result
+                result
 
-          {:error, {:invalid_upto_payment, reason}} = error ->
+              {:error, {:invalid_upto_payment, reason}} = error ->
+                Telemetry.emit(:payment_signature, :validate, :error, %{
+                  reason: :invalid_upto_payment,
+                  detail: reason
+                })
+
+                error
+            end
+
+          format_errors ->
             Telemetry.emit(:payment_signature, :validate, :error, %{
-              reason: :invalid_upto_payment,
-              detail: reason
+              reason: :invalid_format,
+              fields: Enum.map(format_errors, &elem(&1, 0))
             })
 
-            error
+            {:error, {:invalid_format, format_errors}}
         end
 
       _ ->
@@ -239,6 +265,50 @@ defmodule X402.PaymentSignature do
     end)
     |> Enum.sort()
   end
+
+  # Validates the format of fields that have known structural constraints:
+  #   - transactionHash: EVM 0x+64hex OR Solana base58 87-88 chars
+  #   - payerWallet: EVM 0x+40hex OR Solana base58 32-44 chars
+  #
+  # We intentionally do NOT validate `network` and `scheme` here — those fields
+  # are validated downstream by the facilitator / scheme validators which have
+  # the authoritative list of supported values.
+  #
+  # Returns a list of {field, reason} tuples for each invalid field; empty list = ok.
+  @spec validate_field_formats(map()) :: [{String.t(), atom()}]
+  defp validate_field_formats(payload) do
+    [
+      validate_transaction_hash(Map.get(payload, "transactionHash")),
+      validate_payer_wallet(Map.get(payload, "payerWallet"))
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  @spec validate_transaction_hash(String.t() | nil) :: {String.t(), atom()} | nil
+  defp validate_transaction_hash(nil), do: nil
+
+  defp validate_transaction_hash(hash) when is_binary(hash) do
+    cond do
+      Regex.match?(@eth_tx_hash_regex, hash) -> nil
+      Regex.match?(@solana_tx_sig_regex, hash) -> nil
+      true -> {"transactionHash", :invalid_format}
+    end
+  end
+
+  defp validate_transaction_hash(_), do: {"transactionHash", :invalid_format}
+
+  @spec validate_payer_wallet(String.t() | nil) :: {String.t(), atom()} | nil
+  defp validate_payer_wallet(nil), do: nil
+
+  defp validate_payer_wallet(wallet) when is_binary(wallet) do
+    cond do
+      Regex.match?(@eth_address_regex, wallet) -> nil
+      Regex.match?(@solana_address_regex, wallet) -> nil
+      true -> {"payerWallet", :invalid_format}
+    end
+  end
+
+  defp validate_payer_wallet(_), do: {"payerWallet", :invalid_format}
 
   @spec validate_scheme(map(), map()) ::
           :ok | {:error, {:invalid_upto_payment, upto_validation_error()}}

--- a/test/x402/payment_signature_test.exs
+++ b/test/x402/payment_signature_test.exs
@@ -14,7 +14,7 @@ defmodule X402.PaymentSignatureTest do
   describe "decode/1" do
     test "decodes a valid base64 json payload" do
       payload = %{
-        "transactionHash" => "0xabc",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "exact",
         "payerWallet" => "0x1111111111111111111111111111111111111111"
@@ -58,7 +58,7 @@ defmodule X402.PaymentSignatureTest do
   describe "validate/1" do
     test "returns ok for complete payload" do
       payload = %{
-        "transactionHash" => "0xabc",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "exact",
         "payerWallet" => "0x1111111111111111111111111111111111111111"
@@ -92,7 +92,7 @@ defmodule X402.PaymentSignatureTest do
 
     test "validates upto payments when value is within maxPrice from payload" do
       payload = %{
-        "transactionHash" => "0xabc",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111",
@@ -107,7 +107,7 @@ defmodule X402.PaymentSignatureTest do
   describe "validate/2" do
     test "validates upto payments when value is within requirements maxPrice" do
       payload = %{
-        "transactionHash" => "0xabc",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111",
@@ -121,7 +121,7 @@ defmodule X402.PaymentSignatureTest do
 
     test "rejects upto payments when value exceeds maxPrice" do
       payload = %{
-        "transactionHash" => "0xabc",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111",
@@ -136,7 +136,7 @@ defmodule X402.PaymentSignatureTest do
 
     test "rejects upto payments when value is missing" do
       payload = %{
-        "transactionHash" => "0xabc",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111"
@@ -150,7 +150,7 @@ defmodule X402.PaymentSignatureTest do
 
     test "returns invalid_payload for non-map requirements" do
       payload = %{
-        "transactionHash" => "0xabc",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111",
@@ -164,7 +164,7 @@ defmodule X402.PaymentSignatureTest do
   describe "decode_and_validate/1" do
     test "returns ok for valid encoded payload" do
       payload = %{
-        "transactionHash" => "0xabc",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "exact",
         "payerWallet" => "0x1111111111111111111111111111111111111111"
@@ -191,7 +191,7 @@ defmodule X402.PaymentSignatureTest do
   describe "decode_and_validate/2" do
     test "validates upto scheme against requirements" do
       payload = %{
-        "transactionHash" => "0xabc",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111",

--- a/test/x402/payment_signature_test.exs
+++ b/test/x402/payment_signature_test.exs
@@ -14,7 +14,8 @@ defmodule X402.PaymentSignatureTest do
   describe "decode/1" do
     test "decodes a valid base64 json payload" do
       payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" =>
+          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "exact",
         "payerWallet" => "0x1111111111111111111111111111111111111111"
@@ -58,7 +59,8 @@ defmodule X402.PaymentSignatureTest do
   describe "validate/1" do
     test "returns ok for complete payload" do
       payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" =>
+          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "exact",
         "payerWallet" => "0x1111111111111111111111111111111111111111"
@@ -92,7 +94,8 @@ defmodule X402.PaymentSignatureTest do
 
     test "validates upto payments when value is within maxPrice from payload" do
       payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" =>
+          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111",
@@ -107,7 +110,8 @@ defmodule X402.PaymentSignatureTest do
   describe "validate/2" do
     test "validates upto payments when value is within requirements maxPrice" do
       payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" =>
+          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111",
@@ -121,7 +125,8 @@ defmodule X402.PaymentSignatureTest do
 
     test "rejects upto payments when value exceeds maxPrice" do
       payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" =>
+          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111",
@@ -136,7 +141,8 @@ defmodule X402.PaymentSignatureTest do
 
     test "rejects upto payments when value is missing" do
       payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" =>
+          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111"
@@ -150,7 +156,8 @@ defmodule X402.PaymentSignatureTest do
 
     test "returns invalid_payload for non-map requirements" do
       payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" =>
+          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111",
@@ -164,7 +171,8 @@ defmodule X402.PaymentSignatureTest do
   describe "decode_and_validate/1" do
     test "returns ok for valid encoded payload" do
       payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" =>
+          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "exact",
         "payerWallet" => "0x1111111111111111111111111111111111111111"
@@ -191,7 +199,8 @@ defmodule X402.PaymentSignatureTest do
   describe "decode_and_validate/2" do
     test "validates upto scheme against requirements" do
       payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" =>
+          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111",

--- a/test/x402/payment_signature_test.exs
+++ b/test/x402/payment_signature_test.exs
@@ -14,8 +14,7 @@ defmodule X402.PaymentSignatureTest do
   describe "decode/1" do
     test "decodes a valid base64 json payload" do
       payload = %{
-        "transactionHash" =>
-          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "exact",
         "payerWallet" => "0x1111111111111111111111111111111111111111"
@@ -59,8 +58,7 @@ defmodule X402.PaymentSignatureTest do
   describe "validate/1" do
     test "returns ok for complete payload" do
       payload = %{
-        "transactionHash" =>
-          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "exact",
         "payerWallet" => "0x1111111111111111111111111111111111111111"
@@ -94,8 +92,7 @@ defmodule X402.PaymentSignatureTest do
 
     test "validates upto payments when value is within maxPrice from payload" do
       payload = %{
-        "transactionHash" =>
-          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111",
@@ -110,8 +107,7 @@ defmodule X402.PaymentSignatureTest do
   describe "validate/2" do
     test "validates upto payments when value is within requirements maxPrice" do
       payload = %{
-        "transactionHash" =>
-          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111",
@@ -125,8 +121,7 @@ defmodule X402.PaymentSignatureTest do
 
     test "rejects upto payments when value exceeds maxPrice" do
       payload = %{
-        "transactionHash" =>
-          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111",
@@ -141,8 +136,7 @@ defmodule X402.PaymentSignatureTest do
 
     test "rejects upto payments when value is missing" do
       payload = %{
-        "transactionHash" =>
-          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111"
@@ -156,8 +150,7 @@ defmodule X402.PaymentSignatureTest do
 
     test "returns invalid_payload for non-map requirements" do
       payload = %{
-        "transactionHash" =>
-          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111",
@@ -171,8 +164,7 @@ defmodule X402.PaymentSignatureTest do
   describe "decode_and_validate/1" do
     test "returns ok for valid encoded payload" do
       payload = %{
-        "transactionHash" =>
-          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "exact",
         "payerWallet" => "0x1111111111111111111111111111111111111111"
@@ -199,8 +191,7 @@ defmodule X402.PaymentSignatureTest do
   describe "decode_and_validate/2" do
     test "validates upto scheme against requirements" do
       payload = %{
-        "transactionHash" =>
-          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "upto",
         "payerWallet" => "0x1111111111111111111111111111111111111111",

--- a/test/x402/plug/payment_gate_test.exs
+++ b/test/x402/plug/payment_gate_test.exs
@@ -170,7 +170,7 @@ defmodule X402.Plug.PaymentGateTest do
     assert result_conn.status == 200
 
     assert_receive {:verify_called, payload, requirements, hooks_module}
-    assert payload["transactionHash"] == "0xabc"
+    assert payload["transactionHash"] == "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     assert requirements["network"] == "base-sepolia"
     assert requirements["asset"] == "USDC"
     assert requirements["resource"] == "/api/resource"
@@ -523,7 +523,7 @@ defmodule X402.Plug.PaymentGateTest do
 
   defp valid_payment_header do
     %{
-      "transactionHash" => "0xabc",
+      "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "network" => "base-sepolia",
       "scheme" => "exact",
       "payerWallet" => "0x1111111111111111111111111111111111111111"
@@ -534,7 +534,7 @@ defmodule X402.Plug.PaymentGateTest do
 
   defp valid_upto_payment_header(value) do
     %{
-      "transactionHash" => "0xabc",
+      "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "network" => "base-sepolia",
       "scheme" => "upto",
       "payerWallet" => "0x1111111111111111111111111111111111111111",

--- a/test/x402/plug/payment_gate_test.exs
+++ b/test/x402/plug/payment_gate_test.exs
@@ -170,7 +170,8 @@ defmodule X402.Plug.PaymentGateTest do
     assert result_conn.status == 200
 
     assert_receive {:verify_called, payload, requirements, hooks_module}
-    assert payload["transactionHash"] == "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    assert payload["transactionHash"] ==
+             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     assert requirements["network"] == "base-sepolia"
     assert requirements["asset"] == "USDC"
     assert requirements["resource"] == "/api/resource"

--- a/test/x402/plug/payment_gate_test.exs
+++ b/test/x402/plug/payment_gate_test.exs
@@ -170,8 +170,10 @@ defmodule X402.Plug.PaymentGateTest do
     assert result_conn.status == 200
 
     assert_receive {:verify_called, payload, requirements, hooks_module}
+
     assert payload["transactionHash"] ==
              "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
     assert requirements["network"] == "base-sepolia"
     assert requirements["asset"] == "USDC"
     assert requirements["resource"] == "/api/resource"

--- a/test/x402/x402_test.exs
+++ b/test/x402/x402_test.exs
@@ -12,8 +12,7 @@ defmodule X402Test do
 
     test "delegates payment-signature decode and validate" do
       payload = %{
-        "transactionHash" =>
-          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "exact",
         "payerWallet" => "0x1111111111111111111111111111111111111111"

--- a/test/x402/x402_test.exs
+++ b/test/x402/x402_test.exs
@@ -12,7 +12,8 @@ defmodule X402Test do
 
     test "delegates payment-signature decode and validate" do
       payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transactionHash" =>
+          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "exact",
         "payerWallet" => "0x1111111111111111111111111111111111111111"

--- a/test/x402/x402_test.exs
+++ b/test/x402/x402_test.exs
@@ -12,7 +12,7 @@ defmodule X402Test do
 
     test "delegates payment-signature decode and validate" do
       payload = %{
-        "transactionHash" => "0xabc",
+        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "network" => "eip155:8453",
         "scheme" => "exact",
         "payerWallet" => "0x1111111111111111111111111111111111111111"


### PR DESCRIPTION
## Security Council Findings — March 28, 2026

### 🟡 HIGH: PaymentSignature.validate only checks field presence, not format

**Problem:** `validate/2` checked that `transactionHash` and `payerWallet` were present and non-empty strings, but never validated their format. Arbitrary strings like `"fake"` or `"AAAA"` pass structural validation — a spoofed payment proof could slip through if the facilitator is misconfigured, offline, or not performing independent verification.

**Fix:** Added `validate_field_formats/1` called after missing-field check:
- `transactionHash`: must match `0x` + 64 hex chars (EVM) OR base58 87–88 chars (Solana tx signature)
- `payerWallet`: must match `0x` + 40 hex chars (EVM) OR base58 32–44 chars (Solana address)

Returns `{:error, {:invalid_format, [{field, :invalid_format}]}}` on failure with telemetry emitted.

`network` and `scheme` are intentionally NOT validated here — those are validated downstream by facilitator/scheme validators which have the authoritative allowlists.

---

### 🟡 HIGH: SIWX ETSStorage has no max_size cap

**Problem:** Unlike `PaymentIdentifier.ETSCache`, `SIWX.ETSStorage` had no size limit. An attacker generating unique `{address, resource}` pairs would grow the ETS table without bound, eventually OOMing the node.

**Fix:** Added `max_size` option (default: 100,000 entries). When the table is at capacity:
- New insertions return `{:error, :storage_full}`
- Updates to existing keys are **never rejected** (size doesn't grow)
- Configurable via `start_link` opts for operator tuning

After the next cleanup sweep evicts expired records, new entries can be accepted again.

---

### 🟢 LOW: :rand.uniform/1 backoff seeding

**Assessment: Acceptable.** OS process entropy is sufficient for retry jitter spread — cryptographic PRNG seeding is not needed here. No change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens validation for payment proofs and changes SIWX storage behavior to reject writes when the ETS table is full, which could impact integrations that relied on permissive inputs or unlimited growth.
> 
> **Overview**
> **Hardens `PAYMENT-SIGNATURE` verification** by adding structural format checks for `transactionHash` (EVM 0x+64 hex or Solana base58 87–88 chars) and `payerWallet` (EVM 0x+40 hex or Solana base58) in `X402.PaymentSignature.validate/2`, returning `{:error, {:invalid_format, ...}}` and emitting telemetry on failures.
> 
> **Adds a size cap to SIWX ETS storage** (`X402.Extensions.SIWX.ETSStorage`) via a new `max_size` option (default `100_000`); once reached, new `{address, resource}` inserts return `{:error, :storage_full}` while updates to existing keys continue to succeed.
> 
> Tests and doctests are updated to use realistic 32-byte transaction hashes and to reflect the new validation expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ea791e5df0cbebcb27b46174803ae01acaeb217. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->