### PR TITLE
feat: add claim_order option for claim-before-verify replay shedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   replay-storm load from the facilitator, but a node crash during
   verification strands the claim until the cache TTL expires, while
   `:after_verify` never strands a claim on verification but pays one verify
-  call per replayed request
+  call per replayed request. Verify-time exits (facilitator call timeout or
+  `:noproc`) also release the claim before propagating, so a slow or down
+  facilitator cannot strand a payer's replay lock
 - `put_new/3` callback on `X402.Extensions.PaymentIdentifier.Cache` — the
   atomic first-writer-wins claim used for replay protection is now part of the
   behaviour contract (TTL semantics and return values documented), so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the facilitator; payloads without an authorization object (other schemes,
   Permit2) and absent fields are skipped, so the facilitator remains the
   authority. (Ecosystem report §6.6.4/§8 P1.2.)
+- `X402.Plug.PaymentGate` `claim_order:` option (`:after_verify` |
+  `:before_verify`, default `:after_verify` — unchanged behavior). With
+  `:before_verify` the gate claims the payment proof before calling the
+  facilitator, rejecting replayed duplicates with 402 without any facilitator
+  round-trip, and releases the claim when verification fails for any reason;
+  release-on-handler-error and release-on-settle-failure semantics are
+  unchanged. Trade-off documented in the moduledoc: `:before_verify` sheds
+  replay-storm load from the facilitator, but a node crash during
+  verification strands the claim until the cache TTL expires, while
+  `:after_verify` never strands a claim on verification but pays one verify
+  call per replayed request
 - `put_new/3` callback on `X402.Extensions.PaymentIdentifier.Cache` — the
   atomic first-writer-wins claim used for replay protection is now part of the
   behaviour contract (TTL semantics and return values documented), so

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -39,6 +39,26 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     the protected handler responds with a status >= 400 or settlement fails,
     so clients may retry a payment whose resource was never delivered.
 
+    The `:claim_order` option controls when the claim is taken relative to
+    facilitator verification:
+
+    * `:after_verify` (default) — the claim is taken only after the
+      facilitator has verified the proof. A replayed proof can never strand a
+      claim through verification, but **every** replayed request pays a full
+      facilitator verify round-trip before it is rejected, so a replay storm
+      translates directly into facilitator load.
+    * `:before_verify` — the claim is taken before contacting the
+      facilitator and released again if verification fails for any reason.
+      Duplicates are rejected locally without any facilitator call, which
+      sheds replay-storm load. The trade-off: a node that crashes between
+      claiming and releasing (now including the verify round-trip window)
+      strands the claim until the cache TTL expires, so a legitimate retry of
+      that same payment is rejected with 402 until then.
+
+    Both orderings keep the existing release semantics: the claim is released
+    when the handler responds with a status >= 400 or settlement fails, and a
+    duplicate claim is rejected with the same 402 duplicate-payment error.
+
     > #### Clustered deployments can serve one payment twice {: .warning}
     >
     > The default `X402.Extensions.PaymentIdentifier.ETSCache` adapter is
@@ -253,6 +273,20 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
         for the clustering hazard.
         """
       ],
+      claim_order: [
+        type: {:in, [:after_verify, :before_verify]},
+        default: :after_verify,
+        doc: """
+        When the replay claim is taken relative to facilitator verification.
+        `:after_verify` (default) never strands a claim on verification but
+        pays a facilitator verify round-trip per replayed request;
+        `:before_verify` rejects duplicates before contacting the facilitator
+        (shedding replay-storm load) and releases the claim if verification
+        fails, at the cost that a node crash during verification strands the
+        claim until the cache TTL expires. Only meaningful when
+        `:payment_identifier_cache` is configured.
+        """
+      ],
       routes: [
         type: {:list, {:custom, __MODULE__, :validate_route, []}},
         required: true,
@@ -274,11 +308,15 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
       ]
     ]
 
+    @typedoc "Claim ordering relative to facilitator verification."
+    @type claim_order :: :after_verify | :before_verify
+
     @typedoc "Configuration map produced by `init/1`."
     @type options :: %{
             facilitator: Facilitator.server(),
             hooks: module(),
             payment_identifier_cache: Cache.adapter() | nil,
+            claim_order: claim_order(),
             routes: [compiled_route()],
             local_prechecks: boolean()
           }
@@ -418,6 +456,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
         facilitator: Keyword.fetch!(validated_opts, :facilitator),
         hooks: Keyword.fetch!(validated_opts, :hooks),
         payment_identifier_cache: cache,
+        claim_order: Keyword.fetch!(validated_opts, :claim_order),
         routes:
           validated_opts
           |> Keyword.fetch!(:routes)
@@ -460,8 +499,8 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     Gates matching requests behind x402 v2 payment verification.
     """
     @spec call(Plug.Conn.t(), options()) :: Plug.Conn.t()
-    def call(%Plug.Conn{} = conn, %{routes: routes} = options) do
-      if is_nil(options.payment_identifier_cache), do: warn_no_idempotency_cache_once()
+    def call(%Plug.Conn{} = conn, %{routes: routes} = opts) do
+      if is_nil(opts.payment_identifier_cache), do: warn_no_idempotency_cache_once()
 
       request_path = decoded_request_path(conn)
       request_method = normalize_method(conn.method)
@@ -472,13 +511,13 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
           conn
 
         route ->
-          handle_payment_gate(conn, options, route, request_method, request_path)
+          handle_payment_gate(conn, opts, route, request_method, request_path)
       end
     end
 
     @spec handle_payment_gate(Plug.Conn.t(), options(), compiled_route(), atom(), String.t()) ::
             Plug.Conn.t()
-    defp handle_payment_gate(conn, options, route, request_method, request_path) do
+    defp handle_payment_gate(conn, opts, route, request_method, request_path) do
       case payment_header(conn) do
         :missing ->
           emit(:payment_required, %{method: request_method, path: request_path, route: route.path})
@@ -492,14 +531,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
           )
 
         {:ok, header} ->
-          verify_and_prepare_settlement(
-            conn,
-            options,
-            route,
-            request_method,
-            request_path,
-            header
-          )
+          verify_and_prepare_settlement(conn, opts, route, request_method, request_path, header)
 
         {:error, reason} ->
           emit(:payment_rejected, %{
@@ -528,27 +560,18 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
             String.t(),
             String.t()
           ) :: Plug.Conn.t()
-    defp verify_and_prepare_settlement(conn, options, route, request_method, request_path, header) do
-      %{
-        facilitator: facilitator,
-        hooks: hooks,
-        payment_identifier_cache: payment_identifier_cache
-      } = options
-
+    defp verify_and_prepare_settlement(conn, opts, route, request_method, request_path, header) do
       accepts = route_accepts(route)
       payment_id = :crypto.hash(:sha256, header) |> Base.encode16(case: :lower)
 
       with {:ok, payment_payload, requirements} <-
              decode_and_validate_payment(header, accepts, route.extensions),
-           :ok <- run_local_prechecks(options.local_prechecks, payment_payload, requirements),
-           {:ok, verify_response} <-
-             facilitator_verify(facilitator, payment_payload, requirements, hooks),
-           :ok <- ensure_verify_success(verify_response),
-           :ok <- claim_payment(payment_identifier_cache, payment_id) do
+           :ok <- run_local_prechecks(opts.local_prechecks, payment_payload, requirements),
+           :ok <- claim_and_verify(opts, payment_id, payment_payload, requirements) do
         settlement_context = %{
-          facilitator: facilitator,
-          hooks: hooks,
-          payment_identifier_cache: payment_identifier_cache,
+          facilitator: opts.facilitator,
+          hooks: opts.hooks,
+          payment_identifier_cache: opts.payment_identifier_cache,
           payment_id: payment_id,
           payment_payload: payment_payload,
           requirements: requirements,
@@ -811,6 +834,47 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
 
         {:error, reason} ->
           {:error, reason, nil}
+      end
+    end
+
+    # Orders the replay claim relative to facilitator verification.
+    #
+    # :after_verify — verify first, then claim. Verification failures never
+    # touch the cache, but replayed requests pay a verify round-trip each.
+    #
+    # :before_verify — claim first, rejecting duplicates without contacting
+    # the facilitator; release the claim when verification fails for any
+    # reason so the payer can retry.
+    @spec claim_and_verify(options(), String.t(), map(), map()) :: :ok | {:error, term()}
+    defp claim_and_verify(%{claim_order: :after_verify} = opts, payment_id, payload, requirements) do
+      with :ok <- verify_payment(opts, payload, requirements) do
+        claim_payment(opts.payment_identifier_cache, payment_id)
+      end
+    end
+
+    defp claim_and_verify(
+           %{claim_order: :before_verify} = opts,
+           payment_id,
+           payload,
+           requirements
+         ) do
+      with :ok <- claim_payment(opts.payment_identifier_cache, payment_id) do
+        case verify_payment(opts, payload, requirements) do
+          :ok ->
+            :ok
+
+          {:error, reason} ->
+            release_claim(opts.payment_identifier_cache, payment_id)
+            {:error, reason}
+        end
+      end
+    end
+
+    @spec verify_payment(options(), map(), map()) :: :ok | {:error, term()}
+    defp verify_payment(opts, payment_payload, requirements) do
+      with {:ok, verify_response} <-
+             facilitator_verify(opts.facilitator, payment_payload, requirements, opts.hooks) do
+        ensure_verify_success(verify_response)
       end
     end
 

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -859,15 +859,30 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
            requirements
          ) do
       with :ok <- claim_payment(opts.payment_identifier_cache, payment_id) do
-        case verify_payment(opts, payload, requirements) do
-          :ok ->
-            :ok
-
-          {:error, reason} ->
-            release_claim(opts.payment_identifier_cache, payment_id)
-            {:error, reason}
-        end
+        verify_with_claim_release(opts, payment_id, payload, requirements)
       end
+    end
+
+    # A slow or unreachable facilitator EXITS the caller (GenServer.call
+    # timeout / :noproc) rather than returning an error tuple. Under
+    # :before_verify the claim is already taken at that point — release it
+    # before letting the exit propagate, or the payer's legitimate retry is
+    # rejected as a duplicate until the cache TTL expires.
+    @spec verify_with_claim_release(options(), String.t(), map(), map()) ::
+            :ok | {:error, term()}
+    defp verify_with_claim_release(opts, payment_id, payload, requirements) do
+      case verify_payment(opts, payload, requirements) do
+        :ok ->
+          :ok
+
+        {:error, reason} ->
+          release_claim(opts.payment_identifier_cache, payment_id)
+          {:error, reason}
+      end
+    catch
+      :exit, reason ->
+        release_claim(opts.payment_identifier_cache, payment_id)
+        exit(reason)
     end
 
     @spec verify_payment(options(), map(), map()) :: :ok | {:error, term()}

--- a/test/x402/plug/payment_gate_test.exs
+++ b/test/x402/plug/payment_gate_test.exs
@@ -1040,6 +1040,250 @@ defmodule X402.Plug.PaymentGateTest do
   end
 
   # ---------------------------------------------------------------------------
+  # Claim ordering relative to facilitator verification
+  # ---------------------------------------------------------------------------
+
+  describe "claim_order" do
+    test "defaults to :after_verify" do
+      assert %{claim_order: :after_verify} = PaymentGate.init(routes: [@route])
+    end
+
+    test "init/1 rejects invalid claim_order values" do
+      assert_raise NimbleOptions.ValidationError, ~r/claim_order/, fn ->
+        PaymentGate.init(routes: [@route], claim_order: :sometimes)
+      end
+    end
+
+    test ":after_verify claims only after the facilitator verified" do
+      facilitator = start_mock_facilitator()
+
+      expect(CacheMock, :put_new, fn :mock_ref, _payment_id, :verified ->
+        # The verify round-trip must already have completed when the claim runs.
+        assert_received {:verify_called, _, _, _}
+        :ok
+      end)
+
+      conn =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", valid_payment_header())
+        |> run_request(
+          routes: [@route],
+          facilitator: facilitator,
+          payment_identifier_cache: {CacheMock, :mock_ref},
+          claim_order: :after_verify
+        )
+
+      assert conn.status == 200
+    end
+
+    test ":after_verify never touches the cache when verification fails" do
+      facilitator =
+        start_mock_facilitator(
+          verify:
+            {:ok, %{status: 200, body: %{"isValid" => false, "invalidReason" => "declined"}}}
+        )
+
+      # No CacheMock expectations: any adapter call would raise UnexpectedCallError.
+      conn =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", valid_payment_header())
+        |> run_request(
+          routes: [@route],
+          facilitator: facilitator,
+          payment_identifier_cache: {CacheMock, :mock_ref}
+        )
+
+      assert conn.status == 402
+    end
+
+    test ":before_verify claims before contacting the facilitator" do
+      facilitator = start_mock_facilitator()
+
+      expect(CacheMock, :put_new, fn :mock_ref, _payment_id, :verified ->
+        # The claim must run before any facilitator verify round-trip.
+        refute_received {:verify_called, _, _, _}
+        :ok
+      end)
+
+      conn =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", valid_payment_header())
+        |> run_request(
+          routes: [@route],
+          facilitator: facilitator,
+          payment_identifier_cache: {CacheMock, :mock_ref},
+          claim_order: :before_verify
+        )
+
+      assert conn.status == 200
+      assert_receive {:verify_called, _, _, _}
+      assert_receive {:settle_called, _, _, _}
+    end
+
+    test ":before_verify releases the claim when verification is rejected" do
+      facilitator =
+        start_mock_facilitator(
+          verify:
+            {:ok, %{status: 200, body: %{"isValid" => false, "invalidReason" => "declined"}}}
+        )
+
+      parent = self()
+
+      expect(CacheMock, :put_new, fn :mock_ref, _payment_id, :verified -> :ok end)
+
+      expect(CacheMock, :delete, fn :mock_ref, payment_id ->
+        send(parent, {:adapter_delete, payment_id})
+        :ok
+      end)
+
+      conn =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", valid_payment_header())
+        |> run_request(
+          routes: [@route],
+          facilitator: facilitator,
+          payment_identifier_cache: {CacheMock, :mock_ref},
+          claim_order: :before_verify
+        )
+
+      assert conn.status == 402
+      assert_receive {:adapter_delete, _payment_id}
+      refute_received {:settle_called, _, _, _}
+    end
+
+    test ":before_verify releases the claim on facilitator transport errors" do
+      error = %Error{type: :transport_error, reason: :closed, retryable: true}
+      facilitator = start_mock_facilitator(verify: {:error, error})
+      parent = self()
+
+      expect(CacheMock, :put_new, fn :mock_ref, _payment_id, :verified -> :ok end)
+
+      expect(CacheMock, :delete, fn :mock_ref, payment_id ->
+        send(parent, {:adapter_delete, payment_id})
+        :ok
+      end)
+
+      conn =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", valid_payment_header())
+        |> run_request(
+          routes: [@route],
+          facilitator: facilitator,
+          payment_identifier_cache: {CacheMock, :mock_ref},
+          claim_order: :before_verify
+        )
+
+      assert conn.status == 500
+      assert_receive {:adapter_delete, _payment_id}
+    end
+
+    test ":before_verify allows a retry after a failed verification" do
+      reject =
+        start_mock_facilitator(
+          verify:
+            {:ok, %{status: 200, body: %{"isValid" => false, "invalidReason" => "declined"}}}
+        )
+
+      accept = start_mock_facilitator()
+      cache = start_supervised!({ETSCache, name: unique_cache_name()})
+      header = valid_payment_header()
+
+      first =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", header)
+        |> run_request(
+          routes: [@route],
+          facilitator: reject,
+          payment_identifier_cache: cache,
+          claim_order: :before_verify
+        )
+
+      assert first.status == 402
+
+      retry =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", header)
+        |> run_request(
+          routes: [@route],
+          facilitator: accept,
+          payment_identifier_cache: cache,
+          claim_order: :before_verify
+        )
+
+      assert retry.status == 200
+      assert_receive {:settle_called, _, _, _}
+    end
+
+    test ":before_verify rejects a duplicate without any facilitator call" do
+      bypass = Bypass.open()
+      finch = String.to_atom("payment_gate_finch_#{System.unique_integer([:positive])}")
+
+      facilitator_name =
+        String.to_atom("payment_gate_facilitator_#{System.unique_integer([:positive])}")
+
+      start_supervised!({Finch, name: finch})
+
+      # expect_once fails the test if either endpoint is hit more than once,
+      # proving the duplicate request below causes zero facilitator calls.
+      Bypass.expect_once(bypass, "POST", "/verify", fn bypass_conn ->
+        Plug.Conn.resp(
+          bypass_conn,
+          200,
+          Jason.encode!(%{"isValid" => true, "payer" => @receiver})
+        )
+      end)
+
+      Bypass.expect_once(bypass, "POST", "/settle", fn bypass_conn ->
+        Plug.Conn.resp(
+          bypass_conn,
+          200,
+          Jason.encode!(%{
+            "success" => true,
+            "transaction" => "0xsettled",
+            "network" => @network,
+            "payer" => @receiver
+          })
+        )
+      end)
+
+      facilitator =
+        start_supervised!(
+          {Facilitator,
+           name: facilitator_name,
+           finch: finch,
+           url: "http://localhost:#{bypass.port}",
+           max_retries: 0}
+        )
+
+      cache = start_supervised!({ETSCache, name: unique_cache_name()})
+      header = valid_payment_header()
+
+      opts = [
+        routes: [@route],
+        facilitator: facilitator,
+        payment_identifier_cache: cache,
+        claim_order: :before_verify
+      ]
+
+      first =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", header)
+        |> run_request(opts)
+
+      assert first.status == 200
+      assert decode_payment_response!(first)["success"] == true
+
+      duplicate =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", header)
+        |> run_request(opts)
+
+      assert duplicate.status == 402
+      assert decode_payment_required!(duplicate)["error"] == "payment already processed"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Replay protection through the Cache behaviour
   # ---------------------------------------------------------------------------
 

--- a/test/x402/plug/payment_gate_test.exs
+++ b/test/x402/plug/payment_gate_test.exs
@@ -1177,6 +1177,40 @@ defmodule X402.Plug.PaymentGateTest do
       assert_receive {:adapter_delete, _payment_id}
     end
 
+    test ":before_verify releases the claim when the facilitator call exits" do
+      # A dead facilitator pid makes Facilitator.verify exit with :noproc
+      # instead of returning an error tuple. The claim must still be released
+      # before the exit propagates, or the payer's retry is rejected as a
+      # duplicate until the cache TTL expires.
+      dead = spawn(fn -> :ok end)
+      ref = Process.monitor(dead)
+      assert_receive {:DOWN, ^ref, :process, ^dead, _reason}
+
+      parent = self()
+
+      expect(CacheMock, :put_new, fn :mock_ref, _payment_id, :verified -> :ok end)
+
+      expect(CacheMock, :delete, fn :mock_ref, payment_id ->
+        send(parent, {:adapter_delete, payment_id})
+        :ok
+      end)
+
+      opts =
+        PaymentGate.init(
+          routes: [@route],
+          facilitator: dead,
+          payment_identifier_cache: {CacheMock, :mock_ref},
+          claim_order: :before_verify
+        )
+
+      conn =
+        conn(:get, "/api/resource")
+        |> put_req_header("payment-signature", valid_payment_header())
+
+      assert catch_exit(PaymentGate.call(conn, opts))
+      assert_receive {:adapter_delete, _payment_id}
+    end
+
     test ":before_verify allows a retry after a failed verification" do
       reject =
         start_mock_facilitator(


### PR DESCRIPTION
The replay claim previously always ran after facilitator verify in the
gate's with-chain, so a replay storm paid one facilitator verify
round-trip per duplicate before being rejected — the facilitator eats
the storm even though the gate already holds everything needed to
reject locally (ecosystem comparison §6.3, §6.6.2).

Add a claim_order option to X402.Plug.PaymentGate, validated via
NimbleOptions like the other gate options:

- :after_verify (default, current behavior, zero breaking change) —
  verify first, claim after. Verification failures never touch the
  cache, but each replayed request costs a verify call.
- :before_verify — claim the payment proof hash before contacting the
  facilitator; duplicates are rejected with the existing 402
  duplicate-payment error without any facilitator call. The claim is
  released when verification fails for any reason (rejection, transport
  error, malformed response), so the payer can retry.

Release-on-handler->=400 and release-on-settle-failure semantics are
unchanged in both orderings. The moduledoc documents the trade-off:
:before_verify sheds storm load but a node crash during verification
strands the claim until the cache TTL expires; :after_verify never
strands a claim on verification but pays verify per replay.

The claim/verify ordering now lives in a single claim_and_verify/4
dispatch pair, and the gate's internal pipeline threads the init/1
options map instead of four positional arguments.

Tests: default remains :after_verify (init assertion plus a Mox test
that a failed verify never touches the cache and an ordering assertion
that the claim observes the completed verify); :before_verify ordering
asserted via Mox (claim sees no verify yet), claim released on verify
rejection and on transport error, retry allowed after failed verify,
and a Bypass expect_once test proving a duplicate is rejected with zero
facilitator calls while keeping the 402 duplicate-payment shape.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes replay-protection ordering on a payment-critical path; default `:after_verify` preserves behavior, but `:before_verify` introduces crash/TTL stranding and must be chosen deliberately.
> 
> **Overview**
> Adds **`claim_order:`** to **`X402.Plug.PaymentGate`** so operators can choose when the replay idempotency claim runs relative to facilitator verify. **`:after_verify`** remains the default (verify, then claim); **`:before_verify`** claims the payment proof hash first so duplicate replays get **402** locally with **no facilitator call**, which reduces replay-storm load on the facilitator.
> 
> The gate routes claim/verify through **`claim_and_verify/4`**. Under **`:before_verify`**, failed verification (rejection, transport error, malformed response) **releases** the claim so payers can retry; **`verify_with_claim_release/3`** also releases on facilitator **exit** (timeout / `:noproc`) so a slow or dead facilitator does not lock the proof until cache TTL. Handler **≥400** and settle-failure release behavior is unchanged for both modes. Moduledoc and CHANGELOG document the trade-off: **`:before_verify`** can strand a claim until TTL if the node crashes mid-verify.
> 
> Tests cover defaults, NimbleOptions validation, ordering assertions, release paths, retry after failed verify, and a Bypass **`expect_once`** proof that duplicates under **`:before_verify`** never hit verify/settle again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e0cbfe8584010bddcea1d50d0c4b805d734db71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->