### PR TITLE
feat!: drop the legacy v1 validation path in PaymentSignature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- **The legacy "v1" validation path in `X402.PaymentSignature`.** It required
+  `transactionHash`/`network`/`scheme`/`payerWallet` — a shape that matches no
+  published x402 wire format (real v1 payments carry
+  `{scheme, network, payload: {signature, authorization}}` in the `X-PAYMENT`
+  header, which this SDK never reads) — so it advertised v1 interop that was
+  exactly zero while accepting payloads no facilitator would settle. Payloads
+  declaring `x402Version: 1` or omitting the version now return
+  `{:error, {:unsupported_x402_version, 1 | nil}}` (mapped to HTTP 400 by
+  `X402.Plug.PaymentGate`). The `{:missing_fields, _}` and
+  `{:invalid_format, _}` error reasons no longer occur.
+  (Ecosystem report §8 P0.1.)
+
 ## [0.5.0] - 2026-08-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exactly zero while accepting payloads no facilitator would settle. Payloads
   declaring `x402Version: 1` or omitting the version now return
   `{:error, {:unsupported_x402_version, 1 | nil}}` (mapped to HTTP 400 by
-  `X402.Plug.PaymentGate`). The `{:missing_fields, _}` and
-  `{:invalid_format, _}` error reasons no longer occur.
+  `X402.Plug.PaymentGate`). The `{:invalid_format, _}` error reason no
+  longer occurs; `{:missing_fields, _}` remains for v2 `accepted` objects
+  missing required PaymentRequirements fields.
   (Ecosystem report §8 P0.1.)
 
 ## [0.5.0] - 2026-08-26

--- a/lib/x402/payment_signature.ex
+++ b/lib/x402/payment_signature.ex
@@ -1,35 +1,24 @@
 defmodule X402.PaymentSignature do
   @moduledoc """
-  Decodes and validates x402 `PAYMENT-SIGNATURE` header values.
+  Decodes and validates x402 v2 `PAYMENT-SIGNATURE` header values.
 
-  The header value is Base64-encoded JSON. This module supports both the legacy
-  v1 signature fields and the v2 `PaymentPayload` envelope.
+  The header value is Base64-encoded JSON carrying the v2 `PaymentPayload`
+  envelope (`x402Version: 2`). `accepted` must be a complete
+  `X402.PaymentRequirements` object and `payload` must contain the
+  scheme-specific signed data. When requirements are passed to `validate/2`,
+  every core field is matched and advertised `extra` values must be preserved.
 
-  For v2, `accepted` must be a complete `X402.PaymentRequirements` object and
-  `payload` must contain the scheme-specific signed data. When requirements are
-  passed to `validate/2`, every core field is matched and advertised `extra`
-  values must be preserved.
+  Payloads that declare `x402Version: 1` — or omit the version entirely, which
+  x402 v1 clients do — are rejected with
+  `{:error, {:unsupported_x402_version, version}}`. This SDK does not speak the
+  v1 wire format (v1 payments arrive in the `X-PAYMENT` header, which
+  `X402.Plug.PaymentGate` never reads); rejecting explicitly is safer than the
+  false interop of validating a shape no facilitator settles.
   """
 
   alias X402.PaymentRequirements
   alias X402.Telemetry
   alias X402.Utils
-
-  @required_fields ~w(transactionHash network scheme payerWallet)
-
-  # EIP-55 Ethereum address: 0x followed by exactly 40 hex characters (case-insensitive).
-  # We accept mixed-case (checksummed) and lower-case (normalised) addresses.
-  @eth_address_regex ~r/^0x[0-9a-fA-F]{40}$/
-
-  # Transaction hash: 0x followed by exactly 64 hex characters (256-bit hash).
-  # Solana tx IDs are base58, 87-88 chars — we detect them by absence of "0x" prefix.
-  @eth_tx_hash_regex ~r/^0x[0-9a-fA-F]{64}$/
-
-  # Solana base-58 transaction signature (87–88 characters of base58 alphabet).
-  @solana_tx_sig_regex ~r/^[1-9A-HJ-NP-Za-km-z]{87,88}$/
-
-  # Solana wallet address: base58, 32-44 characters.
-  @solana_address_regex ~r/^[1-9A-HJ-NP-Za-km-z]{43,44}$/
 
   # Single source of truth for the 8 KB decode guard — see X402.Header.
   @max_header_bytes X402.Header.max_header_bytes()
@@ -47,10 +36,9 @@ defmodule X402.PaymentSignature do
           | :invalid_payment_requirements
           | :invalid_x402_version
           | :no_matching_requirements
-          | {:missing_fields, [String.t()]}
+          | {:unsupported_x402_version, 1 | nil}
           | {:invalid_fields, [String.t()]}
           | {:invalid_upto_payment, upto_validation_error()}
-          | {:invalid_format, [{field :: String.t(), reason :: atom()}]}
 
   @type decode_and_validate_error :: decode_error() | validate_error()
 
@@ -139,11 +127,13 @@ defmodule X402.PaymentSignature do
 
   @doc since: "0.1.0", group: :verification
   @doc """
-  Validates a decoded v1 or v2 `PAYMENT-SIGNATURE` payload.
+  Validates a decoded v2 `PAYMENT-SIGNATURE` payload.
 
   Payloads with `x402Version: 2` are validated against the v2
-  `PaymentPayload` structure. Payloads with version `1`, or without an explicit
-  version, retain the legacy field validation used by x402 v1.
+  `PaymentPayload` structure. Payloads declaring version `1` — or omitting the
+  version, as v1 clients do — return
+  `{:error, {:unsupported_x402_version, version}}`; any other version returns
+  `{:error, :invalid_x402_version}`.
 
   ## Examples
 
@@ -195,28 +185,8 @@ defmodule X402.PaymentSignature do
   defp do_validate(payload, requirements) do
     case Utils.map_value(payload, {"x402Version", :x402Version}) do
       2 -> validate_v2(payload, requirements)
-      version when version in [nil, 1] -> validate_v1(payload, requirements)
+      version when version in [nil, 1] -> validation_error({:unsupported_x402_version, version})
       _version -> validation_error(:invalid_x402_version)
-    end
-  end
-
-  @spec validate_v1(map(), map()) :: {:ok, map()} | {:error, validate_error()}
-  defp validate_v1(payload, requirements) do
-    with :ok <- check_missing_fields(payload),
-         :ok <- check_field_formats(payload) do
-      case validate_scheme(payload, requirements) do
-        :ok ->
-          Telemetry.emit(:payment_signature, :validate, :ok, %{required_fields: @required_fields})
-          {:ok, payload}
-
-        {:error, {:invalid_upto_payment, reason}} = error ->
-          Telemetry.emit(:payment_signature, :validate, :error, %{
-            reason: :invalid_upto_payment,
-            detail: reason
-          })
-
-          error
-      end
     end
   end
 
@@ -269,36 +239,6 @@ defmodule X402.PaymentSignature do
     {:error, reason}
   end
 
-  defp check_missing_fields(payload) do
-    case missing_fields(payload) do
-      [] ->
-        :ok
-
-      missing ->
-        Telemetry.emit(:payment_signature, :validate, :error, %{
-          reason: :missing_fields,
-          fields: missing
-        })
-
-        {:error, {:missing_fields, missing}}
-    end
-  end
-
-  defp check_field_formats(payload) do
-    case validate_field_formats(payload) do
-      [] ->
-        :ok
-
-      format_errors ->
-        Telemetry.emit(:payment_signature, :validate, :error, %{
-          reason: :invalid_format,
-          fields: Enum.map(format_errors, &elem(&1, 0))
-        })
-
-        {:error, {:invalid_format, format_errors}}
-    end
-  end
-
   @doc since: "0.1.0", group: :verification
   @doc """
   Decodes and validates a `PAYMENT-SIGNATURE` header in one step.
@@ -336,62 +276,6 @@ defmodule X402.PaymentSignature do
     Telemetry.emit(:payment_signature, :decode_and_validate, :error, %{reason: :invalid_payload})
     {:error, :invalid_payload}
   end
-
-  @spec missing_fields(map()) :: [String.t()]
-  defp missing_fields(payload) do
-    payload_keys = Map.keys(payload)
-
-    @required_fields
-    |> Enum.reject(fn field ->
-      value = Map.get(payload, field)
-      field in payload_keys and is_binary(value) and value != ""
-    end)
-    |> Enum.sort()
-  end
-
-  # Validates the format of fields that have known structural constraints:
-  #   - transactionHash: EVM 0x+64hex OR Solana base58 87-88 chars
-  #   - payerWallet: EVM 0x+40hex OR Solana base58 32-44 chars
-  #
-  # We intentionally do NOT validate `network` and `scheme` here — those fields
-  # are validated downstream by the facilitator / scheme validators which have
-  # the authoritative list of supported values.
-  #
-  # Returns a list of {field, reason} tuples for each invalid field; empty list = ok.
-  @spec validate_field_formats(map()) :: [{String.t(), atom()}]
-  defp validate_field_formats(payload) do
-    [
-      validate_transaction_hash(Map.get(payload, "transactionHash")),
-      validate_payer_wallet(Map.get(payload, "payerWallet"))
-    ]
-    |> Enum.reject(&is_nil/1)
-  end
-
-  @spec validate_transaction_hash(String.t() | nil) :: {String.t(), atom()} | nil
-  defp validate_transaction_hash(nil), do: nil
-
-  defp validate_transaction_hash(hash) when is_binary(hash) do
-    cond do
-      Regex.match?(@eth_tx_hash_regex, hash) -> nil
-      Regex.match?(@solana_tx_sig_regex, hash) -> nil
-      true -> {"transactionHash", :invalid_format}
-    end
-  end
-
-  defp validate_transaction_hash(_), do: {"transactionHash", :invalid_format}
-
-  @spec validate_payer_wallet(String.t() | nil) :: {String.t(), atom()} | nil
-  defp validate_payer_wallet(nil), do: nil
-
-  defp validate_payer_wallet(wallet) when is_binary(wallet) do
-    cond do
-      Regex.match?(@eth_address_regex, wallet) -> nil
-      Regex.match?(@solana_address_regex, wallet) -> nil
-      true -> {"payerWallet", :invalid_format}
-    end
-  end
-
-  defp validate_payer_wallet(_), do: {"payerWallet", :invalid_format}
 
   @spec validate_scheme(map(), map()) ::
           :ok | {:error, {:invalid_upto_payment, upto_validation_error()}}

--- a/lib/x402/payment_signature.ex
+++ b/lib/x402/payment_signature.ex
@@ -37,6 +37,7 @@ defmodule X402.PaymentSignature do
           | :invalid_x402_version
           | :no_matching_requirements
           | {:unsupported_x402_version, 1 | nil}
+          | {:missing_fields, [String.t()]}
           | {:invalid_fields, [String.t()]}
           | {:invalid_upto_payment, upto_validation_error()}
 

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -1248,6 +1248,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     @spec status_for_reason(term()) :: 400 | 402 | 500
     defp status_for_reason(reason) when reason in @invalid_request_reasons, do: 400
     defp status_for_reason({:unsupported_x402_version, _version}), do: 400
+    defp status_for_reason({:missing_fields, _fields}), do: 400
     defp status_for_reason({:invalid_upto_payment, _reason}), do: 400
     defp status_for_reason({:invalid_fields, _fields}), do: 400
     defp status_for_reason(:invalid_payment_requirements), do: 400
@@ -1310,6 +1311,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     defp rejection_error(:no_matching_requirements), do: "No matching payment requirements"
     defp rejection_error(:already_exists), do: "payment already processed"
     defp rejection_error({:unsupported_x402_version, _version}), do: "unsupported x402 version"
+    defp rejection_error({:missing_fields, _fields}), do: "invalid_payload"
     defp rejection_error({:invalid_upto_payment, _reason}), do: "invalid_payload"
     defp rejection_error({:invalid_fields, _fields}), do: "invalid_payload"
     defp rejection_error(:invalid_payment_requirements), do: "invalid_payload"

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -1247,9 +1247,8 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
 
     @spec status_for_reason(term()) :: 400 | 402 | 500
     defp status_for_reason(reason) when reason in @invalid_request_reasons, do: 400
-    defp status_for_reason({:missing_fields, _fields}), do: 400
+    defp status_for_reason({:unsupported_x402_version, _version}), do: 400
     defp status_for_reason({:invalid_upto_payment, _reason}), do: 400
-    defp status_for_reason({:invalid_format, _fields}), do: 400
     defp status_for_reason({:invalid_fields, _fields}), do: 400
     defp status_for_reason(:invalid_payment_requirements), do: 400
     defp status_for_reason(:extension_echo_mismatch), do: 400
@@ -1310,9 +1309,8 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     defp rejection_error(:invalid_x402_version), do: "invalid_x402_version"
     defp rejection_error(:no_matching_requirements), do: "No matching payment requirements"
     defp rejection_error(:already_exists), do: "payment already processed"
-    defp rejection_error({:missing_fields, _fields}), do: "invalid_payload"
+    defp rejection_error({:unsupported_x402_version, _version}), do: "unsupported x402 version"
     defp rejection_error({:invalid_upto_payment, _reason}), do: "invalid_payload"
-    defp rejection_error({:invalid_format, _fields}), do: "invalid_payload"
     defp rejection_error({:invalid_fields, _fields}), do: "invalid_payload"
     defp rejection_error(:invalid_payment_requirements), do: "invalid_payload"
     defp rejection_error(:extension_echo_mismatch), do: "invalid_payload"

--- a/test/x402/payment_signature_test.exs
+++ b/test/x402/payment_signature_test.exs
@@ -116,6 +116,13 @@ defmodule X402.PaymentSignatureTest do
       assert PaymentSignature.validate(Map.put(v2_payload("9000"), "extensions", [])) ==
                {:error, :invalid_payload}
     end
+
+    test "returns missing_fields for incomplete v2 accepted objects" do
+      payload = update_in(v2_payload("9000"), ["accepted"], &Map.delete(&1, "asset"))
+
+      assert PaymentSignature.validate(payload) ==
+               {:error, {:missing_fields, ["asset"]}}
+    end
   end
 
   describe "validate/2" do

--- a/test/x402/payment_signature_test.exs
+++ b/test/x402/payment_signature_test.exs
@@ -15,6 +15,23 @@ defmodule X402.PaymentSignatureTest do
     "extra" => %{}
   }
 
+  @v1_payload %{
+    "x402Version" => 1,
+    "scheme" => "exact",
+    "network" => "base-sepolia",
+    "payload" => %{
+      "signature" => "0xsignature",
+      "authorization" => %{
+        "from" => "0x1111111111111111111111111111111111111111",
+        "to" => "0x2222222222222222222222222222222222222222",
+        "value" => "10000",
+        "validAfter" => "0",
+        "validBefore" => "9999999999",
+        "nonce" => "0xnonce"
+      }
+    }
+  }
+
   describe "header_name/0" do
     test "returns PAYMENT-SIGNATURE" do
       assert PaymentSignature.header_name() == "PAYMENT-SIGNATURE"
@@ -23,13 +40,7 @@ defmodule X402.PaymentSignatureTest do
 
   describe "decode/1" do
     test "decodes a valid base64 json payload" do
-      payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "network" => "eip155:8453",
-        "scheme" => "exact",
-        "payerWallet" => "0x1111111111111111111111111111111111111111"
-      }
-
+      payload = v2_payload("9000")
       encoded = payload |> Jason.encode!() |> Base.encode64()
 
       assert PaymentSignature.decode(encoded) == {:ok, payload}
@@ -66,13 +77,8 @@ defmodule X402.PaymentSignatureTest do
   end
 
   describe "validate/1" do
-    test "returns ok for complete payload" do
-      payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "network" => "eip155:8453",
-        "scheme" => "exact",
-        "payerWallet" => "0x1111111111111111111111111111111111111111"
-      }
+    test "validates v2 payloads through the public API" do
+      payload = v2_payload("9000")
 
       assert PaymentSignature.validate(payload) == {:ok, payload}
     end
@@ -81,42 +87,21 @@ defmodule X402.PaymentSignatureTest do
       assert PaymentSignature.validate(nil) == {:error, :invalid_payload}
     end
 
-    test "returns missing_fields for absent values" do
-      payload = %{"network" => "eip155:8453"}
+    test "rejects explicit v1 payloads as unsupported" do
+      assert PaymentSignature.validate(@v1_payload) ==
+               {:error, {:unsupported_x402_version, 1}}
+    end
+
+    test "rejects version-absent payloads as unsupported v1" do
+      payload = Map.delete(@v1_payload, "x402Version")
 
       assert PaymentSignature.validate(payload) ==
-               {:error, {:missing_fields, ["payerWallet", "scheme", "transactionHash"]}}
+               {:error, {:unsupported_x402_version, nil}}
     end
 
-    test "treats empty strings as missing" do
-      payload = %{
-        "transactionHash" => "",
-        "network" => "eip155:8453",
-        "scheme" => "",
-        "payerWallet" => "0x1111111111111111111111111111111111111111"
-      }
-
-      assert PaymentSignature.validate(payload) ==
-               {:error, {:missing_fields, ["scheme", "transactionHash"]}}
-    end
-
-    test "validates upto payments when value is within maxPrice from payload" do
-      payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "network" => "eip155:8453",
-        "scheme" => "upto",
-        "payerWallet" => "0x1111111111111111111111111111111111111111",
-        "value" => "0.009",
-        "maxPrice" => "0.01"
-      }
-
-      assert PaymentSignature.validate(payload) == {:ok, payload}
-    end
-
-    test "validates v2 payloads through the public API" do
-      payload = v2_payload("9000")
-
-      assert PaymentSignature.validate(payload) == {:ok, payload}
+    test "rejects atom-keyed v1 versions as unsupported" do
+      assert PaymentSignature.validate(%{x402Version: 1}) ==
+               {:error, {:unsupported_x402_version, 1}}
     end
 
     test "rejects unsupported explicit protocol versions" do
@@ -134,59 +119,37 @@ defmodule X402.PaymentSignatureTest do
   end
 
   describe "validate/2" do
-    test "validates upto payments when value is within requirements maxPrice" do
-      payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "network" => "eip155:8453",
-        "scheme" => "upto",
-        "payerWallet" => "0x1111111111111111111111111111111111111111",
-        "value" => "0.009"
-      }
+    test "validates upto payments when value is within the requirements amount" do
+      payload = v2_payload("9000")
 
-      requirements = %{"scheme" => "upto", "maxPrice" => "0.01"}
-
-      assert PaymentSignature.validate(payload, requirements) == {:ok, payload}
+      assert PaymentSignature.validate(payload, @v2_requirements) == {:ok, payload}
     end
 
-    test "rejects upto payments when value exceeds maxPrice" do
-      payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "network" => "eip155:8453",
-        "scheme" => "upto",
-        "payerWallet" => "0x1111111111111111111111111111111111111111",
-        "value" => "0.02"
-      }
+    test "rejects upto payments when value exceeds the requirements amount" do
+      payload = v2_payload("10001")
 
-      requirements = %{"scheme" => "upto", "maxPrice" => "0.01"}
-
-      assert PaymentSignature.validate(payload, requirements) ==
+      assert PaymentSignature.validate(payload, @v2_requirements) ==
                {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
     end
 
     test "rejects upto payments when value is missing" do
-      payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "network" => "eip155:8453",
-        "scheme" => "upto",
-        "payerWallet" => "0x1111111111111111111111111111111111111111"
-      }
+      payload =
+        v2_payload("ignored")
+        |> put_in(["payload"], %{"signature" => "0xsignature"})
 
-      requirements = %{"scheme" => "upto", "maxPrice" => "0.01"}
-
-      assert PaymentSignature.validate(payload, requirements) ==
+      assert PaymentSignature.validate(payload, @v2_requirements) ==
                {:error, {:invalid_upto_payment, :missing_payment_value}}
     end
 
-    test "returns invalid_payload for non-map requirements" do
-      payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "network" => "eip155:8453",
-        "scheme" => "upto",
-        "payerWallet" => "0x1111111111111111111111111111111111111111",
-        "value" => "0.01"
-      }
+    test "rejects v1 payloads regardless of requirements" do
+      requirements = %{"scheme" => "exact", "amount" => "10000"}
 
-      assert PaymentSignature.validate(payload, :bad) == {:error, :invalid_payload}
+      assert PaymentSignature.validate(@v1_payload, requirements) ==
+               {:error, {:unsupported_x402_version, 1}}
+    end
+
+    test "returns invalid_payload for non-map requirements" do
+      assert PaymentSignature.validate(v2_payload("9000"), :bad) == {:error, :invalid_payload}
     end
 
     test "matches the complete v2 requirements object" do
@@ -229,14 +192,8 @@ defmodule X402.PaymentSignatureTest do
   end
 
   describe "decode_and_validate/1" do
-    test "returns ok for valid encoded payload" do
-      payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "network" => "eip155:8453",
-        "scheme" => "exact",
-        "payerWallet" => "0x1111111111111111111111111111111111111111"
-      }
-
+    test "returns ok for valid encoded v2 payload" do
+      payload = v2_payload("9000")
       encoded = payload |> Jason.encode!() |> Base.encode64()
 
       assert PaymentSignature.decode_and_validate(encoded) == {:ok, payload}
@@ -246,29 +203,21 @@ defmodule X402.PaymentSignatureTest do
       assert PaymentSignature.decode_and_validate("%%%") == {:error, :invalid_base64}
     end
 
-    test "returns validation errors for missing fields" do
+    test "returns unsupported_x402_version for version-absent payloads" do
       payload = %{"network" => "eip155:8453"}
       encoded = payload |> Jason.encode!() |> Base.encode64()
 
       assert PaymentSignature.decode_and_validate(encoded) ==
-               {:error, {:missing_fields, ["payerWallet", "scheme", "transactionHash"]}}
+               {:error, {:unsupported_x402_version, nil}}
     end
   end
 
   describe "decode_and_validate/2" do
     test "validates upto scheme against requirements" do
-      payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "network" => "eip155:8453",
-        "scheme" => "upto",
-        "payerWallet" => "0x1111111111111111111111111111111111111111",
-        "value" => "0.02"
-      }
-
-      requirements = %{"scheme" => "upto", "maxPrice" => "0.01"}
+      payload = v2_payload("10001")
       encoded = payload |> Jason.encode!() |> Base.encode64()
 
-      assert PaymentSignature.decode_and_validate(encoded, requirements) ==
+      assert PaymentSignature.decode_and_validate(encoded, @v2_requirements) ==
                {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
     end
 

--- a/test/x402/plug/payment_gate_test.exs
+++ b/test/x402/plug/payment_gate_test.exs
@@ -324,6 +324,26 @@ defmodule X402.Plug.PaymentGateTest do
       refute_received {:verify_called, _, _, _}
     end
 
+    test "returns 400 for v2 payloads with an incomplete accepted object" do
+      facilitator = start_mock_facilitator()
+
+      header =
+        valid_payment_payload()
+        |> update_in(["accepted"], &Map.delete(&1, "asset"))
+        |> encode_header()
+
+      conn =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", header)
+        |> run_request(routes: [@route], facilitator: facilitator)
+
+      required = decode_payment_required!(conn)
+
+      assert conn.status == 400
+      assert required["error"] == "invalid_payload"
+      refute_received {:verify_called, _, _, _}
+    end
+
     test "rejects x402Version other than 2 with 400" do
       facilitator = start_mock_facilitator()
 

--- a/test/x402/x402_test.exs
+++ b/test/x402/x402_test.exs
@@ -21,10 +21,17 @@ defmodule X402Test do
 
     test "delegates payment-signature decode and validate" do
       payload = %{
-        "transactionHash" => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "network" => "eip155:8453",
-        "scheme" => "exact",
-        "payerWallet" => "0x1111111111111111111111111111111111111111"
+        "x402Version" => 2,
+        "accepted" => %{
+          "scheme" => "exact",
+          "network" => "eip155:8453",
+          "amount" => "10000",
+          "asset" => "0xasset",
+          "payTo" => "0xreceiver",
+          "maxTimeoutSeconds" => 60,
+          "extra" => %{}
+        },
+        "payload" => %{"signature" => "0xsignature"}
       }
 
       encoded = payload |> Jason.encode!() |> Base.encode64()


### PR DESCRIPTION
The 'v1' path required transactionHash/network/scheme/payerWallet — a
shape matching no published x402 wire format. Real v1 payments carry
{scheme, network, payload: {signature, authorization}} in the X-PAYMENT
header, which this SDK never reads, so the path advertised v1 interop
that was exactly zero while accepting payloads no facilitator settles.
Silent wrongness is worse than absence.

Payloads declaring x402Version: 1 — or omitting the version, as v1
clients do — now fail with {:error, {:unsupported_x402_version, 1 | nil}},
mapped to HTTP 400 by X402.Plug.PaymentGate. Other versions keep
returning :invalid_x402_version. The gate's own v2 guard already blocked
this path for Plug users; this closes it for direct library callers.

Removes ~150 lines of dead validators (required-field, address and tx
hash regex checks) that only that path used.

Ref: docs/ecosystem-comparison.md §8 P0.1 (verified claim matrix/C3)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API for anyone relying on legacy PAYMENT-SIGNATURE shapes or v1/absent-version acceptance; payment validation is security-sensitive but the change fails closed and narrows false positives.
> 
> **Overview**
> **Breaking change:** `X402.PaymentSignature` is **v2-only**. The old path that validated flat `transactionHash` / `payerWallet` fields is removed (~150 lines of validators and `{:invalid_format, _}` errors).
> 
> Payloads with `x402Version: 1` or **no version** now fail with `{:error, {:unsupported_x402_version, 1 | nil}}` instead of being accepted or validated as v1. **v2** behavior is unchanged; `{:missing_fields, _}` still applies to incomplete `accepted` objects.
> 
> `X402.Plug.PaymentGate` maps the new error to **HTTP 400** and the message `"unsupported x402 version"`. Plug still rejects non-v2 versions early via `ensure_v2_payload` (`invalid_x402_version`); this mainly aligns **direct library** callers with explicit rejection rather than false v1 interop.
> 
> Tests and **CHANGELOG** document the removal; convenience delegates now use v2-shaped fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d778dd72c68c32cdf275e8bcdc7e3517a94e66fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->