### PR TITLE
fix: make v0.5.0 Bazaar schemas self-consistent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ The Elixir SDK for the x402 HTTP payment protocol — published on Hex.pm. A **l
 
 ## Quick Context
 - **Language:** Elixir (OTP)
-- **Published:** Hex.pm (`x402 ~> 0.3`)
+- **Published:** Hex.pm (`x402 ~> 0.5.0`)
 - **CI:** GitHub Actions → `mix test --cover`
 - **Docs:** Generated via ExDoc, hosted on hexdocs.pm
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CDP JWT `uris` claim now binds to the full request path (facilitator base URL path + endpoint) — the previous `host + /verify` binding caused the hosted CDP facilitator to reject all requests with 401 (`request_info.path` is now the fully-qualified path)
 - The auth request host is now derived from the URI host and port (port included only when non-default, matching JavaScript `URL.host` semantics) instead of the deprecated `URI.authority` field, which is no longer populated on recent Elixir and failed dialyzer
+- Bazaar text-body declarations now accept string examples and emit a matching string schema
+- Bazaar output schemas now match scalar and array examples instead of always declaring an object
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add the library and only the optional integrations your application uses:
 ```elixir
 def deps do
   [
-    {:x402, "~> 0.5"},
+    {:x402, "~> 0.5.0"},
     {:finch, "~> 0.19"}, # facilitator HTTP calls
     {:plug, "~> 1.14"}   # PaymentGate
   ]

--- a/lib/x402/extensions/bazaar.ex
+++ b/lib/x402/extensions/bazaar.ex
@@ -195,9 +195,15 @@ defmodule X402.Extensions.Bazaar do
   defp put_http_input(info_input, method, opts) when method in @body_methods do
     body_type = body_type!(opts)
 
+    body =
+      case Keyword.get(opts, :input) do
+        nil -> default_body(body_type)
+        input -> input
+      end
+
     info_input
     |> Map.put("bodyType", body_type)
-    |> Map.put("body", Keyword.get(opts, :input, default_body(body_type)))
+    |> Map.put("body", body)
   end
 
   defp put_http_input(info_input, _method, opts) do

--- a/lib/x402/extensions/bazaar.ex
+++ b/lib/x402/extensions/bazaar.ex
@@ -17,8 +17,8 @@ defmodule X402.Extensions.Bazaar do
 
   `info.output` describes the expected response format. It is always present
   (defaulting to a `"json"` content type). The schema's `output` property
-  declares `type` (and optionally `format`) as strings and `example` as an
-  object, optionally constrained by the `:schema` option.
+  declares `type` (and optionally `format`) as strings and infers the JSON
+  type of `example`, optionally refined by the `:schema` option.
 
   The factory returns a plain, string-keyed map ready for JSON encoding:
 
@@ -46,7 +46,7 @@ defmodule X402.Extensions.Bazaar do
 
   @http_schema [
     method: [type: :any],
-    input: [type: {:custom, __MODULE__, :validate_map, []}],
+    input: [type: :any],
     input_schema: [type: {:custom, __MODULE__, :validate_map, []}],
     body_type: [type: :string],
     headers: [type: {:custom, __MODULE__, :validate_map, []}],
@@ -78,8 +78,9 @@ defmodule X402.Extensions.Bazaar do
     * `:method` — (required) HTTP method: `:get`, `:head`, `:delete`,
       `:post`, `:put`, `:patch` (or the uppercase string). Query methods
       produce a read-only signature; body methods add `bodyType` and `body`.
-    * `:input` — example input values (query parameters for query methods,
-      request body for body methods).
+    * `:input` — example input values (a map of query parameters for query
+      methods, a map for `"json"` / `"form-data"` bodies, or a string for
+      `"text"` bodies).
     * `:input_schema` — JSON Schema merged into the schema's `queryParams`
       or `body` property.
     * `:body_type` — request body content type for body methods: `"json"`
@@ -174,6 +175,7 @@ defmodule X402.Extensions.Bazaar do
   @spec build_http_extension(keyword()) :: t()
   defp build_http_extension(opts) do
     method = method!(opts)
+    validate_http_input!(method, opts)
 
     info_input =
       %{"type" => "http", "method" => method}
@@ -191,9 +193,11 @@ defmodule X402.Extensions.Bazaar do
 
   @spec put_http_input(map(), String.t(), keyword()) :: map()
   defp put_http_input(info_input, method, opts) when method in @body_methods do
+    body_type = body_type!(opts)
+
     info_input
-    |> Map.put("bodyType", body_type!(opts))
-    |> Map.put("body", Keyword.get(opts, :input, %{}))
+    |> Map.put("bodyType", body_type)
+    |> Map.put("body", Keyword.get(opts, :input, default_body(body_type)))
   end
 
   defp put_http_input(info_input, _method, opts) do
@@ -253,7 +257,7 @@ defmodule X402.Extensions.Bazaar do
   @spec body_schema(keyword()) :: map()
   defp body_schema(opts) do
     case Keyword.get(opts, :input_schema) do
-      nil -> %{"type" => "object"}
+      nil -> default_body_schema(body_type!(opts))
       schema -> schema
     end
   end
@@ -341,7 +345,7 @@ defmodule X402.Extensions.Bazaar do
     properties =
       %{"type" => %{"type" => "string"}}
       |> maybe_put_any("format", format_schema(Keyword.get(output, :format)))
-      |> Map.put("example", output_example_schema(Keyword.get(output, :schema)))
+      |> Map.put("example", output_example_schema(output))
 
     output_property = %{
       "type" => "object",
@@ -356,9 +360,15 @@ defmodule X402.Extensions.Bazaar do
   defp format_schema(nil), do: nil
   defp format_schema(_format), do: %{"type" => "string"}
 
-  @spec output_example_schema(map() | nil) :: map()
-  defp output_example_schema(nil), do: %{"type" => "object"}
-  defp output_example_schema(schema), do: Map.merge(%{"type" => "object"}, schema)
+  @spec output_example_schema(keyword()) :: map()
+  defp output_example_schema(output) do
+    example = Keyword.get(output, :example)
+    custom_schema = Keyword.get(output, :schema)
+
+    example
+    |> inferred_example_schema(custom_schema)
+    |> Map.merge(custom_schema || %{})
+  end
 
   # --- option accessors ---
 
@@ -403,6 +413,73 @@ defmodule X402.Extensions.Bazaar do
             "invalid :body_type #{inspect(value)}; expected one of #{Enum.join(@body_types, ", ")}"
     end
   end
+
+  @spec validate_http_input!(String.t(), keyword()) :: :ok
+  defp validate_http_input!(method, opts) when method in @query_methods do
+    if Keyword.has_key?(opts, :body_type) do
+      raise ArgumentError, ":body_type is only supported for POST, PUT, and PATCH inputs"
+    end
+
+    case Keyword.get(opts, :input) do
+      nil -> :ok
+      input when is_map(input) -> :ok
+      input -> raise ArgumentError, "expected query :input to be a map, got: #{inspect(input)}"
+    end
+  end
+
+  defp validate_http_input!(method, opts) when method in @body_methods do
+    body_type = body_type!(opts)
+
+    case {body_type, Keyword.get(opts, :input)} do
+      {_body_type, nil} ->
+        :ok
+
+      {"text", input} when is_binary(input) ->
+        :ok
+
+      {body_type, input} when body_type in ["json", "form-data"] and is_map(input) ->
+        :ok
+
+      {"text", input} ->
+        raise ArgumentError, "expected text :input to be a string, got: #{inspect(input)}"
+
+      {body_type, input} ->
+        raise ArgumentError,
+              "expected #{body_type} :input to be a map, got: #{inspect(input)}"
+    end
+  end
+
+  @spec default_body(String.t()) :: map() | String.t()
+  defp default_body("text"), do: ""
+  defp default_body(_body_type), do: %{}
+
+  @spec default_body_schema(String.t()) :: map()
+  defp default_body_schema("text"), do: %{"type" => "string"}
+  defp default_body_schema(_body_type), do: %{"type" => "object"}
+
+  @spec inferred_example_schema(term(), map() | nil) :: map()
+  defp inferred_example_schema(nil, nil), do: %{}
+  defp inferred_example_schema(nil, _custom_schema), do: %{"type" => "object"}
+
+  defp inferred_example_schema(example, _custom_schema) when is_map(example),
+    do: %{"type" => "object"}
+
+  defp inferred_example_schema(example, _custom_schema) when is_list(example),
+    do: %{"type" => "array"}
+
+  defp inferred_example_schema(example, _custom_schema) when is_binary(example),
+    do: %{"type" => "string"}
+
+  defp inferred_example_schema(example, _custom_schema) when is_boolean(example),
+    do: %{"type" => "boolean"}
+
+  defp inferred_example_schema(example, _custom_schema) when is_integer(example),
+    do: %{"type" => "integer"}
+
+  defp inferred_example_schema(example, _custom_schema) when is_float(example),
+    do: %{"type" => "number"}
+
+  defp inferred_example_schema(_example, _custom_schema), do: %{}
 
   @spec transport(keyword()) :: String.t() | nil
   defp transport(opts) do

--- a/lib/x402/facilitator/auth.ex
+++ b/lib/x402/facilitator/auth.ex
@@ -20,8 +20,8 @@ defmodule X402.Facilitator.Auth do
   `{module, opts}` tuple.
 
   Implementations are built once at `start_link` so invalid credentials fail
-  fast, and `c:headers/2` is called once per request so time-based credentials
-  (JWTs, etc.) are never reused across retries.
+  fast, and `c:headers/2` is called once per facilitator operation. Transport
+  retries reuse those headers within the credential's validity window.
   """
 
   @typedoc """
@@ -53,8 +53,8 @@ defmodule X402.Facilitator.Auth do
   @doc """
   Builds the HTTP headers for a single request.
 
-  Called once per request so time-based credentials are never reused across
-  retries. Returns a list of `{name, value}` header tuples.
+  Called once per facilitator operation. Returns a list of `{name, value}`
+  header tuples.
   """
   @callback headers(t(), request_info()) ::
               {:ok, [{String.t(), String.t()}]} | {:error, term()}

--- a/lib/x402/facilitator/auth/cdp.ex
+++ b/lib/x402/facilitator/auth/cdp.ex
@@ -38,9 +38,10 @@ defmodule X402.Facilitator.Auth.CDP do
         auth: {X402.Facilitator.Auth.CDP, api_key_id: "...", api_key_secret: "..."}
       )
 
-  The JWT is generated per request with a fresh nonce and timestamps, so it is
-  never reused across retries. The `aud` claim is intentionally omitted to
-  match the reference CDP SDK's x402 facilitator client.
+  The JWT is generated per facilitator operation with a fresh nonce and
+  timestamps. Transport retries reuse it within its 120-second validity
+  window. The `aud` claim is intentionally omitted to match the reference CDP
+  SDK's x402 facilitator client.
   """
 
   @behaviour X402.Facilitator.Auth

--- a/mix.exs
+++ b/mix.exs
@@ -109,7 +109,7 @@ defmodule X402.MixProject do
   defp docs do
     [
       main: "readme",
-      source_ref: "main",
+      source_ref: "v#{@version}",
       source_url: @source_url,
       extras: [
         "README.md": [title: "Overview"],
@@ -132,6 +132,8 @@ defmodule X402.MixProject do
         ],
         "Facilitator Client": [
           X402.Facilitator,
+          X402.Facilitator.Auth,
+          X402.Facilitator.Auth.CDP,
           X402.Facilitator.HTTP,
           X402.Hooks,
           X402.Hooks.Context,

--- a/test/x402/extensions/bazaar_test.exs
+++ b/test/x402/extensions/bazaar_test.exs
@@ -66,6 +66,19 @@ defmodule X402.Extensions.BazaarTest do
       assert ext["info"]["input"]["body"] == %{}
     end
 
+    test "text body methods accept strings and emit a matching schema" do
+      ext = Bazaar.build_extension(method: :post, body_type: "text", input: "hello")
+
+      assert ext["info"]["input"]["body"] == "hello"
+
+      assert ext["schema"]["properties"]["input"]["properties"]["body"] == %{
+               "type" => "string"
+             }
+
+      default_ext = Bazaar.build_extension(method: :post, body_type: "text")
+      assert default_ext["info"]["input"]["body"] == ""
+    end
+
     test "custom body_type is reflected in info" do
       ext = Bazaar.build_extension(method: :post, input: %{}, body_type: "form-data")
       assert ext["info"]["input"]["bodyType"] == "form-data"
@@ -176,7 +189,7 @@ defmodule X402.Extensions.BazaarTest do
       output_schema = ext["schema"]["properties"]["output"]
       assert output_schema["required"] == ["type"]
       assert output_schema["properties"]["type"] == %{"type" => "string"}
-      assert output_schema["properties"]["example"] == %{"type" => "object"}
+      assert output_schema["properties"]["example"] == %{}
       refute Map.has_key?(output_schema["properties"], "format")
     end
 
@@ -217,6 +230,26 @@ defmodule X402.Extensions.BazaarTest do
       assert ext["schema"]["properties"]["output"]["properties"]["example"] == %{
                "type" => "object"
              }
+    end
+
+    test "schema output example matches scalar and array JSON types" do
+      examples = [
+        {"ok", "string"},
+        {42, "integer"},
+        {1.5, "number"},
+        {true, "boolean"},
+        {["ok"], "array"}
+      ]
+
+      for {example, expected_type} <- examples do
+        ext = Bazaar.build_extension(method: :get, output: [example: example])
+
+        assert ext["info"]["output"]["example"] == example
+
+        assert ext["schema"]["properties"]["output"]["properties"]["example"] == %{
+                 "type" => expected_type
+               }
+      end
     end
 
     test "accepts a keyword list with format, example, and schema" do
@@ -290,9 +323,25 @@ defmodule X402.Extensions.BazaarTest do
       end
     end
 
-    test "raises when input is not a map" do
-      assert_raise NimbleOptions.ValidationError, ~r/input/, fn ->
+    test "raises when query input is not a map" do
+      assert_raise ArgumentError, ~r/expected query :input to be a map/, fn ->
         Bazaar.build_extension(method: :get, input: "bad")
+      end
+    end
+
+    test "raises when body input does not match its body_type" do
+      assert_raise ArgumentError, ~r/expected json :input to be a map/, fn ->
+        Bazaar.build_extension(method: :post, body_type: "json", input: "bad")
+      end
+
+      assert_raise ArgumentError, ~r/expected text :input to be a string/, fn ->
+        Bazaar.build_extension(method: :post, body_type: "text", input: %{})
+      end
+    end
+
+    test "raises when body_type is provided for a query method" do
+      assert_raise ArgumentError, ~r/:body_type is only supported/, fn ->
+        Bazaar.build_extension(method: :get, body_type: "text")
       end
     end
 

--- a/test/x402/extensions/bazaar_test.exs
+++ b/test/x402/extensions/bazaar_test.exs
@@ -64,6 +64,9 @@ defmodule X402.Extensions.BazaarTest do
     test "body method with no input defaults body to empty map" do
       ext = Bazaar.build_extension(method: :post)
       assert ext["info"]["input"]["body"] == %{}
+
+      nil_ext = Bazaar.build_extension(method: :post, input: nil)
+      assert nil_ext["info"]["input"]["body"] == %{}
     end
 
     test "text body methods accept strings and emit a matching schema" do
@@ -77,6 +80,9 @@ defmodule X402.Extensions.BazaarTest do
 
       default_ext = Bazaar.build_extension(method: :post, body_type: "text")
       assert default_ext["info"]["input"]["body"] == ""
+
+      nil_ext = Bazaar.build_extension(method: :post, body_type: "text", input: nil)
+      assert nil_ext["info"]["input"]["body"] == ""
     end
 
     test "custom body_type is reflected in info" do


### PR DESCRIPTION
## What

Fixes two release-blocking inconsistencies found while reviewing the merged v0.5.0 candidate:

- `body_type: "text"` now accepts string bodies and emits a string body schema.
- output example schemas now match string, integer, number, boolean, array, and object examples instead of always declaring `object`.

Also tightens the README requirement to `~> 0.5.0`, points ExDoc source links at the immutable release tag, groups the new auth modules in the API docs, and corrects the auth retry documentation.

## Verification

- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict`
- `MIX_ENV=test mix coveralls` — 78 doctests + 359 tests, 0 failures, 90.7% coverage
- `mix compile --no-optional-deps --warnings-as-errors`
- downstream `integration/consumer` compile + smoke
- `mix dialyzer` — 0 errors
- `mix docs --warnings-as-errors`
- exact `mix hex.build` tarball installed in a clean `Mix.install` consumer and smoked for telemetry, CA loading, CDP auth, text bodies, and scalar output schemas

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Bazaar extension generation, tests, and documentation; no facilitator auth implementation logic changes in the diff.
> 
> **Overview**
> Fixes **Bazaar** discovery payloads so `info` and JSON Schema stay consistent for v0.5.0.
> 
> **HTTP bodies:** `body_type: "text"` now takes string `:input`, defaults the example body to `""`, and emits a `"string"` body schema instead of treating everything as an object. JSON/form-data bodies still require maps. **`:input`** validation is tightened with explicit errors (e.g. `:body_type` only on POST/PUT/PATCH, query `:input` must be a map).
> 
> **Output:** The schema’s `example` property **infers JSON type** from the provided example (string, integer, number, boolean, array, object) and merges optional `:schema`; the default output example schema is empty when no example is given.
> 
> Release hygiene: docs pin **`x402 ~> 0.5.0`**, ExDoc **`source_ref`** points at the release tag, and facilitator **auth** docs note JWTs are built per operation and may be reused on transport retries within the TTL. Changelog and tests cover the Bazaar behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbc78153e075da5cb8613162f5fb8fe2f47380c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->