### PR TITLE
fix!: match gated routes on decoded path_info segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`X402.Plug.PaymentGate` route matching now runs on decoded
+  `conn.path_info` segments instead of the raw `conn.request_path`.**
+  Adapters drop empty path segments when building `path_info`, so
+  `//api/resource` reached the router as the protected resource while the
+  gate's raw string comparison passed it through unpaid — the same bug class
+  as GHSA-3j63-5h8p-gf7c in the legacy TypeScript middleware. Segments are
+  additionally percent-decoded (malformed sequences match verbatim), so the
+  gate also covers routers that decode; a decoded match a router would 404
+  merely answers 402 first, which is the fail-safe direction for a paywall.
+  Regression tests cover double-slash, percent-encoded, encoded-slash, glob,
+  and malformed-percent aliases. Telemetry `path` metadata now reports the
+  decoded path. (Ecosystem report §6.5/§8 P1.4.)
+
 ### Removed
 
 - **The legacy "v1" validation path in `X402.PaymentSignature`.** It required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **`X402.Plug.PaymentGate` route matching now runs on decoded
-  `conn.path_info` segments instead of the raw `conn.request_path`.**
+  `conn.script_name ++ conn.path_info` segments instead of the raw
+  `conn.request_path`.**
   Adapters drop empty path segments when building `path_info`, so
   `//api/resource` reached the router as the protected resource while the
   gate's raw string comparison passed it through unpaid — the same bug class

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -1279,20 +1279,27 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     defp normalize_path("/"), do: "/"
     defp normalize_path(path), do: String.trim_trailing(path, "/")
 
-    # Matching MUST use conn.path_info, not the raw conn.request_path: adapters
-    # drop empty segments when building path_info, so "//premium" reaches the
-    # router as ["premium"] while its request_path stays "//premium" — a raw
-    # string comparison passes the alias through unguarded even though the
-    # router serves the protected resource (the GHSA-3j63-5h8p-gf7c bug class).
-    # Segments are additionally percent-decoded so the gate also covers routers
-    # that decode; when the router does not, a decoded match merely 402s a
-    # request the router would 404 — over-matching is the fail-safe direction
-    # for a paywall. Malformed percent sequences are matched verbatim.
+    # Matching MUST use conn.script_name ++ conn.path_info, not the raw
+    # conn.request_path: adapters drop empty segments when building path_info,
+    # so "//premium" reaches the router as ["premium"] while its request_path
+    # stays "//premium" — a raw string comparison passes the alias through
+    # unguarded even though the router serves the protected resource (the
+    # GHSA-3j63-5h8p-gf7c bug class). script_name must be included because
+    # Plug/Phoenix `forward` pops matched prefix segments from path_info into
+    # script_name — matching on path_info alone would fail open for gates
+    # mounted behind a forwarded prefix whose routes are configured as full
+    # paths. Segments are additionally percent-decoded so the gate also covers
+    # routers that decode; when the router does not, a decoded match merely
+    # 402s a request the router would 404 — over-matching is the fail-safe
+    # direction for a paywall. Malformed percent sequences are matched
+    # verbatim.
     @spec decoded_request_path(Plug.Conn.t()) :: String.t()
-    defp decoded_request_path(%Plug.Conn{path_info: []}), do: "/"
-
-    defp decoded_request_path(%Plug.Conn{path_info: segments}),
-      do: "/" <> Enum.map_join(segments, "/", &decode_segment/1)
+    defp decoded_request_path(%Plug.Conn{script_name: script_name, path_info: path_info}) do
+      case script_name ++ path_info do
+        [] -> "/"
+        segments -> "/" <> Enum.map_join(segments, "/", &decode_segment/1)
+      end
+    end
 
     @spec decode_segment(String.t()) :: String.t()
     defp decode_segment(segment) do

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -389,7 +389,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
         }) do
       if is_nil(payment_identifier_cache), do: warn_no_idempotency_cache_once()
 
-      request_path = normalize_path(conn.request_path)
+      request_path = decoded_request_path(conn)
       request_method = normalize_method(conn.method)
 
       case match_route(routes, request_method, request_path) do
@@ -1278,6 +1278,28 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     @spec normalize_path(String.t()) :: String.t()
     defp normalize_path("/"), do: "/"
     defp normalize_path(path), do: String.trim_trailing(path, "/")
+
+    # Matching MUST use conn.path_info, not the raw conn.request_path: adapters
+    # drop empty segments when building path_info, so "//premium" reaches the
+    # router as ["premium"] while its request_path stays "//premium" — a raw
+    # string comparison passes the alias through unguarded even though the
+    # router serves the protected resource (the GHSA-3j63-5h8p-gf7c bug class).
+    # Segments are additionally percent-decoded so the gate also covers routers
+    # that decode; when the router does not, a decoded match merely 402s a
+    # request the router would 404 — over-matching is the fail-safe direction
+    # for a paywall. Malformed percent sequences are matched verbatim.
+    @spec decoded_request_path(Plug.Conn.t()) :: String.t()
+    defp decoded_request_path(%Plug.Conn{path_info: []}), do: "/"
+
+    defp decoded_request_path(%Plug.Conn{path_info: segments}),
+      do: "/" <> Enum.map_join(segments, "/", &decode_segment/1)
+
+    @spec decode_segment(String.t()) :: String.t()
+    defp decode_segment(segment) do
+      URI.decode(segment)
+    rescue
+      ArgumentError -> segment
+    end
 
     @spec map_to_keyword(map()) :: {:ok, keyword()} | {:error, String.t()}
     defp map_to_keyword(map) do

--- a/test/x402/plug/payment_gate_test.exs
+++ b/test/x402/plug/payment_gate_test.exs
@@ -225,6 +225,79 @@ defmodule X402.Plug.PaymentGateTest do
   end
 
   # ---------------------------------------------------------------------------
+  # Route matching against path aliases — regression tests for the
+  # GHSA-3j63-5h8p-gf7c bug class (route bypass via alternate spellings of a
+  # protected path). Matching runs on decoded conn.path_info segments so the
+  # gate agrees with what the downstream router serves.
+  # ---------------------------------------------------------------------------
+
+  describe "route matching against encoded path aliases" do
+    test "gates a leading-double-slash alias of a protected path" do
+      # Cowboy builds path_info by dropping empty segments, so "//api/resource"
+      # reaches the router as the protected resource while request_path keeps
+      # the raw spelling. Simulate the adapter output directly — Plug.Test
+      # cannot parse a scheme-relative "//" target.
+      conn = %{
+        conn(:get, "/api/resource")
+        | request_path: "//api/resource",
+          path_info: ["api", "resource"]
+      }
+
+      assert run_request(conn, routes: [@route], facilitator: self()).status == 402
+    end
+
+    test "gates a mid-path double-slash alias of a protected path" do
+      conn = %{
+        conn(:get, "/api/resource")
+        | request_path: "/api//resource",
+          path_info: ["api", "resource"]
+      }
+
+      assert run_request(conn, routes: [@route], facilitator: self()).status == 402
+    end
+
+    test "gates a percent-encoded alias of a protected path" do
+      conn = run_request(conn(:get, "/api/re%73ource"), routes: [@route], facilitator: self())
+
+      assert conn.status == 402
+      assert get_resp_header(conn, "payment-required") != []
+    end
+
+    test "gates an encoded-slash alias of a protected path" do
+      conn = run_request(conn(:get, "/api%2Fresource"), routes: [@route], facilitator: self())
+
+      assert conn.status == 402
+    end
+
+    test "gates percent-encoded aliases under glob routes" do
+      route = Map.put(@route, :path, "/api/*")
+      conn = run_request(conn(:get, "/api/%76%31/items"), routes: [route], facilitator: self())
+
+      assert conn.status == 402
+    end
+
+    test "matches malformed percent sequences verbatim without crashing" do
+      passthrough =
+        run_request(conn(:get, "/api/re%zzource"), routes: [@route], facilitator: self())
+
+      assert passthrough.status == 200
+
+      gated_route = Map.put(@route, :path, "/api/re%zzource")
+
+      gated =
+        run_request(conn(:get, "/api/re%zzource"), routes: [gated_route], facilitator: self())
+
+      assert gated.status == 402
+    end
+
+    test "does not gate paths that decode to a different resource" do
+      conn = run_request(conn(:get, "/api/re%73ourceX"), routes: [@route], facilitator: self())
+
+      assert conn.status == 200
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # PaymentRequired (402 signaling) — §5.1 + HTTP transport
   # ---------------------------------------------------------------------------
 

--- a/test/x402/plug/payment_gate_test.exs
+++ b/test/x402/plug/payment_gate_test.exs
@@ -232,6 +232,19 @@ defmodule X402.Plug.PaymentGateTest do
   # ---------------------------------------------------------------------------
 
   describe "route matching against encoded path aliases" do
+    test "gates routes mounted behind a forwarded prefix (script_name)" do
+      # Plug/Phoenix `forward "/api", ...` pops the matched prefix from
+      # path_info into script_name before inner plugs run. Routes configured
+      # as full paths must still match, or forwarded mounts fail open.
+      conn = %{
+        conn(:get, "/api/resource")
+        | script_name: ["api"],
+          path_info: ["resource"]
+      }
+
+      assert run_request(conn, routes: [@route], facilitator: self()).status == 402
+    end
+
     test "gates a leading-double-slash alias of a protected path" do
       # Cowboy builds path_info by dropping empty segments, so "//api/resource"
       # reaches the router as the protected resource while request_path keeps


### PR DESCRIPTION
The gate compared route paths against the raw conn.request_path, while
routers serve requests from conn.path_info — which adapters build by
dropping empty segments. "//api/resource" therefore passed the gate
unmatched (raw string inequality) yet the router served the protected
resource: an unpaid-access bypass, the same bug class as
GHSA-3j63-5h8p-gf7c in the legacy TypeScript middleware, for which we
had zero regression tests.

Matching now runs on path_info segments, percent-decoded per segment
(malformed sequences match verbatim). Decoding over-matches on routers
that serve raw segments; there the gate answers 402 for a request the
router would 404 — the fail-safe direction for a paywall. ResourceInfo
URLs are unaffected (built from Plug.Conn.request_url/1); telemetry
path metadata now reports the decoded path.

Adds regression tests: leading/mid double-slash, percent-encoded,
encoded-slash, glob, malformed-percent aliases, and a
decodes-to-different-resource pass-through.

Ref: docs/ecosystem-comparison.md §6.5, §8 P1.4 (verified security/C6)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes paywall route matching in a security-sensitive plug; incorrect matching could still fail open or over-block legitimate traffic.
> 
> **Overview**
> Fixes an **unpaid-access bypass** where `X402.Plug.PaymentGate` matched routes against raw `conn.request_path` while Plug routers resolve requests from `path_info` (and `script_name` after `forward`). Alternate spellings such as `//api/resource`, mid-path `//`, percent-encoding, or encoded slashes could **miss the gate** yet still hit the protected handler — the same class as **GHSA-3j63-5h8p-gf7c**.
> 
> Route matching now builds the path from **`script_name ++ path_info`**, joins segments, and **percent-decodes** each segment (malformed `%` sequences stay literal). Telemetry **`path` metadata** uses this decoded path; **ResourceInfo URLs** still come from `Plug.Conn.request_url/1`. Where decoding over-matches vs a non-decoding router, the gate prefers **402 over silent pass-through**.
> 
> Adds **regression tests** for forwarded mounts, double-slash aliases, encoding, globs, malformed percent, and decode-to-different-resource pass-through. Documents the fix under **Security** in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e328217f0c940f67bd4e0c8fe5d9417a16f4e70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->