### PR TITLE
fix: declare required runtime applications for v0.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
           MIX_ENV: test
       - run: mix compile --no-optional-deps --warnings-as-errors
         name: Compile without optional deps
+      - name: Compile as a downstream consumer
+        working-directory: integration/consumer
+        run: |
+          mix deps.get
+          mix compile --warnings-as-errors
+          mix run smoke.exs
 
   dialyzer:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-08-15
+
+### Fixed
+
+- Declare `:telemetry` as a required runtime dependency so telemetry events and
+  facilitator calls work in downstream installs without optional dependencies
+- Start the OTP `:public_key` application used by
+  `X402.Facilitator.HTTP.secure_pool_opts/0`
+- Exercise the library from a minimal downstream Mix project in CI to catch
+  missing runtime dependencies before publishing
+
 ## [0.4.0] - 2026-08-15
 
 ### Added

--- a/integration/consumer/.gitignore
+++ b/integration/consumer/.gitignore
@@ -1,0 +1,3 @@
+/_build/
+/deps/
+/mix.lock

--- a/integration/consumer/mix.exs
+++ b/integration/consumer/mix.exs
@@ -1,0 +1,18 @@
+defmodule X402.ConsumerSmoke.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :x402_consumer_smoke,
+      version: "0.0.0",
+      elixir: "~> 1.19",
+      deps: deps()
+    ]
+  end
+
+  defp deps do
+    [
+      {:x402, path: "../.."}
+    ]
+  end
+end

--- a/integration/consumer/smoke.exs
+++ b/integration/consumer/smoke.exs
@@ -1,0 +1,10 @@
+:ok = X402.Telemetry.emit(:payment_required, :encode, :ok)
+
+case X402.Facilitator.HTTP.secure_pool_opts() do
+  [conn_opts: [transport_opts: [verify: :verify_peer, cacerts: certificates]]]
+  when is_list(certificates) and certificates != [] ->
+    :ok
+
+  invalid_options ->
+    raise "unexpected secure pool options: #{inspect(invalid_options)}"
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule X402.MixProject do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.4.1"
   @source_url "https://github.com/cardotrejos/x402"
   @description "Elixir SDK for the x402 HTTP payment protocol"
 
@@ -50,7 +50,7 @@ defmodule X402.MixProject do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :public_key]
     ]
   end
 
@@ -70,6 +70,9 @@ defmodule X402.MixProject do
 
       # Option validation (Dashbit style)
       {:nimble_options, "~> 1.0"},
+
+      # Runtime instrumentation
+      {:telemetry, "~> 1.0"},
 
       # EVM signature verification (optional — only needed for SIWX)
       {:ex_secp256k1, "~> 0.8.0", optional: true},

--- a/test/x402/x402_test.exs
+++ b/test/x402/x402_test.exs
@@ -3,6 +3,15 @@ defmodule X402Test do
 
   doctest X402
 
+  describe "OTP application dependencies" do
+    test "declares every required runtime application" do
+      applications = Application.spec(:x402, :applications)
+
+      assert :telemetry in applications
+      assert :public_key in applications
+    end
+  end
+
   describe "convenience delegates" do
     test "delegates payment-required encode/decode" do
       payload = %{"scheme" => "exact"}


### PR DESCRIPTION
## Summary

- declare `:telemetry` as a required dependency and start OTP `:public_key`
- bump the package to `0.4.1` with a focused changelog entry
- add a minimal downstream Mix project that compiles and exercises both runtime paths in CI

## Why

The clean consumer smoke test for `0.4.0` exposed that telemetry was available in this repository only through optional Finch/Plug dependencies. A downstream project that installs x402 without those optional dependencies cannot emit telemetry or call facilitator operations. The TLS helper also used `:public_key` without declaring its OTP application.

This PR is a packaging hotfix on top of the merged #42; it does not supersede or replace that work.

## Verification

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix credo --strict`
- `mix test --cover` — 75 doctests, 271 tests, 0 failures, 90.2% coverage
- `mix dialyzer` — 0 errors
- `mix docs`
- `MIX_ENV=prod mix compile --no-optional-deps --warnings-as-errors`
- downstream consumer compile and runtime smoke test
- `mix hex.build --output /tmp/x402-0.4.1-release.tar`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and application metadata only; no protocol, payment, or facilitator logic changes.
> 
> **Overview**
> **v0.4.1 packaging hotfix** so installs that skip optional Finch/Plug still get working telemetry and facilitator TLS helpers.
> 
> `:telemetry` is now a **required** Mix dependency (not only pulled in transitively), and the `:x402` application starts OTP **`:public_key`** for `X402.Facilitator.HTTP.secure_pool_opts/0`. CI gains a minimal **`integration/consumer`** project that path-depends on the library, compiles without optional deps, and runs `smoke.exs` to exercise telemetry emit and secure pool opts. A unit test asserts `:telemetry` and `:public_key` appear in the application spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a624f09b118a9eb4f8d6c463419c91cd8a94f61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->