### PR TITLE
docs: add SECURITY.md and correct the CDP token-reuse doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Documented the clustered-BEAM double-execution hazard of the per-node ETS
   replay cache in the `PaymentGate`, `Cache`, and `ETSCache` moduledocs
+- Added `SECURITY.md` — private vulnerability reporting, supported versions,
+  and the SDK's trust model (facilitator-delegated verification, transport
+  hardening, per-node replay cache caveat)
+- Corrected the `X402.Facilitator.Auth.CDP.headers/2` doc: the JWT is signed
+  fresh per facilitator operation, and transport retries within one operation
+  reuse it inside its 120-second validity window
 
 ### Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately via
+[GitHub private vulnerability reporting](https://github.com/cardotrejos/x402/security/advisories/new)
+on this repository. Do **not** open a public issue for security reports.
+
+You can expect an acknowledgement within 72 hours. Please include a minimal
+reproduction and the affected version. Coordinated disclosure is appreciated;
+we will credit reporters in the release notes unless you prefer otherwise.
+
+## Supported versions
+
+Only the latest release published on [Hex.pm](https://hex.pm/packages/x402)
+receives security fixes.
+
+## Trust model
+
+This library implements the **resource server** and **facilitator client**
+roles of the x402 payment protocol. Understanding what it does and does not
+verify matters for deploying it safely:
+
+- **Payment signature verification is delegated to the facilitator you
+  configure.** `X402.Plug.PaymentGate` validates payload structure, matches
+  requirements, and runs cheap local pre-checks (payTo binding, exact amount
+  equality, validity windows), but it performs no signature cryptography and
+  no on-chain checks. Your resource server's payment security equals your
+  facilitator's — choose one you trust, and note that no x402 SDK's server
+  role independently verifies settlement on-chain.
+- **Facilitator transport is enforced to `https://`** (loopback exempt for
+  development), with TLS peer verification and system CA certificates on the
+  default pool. Per-request facilitator authentication (Coinbase CDP JWT) is
+  supported via `X402.Facilitator.Auth`.
+- **Inbound payment headers are capped at 8 KB before any decoding** and
+  fail closed on malformed Base64/JSON.
+- **Replay protection** in `X402.Plug.PaymentGate` (the payment-identifier
+  cache claim) is **per-node** with the bundled ETS adapter. In a clustered
+  deployment each node claims independently — use a shared adapter
+  (implementing `X402.Extensions.PaymentIdentifier.Cache`) if a duplicate
+  request served by a second node is unacceptable for your resource.
+
+## Known advisories affecting the wider x402 ecosystem
+
+This SDK is not affected by, but its design responds to,
+[GHSA-3j63-5h8p-gf7c](https://github.com/advisories/GHSA-3j63-5h8p-gf7c)
+(route-matching bypass in the legacy TypeScript middleware — this SDK matches
+on decoded `path_info` segments and carries regression tests for that bug
+class) and
+[GHSA-qr2g-p6q7-w82m](https://github.com/advisories/GHSA-qr2g-p6q7-w82m)
+(SVM duplicate settlement in the official SDKs — this SDK does not implement
+SVM settlement).

--- a/lib/x402/facilitator/auth/cdp.ex
+++ b/lib/x402/facilitator/auth/cdp.ex
@@ -105,7 +105,9 @@ defmodule X402.Facilitator.Auth.CDP do
   Builds the `Authorization` (and `Correlation-Context`) headers for a request.
 
   The JWT binds the request method, host, and path in its `uris` claim and is
-  signed fresh for every call.
+  signed fresh each time headers are built; transport retries within one
+  facilitator operation reuse the same token inside its 120-second validity
+  window.
   """
   @doc since: "0.5.0"
   @spec headers(t(), Auth.request_info()) :: {:ok, [{String.t(), String.t()}]}


### PR DESCRIPTION
A payments library should state how to report vulnerabilities and what
its trust model actually guarantees. SECURITY.md covers private
reporting via GitHub advisories, the supported-versions policy, and the
deployment-relevant facts: verification is delegated to the configured
facilitator (local pre-checks are structural only), https is enforced on
facilitator transport, inbound headers are capped at 8KB pre-decode, and
the bundled replay cache is per-node — clustered deployments need a
shared Cache adapter.

Also corrects the CDP headers/2 doc, which claimed the JWT is signed
fresh for every call: transport retries within one facilitator operation
reuse the token inside its 120-second validity window (the moduledoc
already said this correctly).

Ref: docs/ecosystem-comparison.md §6.6 items 5 and 7

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security-behavior modifications.
> 
> **Overview**
> Adds **`SECURITY.md`** so deployers and reporters have a single place for **private vulnerability reporting** (GitHub advisories), **supported-versions policy** (latest Hex release only), and the SDK **trust model**: facilitator-delegated signature verification, `https://` facilitator transport, 8 KB inbound header caps, and **per-node** replay protection with the bundled ETS cache (shared `Cache` adapter for clusters). It also notes ecosystem advisories GHSA-3j63-5h8p-gf7c and GHSA-qr2g-p6q7-w82m in relation to this codebase.
> 
> **`CHANGELOG.md`** records those documentation additions under the Documentation section.
> 
> The **`X402.Facilitator.Auth.CDP.headers/2`** docstring is corrected: JWTs are signed when headers are built for each facilitator operation, not on every low-level HTTP attempt—**transport retries within one operation reuse the same token** within the 120-second validity window, aligning with the module doc and actual retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ad9555a32163547811caca84980feafcc208794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->