### PR TITLE
ci: bump actions/checkout and actions/cache to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
         elixir: ["1.19"]
         otp: ["27"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
       - name: Cache deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -50,13 +50,13 @@ jobs:
         elixir: ["1.19"]
         otp: ["27"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
       - name: Cache deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -66,7 +66,7 @@ jobs:
             ${{ runner.os }}-mix-v2-${{ matrix.elixir }}-${{ matrix.otp }}-
             ${{ runner.os }}-mix-v2-
       - name: Cache PLTs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: priv/plts
           key: ${{ runner.os }}-plt-v3-${{ matrix.elixir }}-${{ matrix.otp }}-${{ hashFiles('mix.lock') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: erlef/setup-beam@v1
         with:
@@ -17,7 +17,7 @@ jobs:
           otp-version: "27"
 
       - name: Cache deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps


### PR DESCRIPTION
## Summary

CI runs were emitting warnings on every job:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4.

This bumps both actions to their v5 majors, which target Node 24 natively:

- `actions/checkout@v4` → `v5` (ci.yml, publish.yml)
- `actions/cache@v4` → `v5` (ci.yml ×3, publish.yml)

Both are drop-in upgrades — no input changes, and existing cache keys keep working. `erlef/setup-beam@v1` was not flagged and is left as is.

## Test plan

- CI on this PR should run without the Node.js 20 deprecation annotations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency bumps with no application or secret-handling changes.
> 
> **Overview**
> Updates GitHub Actions workflows to use **v5** of `actions/checkout` and `actions/cache` instead of **v4**, addressing runner warnings that those v4 actions still target deprecated Node.js 20.
> 
> Changes apply to the **CI** workflow (`test` and `dialyzer` jobs, including deps and PLT caches) and the **publish** workflow. Step inputs and cache keys are unchanged, so behavior and cache reuse should stay the same; `erlef/setup-beam@v1` is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e2f2551801da1fe1df4efa7c452fee9f7983e86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->