### PR TITLE
feat: add put_new to the payment identifier Cache behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behaviour contract (TTL semantics and return values documented), so
   alternative adapters (Redis, Mnesia, database-backed) can be plugged into
   `X402.Plug.PaymentGate`; the cache moduledoc includes a Redis `SET NX PX`
-  adapter sketch
+  adapter sketch. The contract forbids evicting live entries to admit a new
+  claim: at capacity, `ETSCache.put_new/3` now purges expired entries and
+  otherwise refuses with `{:error, :cache_full}` (the gate fails closed) —
+  previously it evicted the soonest-expiring live claim, which let cheap junk
+  claims drop legitimate replay locks
+- `X402.Plug.PaymentGate` `payment_identifier_cache:` accepts `{:global, name}`
+  and `{:via, registry, term}` GenServer names, normalized to the bundled
+  `ETSCache` adapter like a bare pid/name
 - `X402.Plug.PaymentGate` `payment_identifier_cache:` now also accepts a
   `{module, cache}` adapter tuple implementing
   `X402.Extensions.PaymentIdentifier.Cache`; a bare pid/name keeps working and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the facilitator; payloads without an authorization object (other schemes,
   Permit2) and absent fields are skipped, so the facilitator remains the
   authority. (Ecosystem report §6.6.4/§8 P1.2.)
+- `put_new/3` callback on `X402.Extensions.PaymentIdentifier.Cache` — the
+  atomic first-writer-wins claim used for replay protection is now part of the
+  behaviour contract (TTL semantics and return values documented), so
+  alternative adapters (Redis, Mnesia, database-backed) can be plugged into
+  `X402.Plug.PaymentGate`; the cache moduledoc includes a Redis `SET NX PX`
+  adapter sketch
+- `X402.Plug.PaymentGate` `payment_identifier_cache:` now also accepts a
+  `{module, cache}` adapter tuple implementing
+  `X402.Extensions.PaymentIdentifier.Cache`; a bare pid/name keeps working and
+  is normalized to the bundled `ETSCache` adapter
+
+### Changed
+
+- `X402.Plug.PaymentGate` routes all replay claim/release calls through the
+  `X402.Extensions.PaymentIdentifier.Cache` behaviour instead of calling
+  `ETSCache` directly; adapter claim errors other than
+  `{:error, :already_exists}` fail closed with HTTP 500
+- Implementations of `X402.Extensions.PaymentIdentifier.Cache` must now export
+  `put_new/3`; `validate_adapter/1` rejects adapters without it
+
+### Documentation
+
+- Documented the clustered-BEAM double-execution hazard of the per-node ETS
+  replay cache in the `PaymentGate`, `Cache`, and `ETSCache` moduledocs
 
 ### Security
 

--- a/lib/x402/extensions/payment_identifier/cache.ex
+++ b/lib/x402/extensions/payment_identifier/cache.ex
@@ -4,7 +4,89 @@ defmodule X402.Extensions.PaymentIdentifier.Cache do
 
   Cache adapters are configured as `{module, cache}` tuples where `module`
   implements this behaviour and `cache` is adapter-specific runtime state
-  (for example, a pid or registered process name).
+  (for example, a pid, a registered process name, or a connection handle).
+
+  `X402.Plug.PaymentGate` routes all replay-protection calls through this
+  behaviour. The claim that prevents a payment proof from being settled twice
+  is `c:put_new/3`, so every adapter must implement it with **atomic
+  first-writer-wins semantics**: when several processes race to claim the same
+  payment identifier, exactly one call may return `:ok` and all others must
+  return `{:error, :already_exists}`.
+
+  ## Clustered deployments: double-execution hazard
+
+  > #### Per-node caches do not protect a cluster {: .warning}
+  >
+  > The bundled `X402.Extensions.PaymentIdentifier.ETSCache` adapter stores
+  > claims in a **per-node ETS table**. In a clustered BEAM deployment every
+  > node keeps its own table, so a replayed payment proof routed to two
+  > different nodes is claimed independently on each — the protected handler
+  > (and its side effects) can run **once per node** for a single payment.
+  > The facilitator may still reject the duplicate settlement, but by then the
+  > resource has already been served twice.
+  >
+  > If you run more than one node, supply an adapter backed by a shared store
+  > (Redis, Mnesia, your database) instead of the default ETS adapter.
+
+  ## Writing a distributed adapter
+
+  `c:put_new/3` must combine "insert if absent" and "expire after TTL" in a
+  single atomic operation of the backing store. In Redis that operation is
+  `SET key value NX PX ttl`. A minimal adapter sketch:
+
+      defmodule MyApp.RedisPaymentCache do
+        @behaviour X402.Extensions.PaymentIdentifier.Cache
+
+        @ttl_ms :timer.hours(1)
+
+        @impl true
+        def put_new(conn, payment_id, value) do
+          # SET ... NX PX — atomic first-writer-wins with TTL in one command.
+          case Redix.command(conn, ["SET", key(payment_id), encode(value), "NX", "PX", @ttl_ms]) do
+            {:ok, "OK"} -> :ok
+            {:ok, nil} -> {:error, :already_exists}
+            {:error, reason} -> {:error, reason}
+          end
+        end
+
+        @impl true
+        def put(conn, payment_id, value) do
+          case Redix.command(conn, ["SET", key(payment_id), encode(value), "PX", @ttl_ms]) do
+            {:ok, "OK"} -> :ok
+            {:error, reason} -> {:error, reason}
+          end
+        end
+
+        @impl true
+        def get(conn, payment_id) do
+          case Redix.command(conn, ["GET", key(payment_id)]) do
+            {:ok, nil} -> :miss
+            {:ok, encoded} -> {:hit, decode(encoded)}
+            {:error, reason} -> {:error, reason}
+          end
+        end
+
+        @impl true
+        def delete(conn, payment_id) do
+          case Redix.command(conn, ["DEL", key(payment_id)]) do
+            {:ok, _count} -> :ok
+            {:error, reason} -> {:error, reason}
+          end
+        end
+
+        defp key(payment_id), do: "x402:payment:" <> payment_id
+        # encode/1 and decode/1 map `:verified | {:rejected, reason}` to a
+        # string representation of your choice.
+      end
+
+  Configure it on the gate as:
+
+      plug X402.Plug.PaymentGate,
+        payment_identifier_cache: {MyApp.RedisPaymentCache, MyApp.Redis},
+        routes: [...]
+
+  Adapter errors other than `{:error, :already_exists}` fail closed: the gate
+  responds with HTTP 500 and the protected handler does not run.
   """
 
   alias X402.Extensions.PaymentIdentifier
@@ -24,11 +106,47 @@ defmodule X402.Extensions.PaymentIdentifier.Cache do
   @typedoc "Result returned by write/delete operations."
   @type write_result :: :ok | {:error, term()}
 
+  @typedoc "Result returned by `put_new/3`."
+  @type put_new_result :: :ok | {:error, :already_exists} | {:error, term()}
+
+  @doc """
+  Reads the value stored for `key`, or `:miss` when absent or expired.
+  """
   @callback get(cache :: term(), key()) :: get_result()
+
+  @doc """
+  Unconditionally stores `value` for `key`, resetting its TTL.
+  """
   @callback put(cache :: term(), key(), value()) :: write_result()
+
+  @doc """
+  Atomically stores `value` for `key` only when no live entry exists.
+
+  This is the replay-protection claim used by `X402.Plug.PaymentGate`, and it
+  must be **atomic first-writer-wins**: under concurrent calls with the same
+  `key`, exactly one caller receives `:ok` and every other caller receives
+  `{:error, :already_exists}`. Checking existence and inserting in two
+  separate store operations is not acceptable — use the backing store's
+  atomic primitive (`:ets.insert_new/2`, Redis `SET NX PX`, an `INSERT` with
+  a unique constraint, and so on).
+
+  The entry must expire after the adapter's TTL; an expired entry must not
+  block a new claim for the same `key`. Return `{:error, :already_exists}`
+  only for a live (non-expired) duplicate — any other `{:error, reason}` is
+  treated as an adapter failure and fails the request closed.
+  """
+  @callback put_new(cache :: term(), key(), value()) :: put_new_result()
+
+  @doc """
+  Removes the entry for `key`, releasing a previously successful claim.
+  """
   @callback delete(cache :: term(), key()) :: write_result()
 
-  @required_callbacks [get: 2, put: 3, delete: 2]
+  @required_callbacks [get: 2, put: 3, put_new: 3, delete: 2]
+
+  @adapter_error "expected a cache adapter tuple {module, cache} where module " <>
+                   "implements the X402.Extensions.PaymentIdentifier.Cache callbacks " <>
+                   "get/2, put/3, put_new/3, and delete/2"
 
   @doc since: "0.1.0"
   @doc """
@@ -38,11 +156,11 @@ defmodule X402.Extensions.PaymentIdentifier.Cache do
   def validate_adapter({module, _cache}) when is_atom(module) do
     case implementation?(module) do
       true -> :ok
-      false -> {:error, "expected a cache adapter tuple {module, cache}"}
+      false -> {:error, @adapter_error}
     end
   end
 
-  def validate_adapter(_invalid), do: {:error, "expected a cache adapter tuple {module, cache}"}
+  def validate_adapter(_invalid), do: {:error, @adapter_error}
 
   @doc since: "0.1.0"
   @doc """
@@ -75,6 +193,21 @@ defmodule X402.Extensions.PaymentIdentifier.Cache do
   end
 
   def put(_adapter, _payment_id, _value), do: {:error, :invalid_adapter}
+
+  @doc since: "0.6.0"
+  @doc """
+  Atomically claims a payment identifier through the adapter's `c:put_new/3`.
+
+  Returns `:ok` when this caller won the claim, `{:error, :already_exists}`
+  when a live entry already holds it, or `{:error, reason}` on adapter
+  failure. See `c:put_new/3` for the atomicity contract.
+  """
+  @spec put_new(adapter(), key(), value()) :: put_new_result()
+  def put_new({module, cache}, payment_id, value) when is_binary(payment_id) do
+    module.put_new(cache, payment_id, value)
+  end
+
+  def put_new(_adapter, _payment_id, _value), do: {:error, :invalid_adapter}
 
   @doc since: "0.1.0"
   @doc """

--- a/lib/x402/extensions/payment_identifier/cache.ex
+++ b/lib/x402/extensions/payment_identifier/cache.ex
@@ -107,7 +107,8 @@ defmodule X402.Extensions.PaymentIdentifier.Cache do
   @type write_result :: :ok | {:error, term()}
 
   @typedoc "Result returned by `put_new/3`."
-  @type put_new_result :: :ok | {:error, :already_exists} | {:error, term()}
+  @type put_new_result ::
+          :ok | {:error, :already_exists} | {:error, :cache_full} | {:error, term()}
 
   @doc """
   Reads the value stored for `key`, or `:miss` when absent or expired.
@@ -131,7 +132,10 @@ defmodule X402.Extensions.PaymentIdentifier.Cache do
   a unique constraint, and so on).
 
   The entry must expire after the adapter's TTL; an expired entry must not
-  block a new claim for the same `key`. Return `{:error, :already_exists}`
+  block a new claim for the same `key`. An adapter with bounded capacity must
+  **never evict a live entry to admit a new claim** — a live claim is another
+  payment's replay lock; refuse with `{:error, :cache_full}` instead
+  (`X402.Plug.PaymentGate` fails closed on it). Return `{:error, :already_exists}`
   only for a live (non-expired) duplicate — any other `{:error, reason}` is
   treated as an adapter failure and fails the request closed.
   """

--- a/lib/x402/extensions/payment_identifier/ets_cache.ex
+++ b/lib/x402/extensions/payment_identifier/ets_cache.ex
@@ -148,10 +148,15 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCache do
   Returns `:ok` if the entry was inserted, or `{:error, :already_exists}` if
   a non-expired entry for `payment_id` is already present. This is used to
   prevent concurrent requests from double-settling the same payment proof.
+
+  When the table is at `:max_size` and purging expired entries does not free a
+  slot, returns `{:error, :cache_full}` instead of evicting a live claim —
+  evicting live claims would let cheap junk claims drop legitimate replay
+  locks. Size `:max_size` for your expected claim TTL × request rate.
   """
   @impl Cache
   @spec put_new(server(), Cache.key(), Cache.value()) ::
-          :ok | {:error, :already_exists | :invalid_cache_value}
+          :ok | {:error, :already_exists | :cache_full | :invalid_cache_value}
   def put_new(cache, payment_id, value) when is_binary(payment_id) do
     case valid_value?(value) do
       true -> GenServer.call(cache, {:put_new, payment_id, value})
@@ -249,18 +254,31 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCache do
       _ -> :ok
     end
 
-    # Enforce max_size — unlike `put`, the original put_new had no capacity
-    # check, allowing the cache to grow without bound under concurrent load.
-    if :ets.info(state.table, :size) >= state.max_size and
-         not :ets.member(state.table, payment_id) do
-      evict_soonest_expiry(state.table)
+    # Enforce max_size WITHOUT ever evicting a live entry. A claim protects a
+    # payment that is in flight or already settled; admitting a new claim by
+    # dropping another payer's live claim would let cheap junk claims (unique
+    # headers that later fail facilitator verification) evict legitimate
+    # replay locks and reopen double-delivery. Purge expired entries; if the
+    # table is still full, refuse the claim — the gate fails closed on this
+    # error, degrading to denial of new paid requests rather than replay.
+    if at_capacity?(state, payment_id) do
+      delete_expired_entries(state.table, now)
     end
 
-    # ets.insert_new is atomic — only one concurrent process wins the race.
-    case :ets.insert_new(state.table, {payment_id, value, expires_at_ms}) do
-      true -> {:reply, :ok, state}
-      false -> {:reply, {:error, :already_exists}, state}
-    end
+    reply =
+      cond do
+        at_capacity?(state, payment_id) ->
+          {:error, :cache_full}
+
+        # ets.insert_new is atomic — only one concurrent process wins the race.
+        :ets.insert_new(state.table, {payment_id, value, expires_at_ms}) ->
+          :ok
+
+        true ->
+          {:error, :already_exists}
+      end
+
+    {:reply, reply, state}
   end
 
   def handle_call({:delete, payment_id}, _from, state) do
@@ -280,6 +298,12 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCache do
   @spec schedule_cleanup(pos_integer()) :: reference()
   defp schedule_cleanup(cleanup_interval_ms) do
     Process.send_after(self(), :cleanup, cleanup_interval_ms)
+  end
+
+  @spec at_capacity?(state(), term()) :: boolean()
+  defp at_capacity?(state, payment_id) do
+    :ets.info(state.table, :size) >= state.max_size and
+      not :ets.member(state.table, payment_id)
   end
 
   @spec evict_soonest_expiry(:ets.tid() | atom()) :: true

--- a/lib/x402/extensions/payment_identifier/ets_cache.ex
+++ b/lib/x402/extensions/payment_identifier/ets_cache.ex
@@ -4,6 +4,15 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCache do
 
   Entries expire after `:ttl_ms` (default: 1 hour). Expired entries are removed
   by an internal periodic cleanup loop.
+
+  > #### Per-node only {: .warning}
+  >
+  > The ETS table lives on the local node. In a clustered BEAM deployment each
+  > node keeps its own independent table, so this adapter cannot prevent the
+  > same payment proof from being served once per node. See the
+  > "Clustered deployments" section in
+  > `X402.Extensions.PaymentIdentifier.Cache` for a shared-store adapter
+  > sketch.
   """
 
   use GenServer
@@ -140,6 +149,7 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCache do
   a non-expired entry for `payment_id` is already present. This is used to
   prevent concurrent requests from double-settling the same payment proof.
   """
+  @impl Cache
   @spec put_new(server(), Cache.key(), Cache.value()) ::
           :ok | {:error, :already_exists | :invalid_cache_value}
   def put_new(cache, payment_id, value) when is_binary(payment_id) do

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -343,6 +343,16 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
             {:ok, Cache.adapter() | nil} | {:error, String.t()}
     def validate_payment_identifier_cache(nil), do: {:ok, nil}
 
+    # {:global, name} and {:via, registry, term} are unambiguous GenServer
+    # names, never adapter tuples — route them to the default ETSCache adapter
+    # like a bare pid/name.
+    def validate_payment_identifier_cache({:global, _name} = server),
+      do: {:ok, {ETSCache, server}}
+
+    def validate_payment_identifier_cache({:via, registry, _term} = server)
+        when is_atom(registry),
+        do: {:ok, {ETSCache, server}}
+
     def validate_payment_identifier_cache({module, _cache} = adapter) when is_atom(module) do
       case Cache.validate_adapter(adapter) do
         :ok ->

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -29,10 +29,30 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     [x402 v2 specification](https://github.com/x402-foundation/x402/blob/main/specs/x402-specification-v2.md)
     and
     [HTTP transport](https://github.com/x402-foundation/x402/blob/main/specs/transports-v2/http.md).
+
+    ## Replay protection
+
+    When `:payment_identifier_cache` is configured, the gate claims the SHA-256
+    hash of the raw `PAYMENT-SIGNATURE` header through the
+    `X402.Extensions.PaymentIdentifier.Cache` behaviour before settling.
+    Duplicate proofs are rejected with **402** and the claim is released when
+    the protected handler responds with a status >= 400 or settlement fails,
+    so clients may retry a payment whose resource was never delivered.
+
+    > #### Clustered deployments can serve one payment twice {: .warning}
+    >
+    > The default `X402.Extensions.PaymentIdentifier.ETSCache` adapter is
+    > **per-node**: every node in a cluster keeps its own claim table, so a
+    > replayed proof load-balanced onto two nodes runs the protected handler on
+    > each of them even though only one settlement can ultimately succeed. If
+    > you deploy more than one node, configure a shared-store adapter instead —
+    > see the "Writing a distributed adapter" section in
+    > `X402.Extensions.PaymentIdentifier.Cache` for a Redis sketch.
     """
 
     @behaviour Plug
 
+    alias X402.Extensions.PaymentIdentifier.Cache
     alias X402.Extensions.PaymentIdentifier.ETSCache
     alias X402.Facilitator
     alias X402.Facilitator.Error
@@ -218,13 +238,19 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
         doc: "Lifecycle hook module implementing `X402.Hooks`."
       ],
       payment_identifier_cache: [
-        type: {:or, [:atom, :pid, :any]},
+        type: {:custom, __MODULE__, :validate_payment_identifier_cache, []},
         default: nil,
         doc: """
-        Optional `ETSCache` server pid/name used for idempotency. When set,
-        the plug performs an atomic claim (via `put_new`) on the payment proof
-        hash before settling, preventing concurrent requests from double-settling
-        the same payment.
+        Optional idempotency cache used for replay protection. Accepts either
+        an `ETSCache` server pid/name (the default adapter), or a
+        `{module, cache}` adapter tuple where `module` implements
+        `X402.Extensions.PaymentIdentifier.Cache` and `cache` is passed to its
+        callbacks (for example `{MyApp.RedisPaymentCache, MyApp.Redis}`).
+        When set, the plug performs an atomic claim (via the adapter's
+        `put_new/3`) on the payment proof hash before settling, preventing
+        concurrent requests from double-settling the same payment. The default
+        ETS adapter is per-node — see the "Replay protection" section above
+        for the clustering hazard.
         """
       ],
       routes: [
@@ -252,7 +278,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     @type options :: %{
             facilitator: Facilitator.server(),
             hooks: module(),
-            payment_identifier_cache: ETSCache.server() | nil,
+            payment_identifier_cache: Cache.adapter() | nil,
             routes: [compiled_route()],
             local_prechecks: boolean()
           }
@@ -287,7 +313,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     @type settlement_context :: %{
             facilitator: Facilitator.server(),
             hooks: module(),
-            payment_identifier_cache: ETSCache.server() | nil,
+            payment_identifier_cache: Cache.adapter() | nil,
             payment_id: String.t(),
             payment_payload: map(),
             requirements: map(),
@@ -311,6 +337,26 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     end
 
     def validate_atomic_amount(_value), do: {:error, "expected a digit-only atomic-unit amount"}
+
+    @doc false
+    @spec validate_payment_identifier_cache(term()) ::
+            {:ok, Cache.adapter() | nil} | {:error, String.t()}
+    def validate_payment_identifier_cache(nil), do: {:ok, nil}
+
+    def validate_payment_identifier_cache({module, _cache} = adapter) when is_atom(module) do
+      case Cache.validate_adapter(adapter) do
+        :ok ->
+          {:ok, adapter}
+
+        {:error, message} ->
+          {:error,
+           message <>
+             "; to address a remote ETSCache as {name, node}, wrap it explicitly: " <>
+             "{X402.Extensions.PaymentIdentifier.ETSCache, {name, node}}"}
+      end
+    end
+
+    def validate_payment_identifier_cache(server), do: {:ok, {ETSCache, server}}
 
     @doc false
     @spec validate_route(term()) :: {:ok, map()} | {:error, String.t()}
@@ -758,17 +804,16 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
       end
     end
 
-    @spec claim_payment(ETSCache.server() | nil, String.t()) ::
-            :ok | {:error, :already_exists}
+    @spec claim_payment(Cache.adapter() | nil, String.t()) :: Cache.put_new_result()
     defp claim_payment(nil, _payment_id), do: :ok
 
-    defp claim_payment(cache, payment_id) do
-      ETSCache.put_new(cache, payment_id, :verified)
+    defp claim_payment(adapter, payment_id) do
+      Cache.put_new(adapter, payment_id, :verified)
     end
 
-    @spec release_claim(ETSCache.server() | nil, String.t()) :: :ok | {:error, term()}
+    @spec release_claim(Cache.adapter() | nil, String.t()) :: Cache.write_result()
     defp release_claim(nil, _payment_id), do: :ok
-    defp release_claim(cache, payment_id), do: ETSCache.delete(cache, payment_id)
+    defp release_claim(adapter, payment_id), do: Cache.delete(adapter, payment_id)
 
     @spec facilitator_verify(Facilitator.server(), map(), map(), module()) ::
             Facilitator.response()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
+Mox.defmock(X402.PaymentIdentifierCacheMock, for: X402.Extensions.PaymentIdentifier.Cache)
+
 ExUnit.start(exclude: [:smoke])

--- a/test/x402/extensions/payment_identifier/cache_test.exs
+++ b/test/x402/extensions/payment_identifier/cache_test.exs
@@ -2,6 +2,7 @@ defmodule X402.Extensions.PaymentIdentifier.CacheTest do
   use ExUnit.Case, async: true
 
   alias X402.Extensions.PaymentIdentifier.Cache
+  alias X402.Extensions.PaymentIdentifier.ETSCache
 
   defmodule ValidCache do
     @moduledoc false
@@ -20,6 +21,12 @@ defmodule X402.Extensions.PaymentIdentifier.CacheTest do
     end
 
     @impl Cache
+    def put_new(owner, payment_id, value) do
+      send(owner, {:cache_put_new, payment_id, value})
+      :ok
+    end
+
+    @impl Cache
     def delete(owner, payment_id) do
       send(owner, {:cache_delete, payment_id})
       :ok
@@ -32,8 +39,19 @@ defmodule X402.Extensions.PaymentIdentifier.CacheTest do
     def get(_cache, _payment_id), do: :miss
   end
 
+  defmodule LegacyCache do
+    @moduledoc false
+    # Implements the pre-0.6.0 callback set without put_new/3 — no longer a
+    # complete adapter, because the gate's replay claim goes through put_new.
+
+    def get(_cache, _payment_id), do: :miss
+    def put(_cache, _payment_id, _value), do: :ok
+    def delete(_cache, _payment_id), do: :ok
+  end
+
   test "validate_adapter/1 accepts behaviour implementations" do
     assert :ok = Cache.validate_adapter({ValidCache, self()})
+    assert :ok = Cache.validate_adapter({ETSCache, self()})
   end
 
   test "validate_adapter/1 rejects invalid adapter values" do
@@ -41,12 +59,17 @@ defmodule X402.Extensions.PaymentIdentifier.CacheTest do
     assert {:error, _message} = Cache.validate_adapter(:invalid)
   end
 
+  test "validate_adapter/1 rejects adapters without put_new/3" do
+    assert {:error, message} = Cache.validate_adapter({LegacyCache, self()})
+    assert message =~ "put_new/3"
+  end
+
   test "validate_optional_adapter/1 allows nil and valid adapters" do
     assert :ok = Cache.validate_optional_adapter(nil)
     assert :ok = Cache.validate_optional_adapter({ValidCache, self()})
   end
 
-  test "get/2, put/3, and delete/2 dispatch to adapter module" do
+  test "get/2, put/3, put_new/3, and delete/2 dispatch to adapter module" do
     adapter = {ValidCache, self()}
 
     assert :miss = Cache.get(adapter, "payment-1")
@@ -55,6 +78,9 @@ defmodule X402.Extensions.PaymentIdentifier.CacheTest do
     assert :ok = Cache.put(adapter, "payment-1", :verified)
     assert_receive {:cache_put, "payment-1", :verified}
 
+    assert :ok = Cache.put_new(adapter, "payment-1", :verified)
+    assert_receive {:cache_put_new, "payment-1", :verified}
+
     assert :ok = Cache.delete(adapter, "payment-1")
     assert_receive {:cache_delete, "payment-1"}
   end
@@ -62,6 +88,7 @@ defmodule X402.Extensions.PaymentIdentifier.CacheTest do
   test "returns invalid adapter errors for malformed adapter tuples" do
     assert {:error, :invalid_adapter} = Cache.get(:invalid, "payment-1")
     assert {:error, :invalid_adapter} = Cache.put(:invalid, "payment-1", :verified)
+    assert {:error, :invalid_adapter} = Cache.put_new(:invalid, "payment-1", :verified)
     assert {:error, :invalid_adapter} = Cache.delete(:invalid, "payment-1")
   end
 end

--- a/test/x402/extensions/payment_identifier/ets_cache_security_test.exs
+++ b/test/x402/extensions/payment_identifier/ets_cache_security_test.exs
@@ -43,6 +43,50 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCacheSecurityTest do
     assert {:hit, :verified} = ETSCache.get(cache, "payment-1")
   end
 
+  test "put_new refuses new claims at capacity instead of evicting live claims" do
+    max_size = 5
+    cache = start_cache(max_size: max_size)
+
+    # Fill the cache with live claims (an attacker's junk claims, or simply a
+    # busy gate) up to capacity.
+    for i <- 1..max_size do
+      assert :ok = ETSCache.put_new(cache, "claim-#{i}", :verified)
+    end
+
+    # A new claim must be refused — never admitted by dropping another
+    # payment's live replay lock (that would reopen double-delivery under
+    # claim-before-verify junk floods).
+    assert {:error, :cache_full} = ETSCache.put_new(cache, "victim-claim", :verified)
+
+    # Every original claim survives untouched.
+    for i <- 1..max_size do
+      assert {:hit, :verified} = ETSCache.get(cache, "claim-#{i}")
+    end
+
+    # Re-claiming an existing id still reports the duplicate, not capacity.
+    assert {:error, :already_exists} = ETSCache.put_new(cache, "claim-1", :verified)
+
+    # Releasing a claim frees a slot for the next claim.
+    assert :ok = ETSCache.delete(cache, "claim-1")
+    assert :ok = ETSCache.put_new(cache, "victim-claim", :verified)
+  end
+
+  test "put_new at capacity purges expired entries before refusing" do
+    max_size = 3
+    cache = start_cache(max_size: max_size, ttl_ms: 30)
+
+    for i <- 1..max_size do
+      assert :ok = ETSCache.put_new(cache, "claim-#{i}", :verified)
+    end
+
+    # Let the claims expire; the periodic cleanup has not run yet
+    # (cleanup_interval_ms is 60s), so the purge inside put_new must free the
+    # slots on its own.
+    Process.sleep(60)
+
+    assert :ok = ETSCache.put_new(cache, "fresh-claim", :verified)
+  end
+
   defp start_cache(opts) do
     name = String.to_atom("ets_cache_security_#{System.unique_integer([:positive, :monotonic])}")
     options = Keyword.merge([name: name, cleanup_interval_ms: 60_000], opts)

--- a/test/x402/extensions/payment_identifier/ets_cache_test.exs
+++ b/test/x402/extensions/payment_identifier/ets_cache_test.exs
@@ -1,7 +1,35 @@
 defmodule X402.Extensions.PaymentIdentifier.ETSCacheTest do
   use ExUnit.Case, async: false
 
+  alias X402.Extensions.PaymentIdentifier.Cache
   alias X402.Extensions.PaymentIdentifier.ETSCache
+
+  test "conforms to the Cache behaviour, including put_new/3" do
+    behaviours =
+      ETSCache.module_info(:attributes)
+      |> Keyword.get_values(:behaviour)
+      |> List.flatten()
+
+    assert Cache in behaviours
+    assert X402.Behaviour.implements?(ETSCache, get: 2, put: 3, put_new: 3, delete: 2)
+    assert :ok = Cache.validate_adapter({ETSCache, ETSCache})
+  end
+
+  test "put_new/3 lets exactly one of many concurrent claimants win" do
+    cache = start_cache(ttl_ms: 60_000)
+
+    results =
+      1..50
+      |> Task.async_stream(
+        fn _index -> ETSCache.put_new(cache, "contested-payment", :verified) end,
+        max_concurrency: 50,
+        ordered: false
+      )
+      |> Enum.map(fn {:ok, result} -> result end)
+
+    assert Enum.count(results, &(&1 == :ok)) == 1
+    assert Enum.count(results, &(&1 == {:error, :already_exists})) == 49
+  end
 
   test "put/3 and get/2 store and retrieve verified entries" do
     cache = start_cache(ttl_ms: 1_000)

--- a/test/x402/extensions/payment_identifier/ets_cache_test.exs
+++ b/test/x402/extensions/payment_identifier/ets_cache_test.exs
@@ -118,18 +118,20 @@ defmodule X402.Extensions.PaymentIdentifier.ETSCacheTest do
     assert {:hit, :verified} = ETSCache.get(cache, "payment-1")
   end
 
-  test "put_new/3 evicts the soonest-expiring entry when at max_size" do
+  test "put_new/3 refuses new entries at max_size without evicting live claims" do
     cache = start_cache(ttl_ms: 1_000, max_size: 2)
 
     assert :ok = ETSCache.put_new(cache, "payment-1", :verified)
     assert :ok = ETSCache.put_new(cache, "payment-2", :verified)
 
-    # Adding a third entry must succeed (evicts one of the existing entries).
-    assert :ok = ETSCache.put_new(cache, "payment-3", :verified)
+    # A live claim is another payment's replay lock — never evict it to admit
+    # a new claim; refuse instead (the gate fails closed on this error).
+    assert {:error, :cache_full} = ETSCache.put_new(cache, "payment-3", :verified)
 
     %{table: table} = :sys.get_state(cache)
     assert :ets.info(table, :size) == 2
-    assert {:hit, :verified} = ETSCache.get(cache, "payment-3")
+    assert {:hit, :verified} = ETSCache.get(cache, "payment-1")
+    assert {:hit, :verified} = ETSCache.get(cache, "payment-2")
   end
 
   defp start_cache(opts) do

--- a/test/x402/plug/payment_gate_test.exs
+++ b/test/x402/plug/payment_gate_test.exs
@@ -19,10 +19,14 @@ defmodule X402.Plug.PaymentGateTest do
   use ExUnit.Case, async: false
   doctest X402.Plug.PaymentGate
 
+  import Mox
   import Plug.Conn
   import Plug.Test
 
   alias X402.Extensions.PaymentIdentifier.ETSCache
+  alias X402.PaymentIdentifierCacheMock, as: CacheMock
+
+  setup :verify_on_exit!
   alias X402.Facilitator
   alias X402.Facilitator.Error
   alias X402.PaymentRequired
@@ -1035,6 +1039,204 @@ defmodule X402.Plug.PaymentGateTest do
     end
   end
 
+  # ---------------------------------------------------------------------------
+  # Replay protection through the Cache behaviour
+  # ---------------------------------------------------------------------------
+
+  describe "payment identifier cache adapters" do
+    test "init/1 wraps a pid or name in the default ETSCache adapter" do
+      pid = self()
+      name = :payment_gate_cache_compat
+
+      assert %{payment_identifier_cache: {ETSCache, ^pid}} =
+               PaymentGate.init(routes: [@route], payment_identifier_cache: pid)
+
+      assert %{payment_identifier_cache: {ETSCache, ^name}} =
+               PaymentGate.init(routes: [@route], payment_identifier_cache: name)
+
+      assert %{payment_identifier_cache: nil} = PaymentGate.init(routes: [@route])
+    end
+
+    test "init/1 accepts a {module, cache} adapter tuple as-is" do
+      assert %{payment_identifier_cache: {CacheMock, :mock_ref}} =
+               PaymentGate.init(
+                 routes: [@route],
+                 payment_identifier_cache: {CacheMock, :mock_ref}
+               )
+    end
+
+    test "init/1 rejects adapter tuples whose module misses callbacks" do
+      assert_raise NimbleOptions.ValidationError, ~r/put_new\/3/, fn ->
+        PaymentGate.init(
+          routes: [@route],
+          payment_identifier_cache: {X402.Extensions.PaymentIdentifier, :ref}
+        )
+      end
+    end
+
+    test "claims through a custom adapter and releases when the handler fails" do
+      facilitator = start_mock_facilitator()
+      parent = self()
+
+      expect(CacheMock, :put_new, fn :mock_ref, payment_id, :verified ->
+        send(parent, {:adapter_put_new, payment_id})
+        :ok
+      end)
+
+      expect(CacheMock, :delete, fn :mock_ref, payment_id ->
+        send(parent, {:adapter_delete, payment_id})
+        :ok
+      end)
+
+      response_conn =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", valid_payment_header())
+        |> gate_request(
+          routes: [@route],
+          facilitator: facilitator,
+          payment_identifier_cache: {CacheMock, :mock_ref}
+        )
+        |> Plug.Conn.send_resp(500, "handler failed")
+
+      assert response_conn.status == 500
+      assert_receive {:adapter_put_new, payment_id}
+      assert_receive {:adapter_delete, ^payment_id}
+      refute_received {:settle_called, _, _, _}
+    end
+
+    test "releases the claim through the adapter when settlement fails" do
+      settle_body = %{
+        "success" => false,
+        "errorReason" => "insufficient_funds",
+        "transaction" => "",
+        "network" => @network
+      }
+
+      facilitator = start_mock_facilitator(settle: {:ok, %{status: 200, body: settle_body}})
+      parent = self()
+
+      expect(CacheMock, :put_new, fn :mock_ref, _payment_id, :verified -> :ok end)
+
+      expect(CacheMock, :delete, fn :mock_ref, payment_id ->
+        send(parent, {:adapter_delete, payment_id})
+        :ok
+      end)
+
+      conn =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", valid_payment_header())
+        |> run_request(
+          routes: [@route],
+          facilitator: facilitator,
+          payment_identifier_cache: {CacheMock, :mock_ref}
+        )
+
+      assert conn.status == 402
+      assert_receive {:adapter_delete, _payment_id}
+    end
+
+    test "rejects a duplicate claim from a custom adapter with 402" do
+      facilitator = start_mock_facilitator()
+
+      expect(CacheMock, :put_new, fn :mock_ref, _payment_id, :verified ->
+        {:error, :already_exists}
+      end)
+
+      conn =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", valid_payment_header())
+        |> run_request(
+          routes: [@route],
+          facilitator: facilitator,
+          payment_identifier_cache: {CacheMock, :mock_ref}
+        )
+
+      assert conn.status == 402
+      assert decode_payment_required!(conn)["error"] == "payment already processed"
+      refute_received {:settle_called, _, _, _}
+    end
+
+    test "fails closed with 500 when the adapter claim errors" do
+      facilitator = start_mock_facilitator()
+
+      expect(CacheMock, :put_new, fn :mock_ref, _payment_id, :verified ->
+        {:error, :backend_unavailable}
+      end)
+
+      conn =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", valid_payment_header())
+        |> run_request(
+          routes: [@route],
+          facilitator: facilitator,
+          payment_identifier_cache: {CacheMock, :mock_ref}
+        )
+
+      assert conn.status == 500
+      refute_received {:settle_called, _, _, _}
+    end
+
+    test "rejects duplicate payment proofs with the default ETS adapter" do
+      facilitator = start_mock_facilitator()
+      cache = start_supervised!({ETSCache, name: unique_cache_name()})
+      header = valid_payment_header()
+
+      first =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", header)
+        |> run_request(
+          routes: [@route],
+          facilitator: facilitator,
+          payment_identifier_cache: cache
+        )
+
+      assert first.status == 200
+      assert_receive {:settle_called, _, _, _}
+
+      duplicate =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", header)
+        |> run_request(
+          routes: [@route],
+          facilitator: facilitator,
+          payment_identifier_cache: cache
+        )
+
+      assert duplicate.status == 402
+      assert decode_payment_required!(duplicate)["error"] == "payment already processed"
+      refute_received {:settle_called, _, _, _}
+    end
+
+    test "exactly one of two concurrent identical requests wins the claim" do
+      facilitator = start_mock_facilitator()
+      cache = start_supervised!({ETSCache, name: unique_cache_name()})
+      header = valid_payment_header()
+
+      opts = [
+        routes: [@route],
+        facilitator: facilitator,
+        payment_identifier_cache: cache
+      ]
+
+      statuses =
+        1..2
+        |> Enum.map(fn _index ->
+          Task.async(fn ->
+            conn(:get, "/api/resource")
+            |> put_req_header("payment-signature", header)
+            |> gate_request(opts)
+            |> maybe_send_ok()
+            |> Map.fetch!(:status)
+          end)
+        end)
+        |> Task.await_many()
+
+      assert Enum.sort(statuses) == [200, 402]
+      assert_receive {:settle_called, _, _, _}
+      refute_received {:settle_called, _, _, _}
+    end
+  end
+
   describe "real facilitator client integration" do
     test "sends the upto ceiling to verify and the handler amount to settle" do
       bypass = Bypass.open()
@@ -1426,6 +1628,10 @@ defmodule X402.Plug.PaymentGateTest do
     conn
     |> gate_request(opts)
     |> maybe_send_ok()
+  end
+
+  defp unique_cache_name do
+    String.to_atom("payment_gate_cache_#{System.unique_integer([:positive, :monotonic])}")
   end
 
   defp gate_request(conn, opts), do: PaymentGate.call(conn, PaymentGate.init(opts))

--- a/test/x402/plug/payment_gate_test.exs
+++ b/test/x402/plug/payment_gate_test.exs
@@ -1476,6 +1476,17 @@ defmodule X402.Plug.PaymentGateTest do
   # ---------------------------------------------------------------------------
 
   describe "init/1 validation" do
+    test "normalizes :global and :via names to the default ETSCache adapter" do
+      global = PaymentGate.init(routes: [@route], payment_identifier_cache: {:global, :my_cache})
+
+      assert global.payment_identifier_cache == {ETSCache, {:global, :my_cache}}
+
+      via_name = {:via, Registry, {MyRegistry, :cache}}
+      via = PaymentGate.init(routes: [@route], payment_identifier_cache: via_name)
+
+      assert via.payment_identifier_cache == {ETSCache, via_name}
+    end
+
     test "raises on missing routes and invalid values" do
       assert_raise NimbleOptions.ValidationError, fn ->
         PaymentGate.init(facilitator: self())


### PR DESCRIPTION
The replay-protection claim in X402.Plug.PaymentGate previously called
X402.Extensions.PaymentIdentifier.ETSCache.put_new/3 directly, while the
Cache behaviour only defined get/put/delete. The one callback that
matters for replay protection was therefore outside the behaviour
contract, and no alternative (Redis/Mnesia/database) adapter could be
plugged in — behaviour-over-config only pays off when the call sites go
through the behaviour (ecosystem comparison §5.3.3, §8 P1.3).

Changes:

- Add put_new/3 as a required @callback on the Cache behaviour with a
  documented atomic first-writer-wins contract: exactly one concurrent
  claimant may receive :ok, live duplicates return
  {:error, :already_exists}, entries expire after the adapter TTL, and
  any other error fails the request closed.
- Route all PaymentGate claim/release calls through the behaviour via
  Cache.put_new/3 and Cache.delete/2 dispatch helpers. ETSCache remains
  the default: init/1 normalizes a bare pid/name (the previously
  documented option shape) into an {ETSCache, ref} adapter tuple, so
  existing configs keep working, while {module, cache} tuples select a
  custom adapter and are validated against the callback set.
- Loudly document the clustered-BEAM double-execution hazard (the
  per-node ETS default lets a cluster serve one payment once per node)
  in the PaymentGate, Cache, and ETSCache moduledocs, plus a Redis
  SET NX PX adapter sketch in the Cache moduledoc as a template for
  distributed adapters (ecosystem comparison §6.3, matrix/C4).

Tests: ETSCache behaviour conformance and a 50-way put_new race
(exactly one winner); Mox-based gate tests proving claims and releases
go through a custom adapter, duplicate claims map to the existing 402
duplicate-payment shape, and adapter failures fail closed with 500;
duplicate and two-concurrent-request coverage on the default ETS
adapter; init/1 normalization and rejection of incomplete adapters.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes replay-protection contracts and ETS capacity behavior on the payment gate; misconfigured or full caches can deny paid traffic (500) or, with default ETS in a cluster, still allow double delivery across nodes.
> 
> **Overview**
> Adds **`put_new/3`** to the `X402.Extensions.PaymentIdentifier.Cache` behaviour as the formal **atomic first-writer-wins** replay claim, with a `Cache.put_new/3` dispatcher and stricter `validate_adapter/1` (adapters without `put_new/3` are rejected).
> 
> **`X402.Plug.PaymentGate`** now routes idempotency **claim/release** through the behaviour (`Cache.put_new/3` / `Cache.delete/2`) instead of calling `ETSCache` directly. `payment_identifier_cache:` accepts a `{module, cache}` tuple or normalizes a bare pid/name (plus `{:global, _}` / `{:via, _, _}`) to `{ETSCache, ref}`; duplicate claims still answer **402**, and adapter failures other than `{:error, :already_exists}` fail closed with **500**.
> 
> **`ETSCache.put_new/3`** no longer evicts a live entry when at `max_size`—it purges expired keys first, then returns **`{:error, :cache_full}`** rather than dropping another payment’s replay lock (a junk-claim flood vector). Moduledocs call out the **per-node ETS clustering hazard** and include a Redis `SET NX PX` adapter sketch.
> 
> Tests add Mox coverage for custom adapters, concurrent claim races, and the new capacity semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25a8ae2a28e0b42b2fe3c71402abb5b292ec6459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->