### PR TITLE
fix: return {:ok, module} from validate_module callbacks

### DIFF
--- a/lib/x402/extensions/siwx/storage.ex
+++ b/lib/x402/extensions/siwx/storage.ex
@@ -40,10 +40,10 @@ defmodule X402.Extensions.SIWX.Storage do
 
   This function is intended for `NimbleOptions` custom validation.
   """
-  @spec validate_module(term()) :: :ok | {:error, String.t()}
+  @spec validate_module(term()) :: {:ok, module()} | {:error, String.t()}
   def validate_module(module) when is_atom(module) do
     case implementation?(module) do
-      true -> :ok
+      true -> {:ok, module}
       false -> {:error, "expected a module implementing X402.Extensions.SIWX.Storage"}
     end
   end

--- a/lib/x402/extensions/siwx/verifier.ex
+++ b/lib/x402/extensions/siwx/verifier.ex
@@ -27,10 +27,10 @@ defmodule X402.Extensions.SIWX.Verifier do
 
   This function is intended for `NimbleOptions` custom validation.
   """
-  @spec validate_module(term()) :: :ok | {:error, String.t()}
+  @spec validate_module(term()) :: {:ok, module()} | {:error, String.t()}
   def validate_module(module) when is_atom(module) do
     case implementation?(module) do
-      true -> :ok
+      true -> {:ok, module}
       false -> {:error, "expected a module implementing X402.Extensions.SIWX.Verifier"}
     end
   end

--- a/lib/x402/hooks.ex
+++ b/lib/x402/hooks.ex
@@ -95,10 +95,10 @@ defmodule X402.Hooks do
 
   This function is designed for `NimbleOptions` custom validation.
   """
-  @spec validate_module(term()) :: :ok | {:error, String.t()}
+  @spec validate_module(term()) :: {:ok, term()} | {:error, String.t()}
   def validate_module(module) when is_atom(module) do
     case implementation?(module) do
-      true -> :ok
+      true -> {:ok, module}
       false -> {:error, "expected a module implementing X402.Hooks"}
     end
   end

--- a/test/x402/extensions/siwx/storage_test.exs
+++ b/test/x402/extensions/siwx/storage_test.exs
@@ -23,7 +23,7 @@ defmodule X402.Extensions.SIWX.StorageTest do
 
   describe "validate_module/1" do
     test "returns ok for valid storage module" do
-      assert Storage.validate_module(ValidStorage) == :ok
+      assert {:ok, ValidStorage} = Storage.validate_module(ValidStorage)
     end
 
     test "returns error for invalid storage modules" do

--- a/test/x402/extensions/siwx/verifier_test.exs
+++ b/test/x402/extensions/siwx/verifier_test.exs
@@ -17,7 +17,7 @@ defmodule X402.Extensions.SIWX.VerifierTest do
 
   describe "validate_module/1" do
     test "returns ok for valid verifier module" do
-      assert Verifier.validate_module(ValidVerifier) == :ok
+      assert {:ok, ValidVerifier} = Verifier.validate_module(ValidVerifier)
     end
 
     test "returns error for invalid verifier module" do


### PR DESCRIPTION
NimbleOptions 1.1.x requires custom validators to return {:ok, value} instead of just :ok. The x402 plug fails to boot with the new nimble_options because Hooks.validate_module/1, Storage.validate_module/1, and Verifier.validate_module/1 return :ok on success.

Update all three validators to return {:ok, module} and adjust the test expectations to match.