### PR TITLE
feat: payer client — X402.Signer, EIP-3009 signing, X402.Client + Finch 402 retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer occurs; `{:missing_fields, _}` remains for v2 `accepted` objects
   missing required PaymentRequirements fields.
   (Ecosystem report §8 P0.1.)
+- Payer client (report §8 P0.4): `X402.Client` — transport-agnostic core with
+  `select_requirements/2` (filterable payment-option selection with a
+  `max_amount` budget guard), `build_payment/3` (v2 `PaymentPayload` assembly
+  with full requirements and extension echo), and `encode_payment/1`
+- `X402.Signer` behaviour — the client-side signing seam (`address/1` +
+  `sign_eip712/3` over the precomputed EIP-712 digest and full typed data),
+  with `X402.Signer.LocalKey` as the built-in raw-private-key implementation
+  (optional `ex_secp256k1`/`ex_keccak`; the key is redacted from `inspect/1`)
+- `X402.EIP3009` — EIP-3009 `TransferWithAuthorization` building, EIP-712
+  domain derivation from payment requirements, digest computation, signing,
+  and signer recovery, promoted from `test/support/x402_test_payments.ex`
+  (which now delegates to it)
+- `X402.Client.Finch` — HTTP convenience client: on `402` with a
+  `PAYMENT-REQUIRED` header it decodes, signs, and retries once with
+  `PAYMENT-SIGNATURE` (never pays twice), returning the decoded
+  `PAYMENT-RESPONSE` settlement receipt; includes an `on_payment_required`
+  budget/consent hook and enforces `https://` for non-loopback resources
+- `[:x402, :client, :select | :sign | :build | :request]` telemetry events
+- `guides/client.md` — "Paying for x402 Resources from Elixir"
 
 ## [0.5.0] - 2026-08-26
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ facilitator, chain, or web framework.
 
 - x402 v2 `PAYMENT-REQUIRED`, `PAYMENT-SIGNATURE`, and `PAYMENT-RESPONSE` headers
 - Complete v2 payment-requirement and extension-echo validation
+- Payer client with EIP-3009 signing and an automatic `402 → sign → retry` Finch flow
 - Facilitator `/verify` and `/settle` client with retries, hooks, and telemetry
 - Plug/Phoenix payment gate that settles only after successful resource handling
 - `"exact"` and metered `"upto"` authorization flows

--- a/guides/client.md
+++ b/guides/client.md
@@ -1,0 +1,142 @@
+# Paying for x402 Resources from Elixir
+
+x402 has two halves: servers that require payment, and clients that pay. This
+guide covers the payer side — calling an x402-protected API from Elixir and
+letting the SDK handle the `402 → sign → retry` dance.
+
+## How a payment happens
+
+1. Your client requests a protected resource and receives **402 Payment
+   Required** with a `PAYMENT-REQUIRED` header describing acceptable payments.
+2. The client picks one entry from `accepts`, signs an
+   [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009)
+   `TransferWithAuthorization` for it (an off-chain signature — no gas, no
+   transaction), and retries the request with the signed payment in a
+   `PAYMENT-SIGNATURE` header.
+3. The server verifies and settles the payment through its facilitator and
+   responds with the resource, plus a `PAYMENT-RESPONSE` header containing the
+   settlement receipt.
+
+The SDK signs the `exact` scheme on EVM (`eip155:*`) networks.
+
+## Quick start with Finch
+
+Add the optional dependencies the payer needs — `finch` for HTTP and
+`ex_secp256k1`/`ex_keccak` for signing:
+
+```elixir
+def deps do
+  [
+    {:x402, "~> 0.6"},
+    {:finch, "~> 0.19"},
+    {:ex_secp256k1, "~> 0.8.0"},
+    {:ex_keccak, "~> 0.7.8"}
+  ]
+end
+```
+
+Start a Finch pool with TLS verification, build a signer, and make the
+request:
+
+```elixir
+{:ok, _pid} =
+  Finch.start_link(
+    name: MyApp.Finch,
+    pools: %{default: X402.Facilitator.HTTP.secure_pool_opts()}
+  )
+
+# A raw secp256k1 private key — load it from a secret store, never from code.
+{:ok, signer} = X402.Signer.LocalKey.new(System.fetch_env!("PAYER_PRIVATE_KEY"))
+
+{:ok, %{status: 200, body: body, payment_response: receipt}} =
+  X402.Client.Finch.request(MyApp.Finch, "https://api.example.com/premium-data",
+    signer: signer,
+    max_amount: "10000"
+  )
+
+IO.inspect(receipt["transaction"], label: "settlement tx")
+```
+
+`request/3` performs the request; when it hits a 402 it builds, signs, and
+retries **once** — a payment is never signed or sent twice for the same call.
+Responses that do not require payment pass through untouched.
+
+### Budgets and consent
+
+Two options keep an automated payer in check:
+
+- `:max_amount` — an atomic-unit ceiling. Payment options above it are never
+  selected; if nothing affordable is offered you get
+  `{:error, :no_acceptable_requirements}`.
+- `:on_payment_required` — a hook invoked with the decoded `PaymentRequired`
+  map *before* anything is signed. Return `:cancel` to abort with
+  `{:error, :payment_cancelled}`:
+
+```elixir
+X402.Client.Finch.request(MyApp.Finch, url,
+  signer: signer,
+  on_payment_required: fn payment_required ->
+    case MyApp.Budget.approve(payment_required["accepts"]) do
+      :ok -> :ok
+      :denied -> :cancel
+    end
+  end
+)
+```
+
+You can also pin the payment with `:network`, `:scheme`, and `:asset` filters.
+
+## Bring your own HTTP client
+
+`X402.Client` is pure — no processes, no HTTP. Use it with Req, Tesla,
+httpc, or anything else:
+
+```elixir
+alias X402.{Client, PaymentRequired}
+
+# 1. You made a request and got a 402 with a PAYMENT-REQUIRED header:
+{:ok, payment_required} = PaymentRequired.decode(header_value)
+
+# 2. Build and sign the payment:
+{:ok, payload} = Client.build_payment(payment_required, signer, max_amount: "10000")
+{:ok, header} = Client.encode_payment(payload)
+
+# 3. Retry the request with {"payment-signature", header}.
+```
+
+`Client.select_requirements/2` is also public if you want to inspect or
+choose the payment option yourself before signing.
+
+## Custom signers
+
+`X402.Signer.LocalKey` holds a raw private key in memory — fine for testing
+and low-value automation. For production payers implement the `X402.Signer`
+behaviour over your KMS, hardware wallet, or signing service:
+
+```elixir
+defmodule MyApp.KMSSigner do
+  @behaviour X402.Signer
+
+  defstruct [:key_id, :address]
+
+  @impl true
+  def address(%__MODULE__{address: address}), do: {:ok, address}
+
+  @impl true
+  def sign_eip712(%__MODULE__{key_id: key_id}, digest, _typed_data) do
+    # Ask the KMS to sign the 32-byte digest; return the 65-byte r || s || v
+    # signature. Implementations that can only sign full EIP-712 typed data
+    # can use the third argument instead of the digest.
+    MyApp.KMS.sign(key_id, digest)
+  end
+end
+```
+
+Anything that returns `{:ok, address}` and `{:ok, signature}` plugs into
+`X402.Client.build_payment/3` and `X402.Client.Finch.request/3` unchanged.
+
+## Telemetry
+
+The client emits `[:x402, :client, :select]`, `[:x402, :client, :sign]`,
+`[:x402, :client, :build]`, and `[:x402, :client, :request]` events with a
+`:status` of `:ok` or `:error` — see `X402.Telemetry`.

--- a/lib/x402/client.ex
+++ b/lib/x402/client.ex
@@ -1,0 +1,369 @@
+defmodule X402.Client do
+  @moduledoc """
+  Transport-agnostic payer client for x402 v2 payments.
+
+  Pure functions covering the client half of the protocol: selecting a
+  payment option from a server's `PAYMENT-REQUIRED` response, signing it
+  through the `X402.Signer` behaviour, assembling the v2 `PaymentPayload`
+  envelope, and encoding it to a `PAYMENT-SIGNATURE` header value. Bring your
+  own HTTP client, or use `X402.Client.Finch` for a ready-made
+  402 → sign → retry flow.
+
+  This release signs the `exact` scheme on EVM (`eip155:*`) networks via
+  EIP-3009 (`X402.EIP3009`); other scheme/network combinations return
+  `{:error, {:unsupported_kind, scheme, network}}`.
+
+  ## Example
+
+      {:ok, signer} = X402.Signer.LocalKey.new(System.fetch_env!("PAYER_KEY"))
+
+      with {:ok, payment_required} <- X402.PaymentRequired.decode(header_value),
+           {:ok, payload} <- X402.Client.build_payment(payment_required, signer),
+           {:ok, header} <- X402.Client.encode_payment(payload) do
+        # retry the request with {"payment-signature", header}
+      end
+  """
+
+  alias X402.EIP3009
+  alias X402.PaymentRequirements
+  alias X402.Signer
+  alias X402.Telemetry
+  alias X402.Utils
+
+  @select_opts_schema [
+    network: [
+      type: :string,
+      doc: """
+      Only select requirements on this CAIP-2 network. A trailing `*` acts as
+      a prefix wildcard (for example `"eip155:*"`).
+      """
+    ],
+    scheme: [
+      type: :string,
+      doc: "Only select requirements using this scheme (for example `\"exact\"`)."
+    ],
+    asset: [
+      type: :string,
+      doc: "Only select requirements paying with this asset (compared case-insensitively)."
+    ],
+    max_amount: [
+      type: {:or, [:string, :non_neg_integer]},
+      doc: """
+      Only select requirements whose `amount` (in atomic units) does not
+      exceed this value — the budget guard for automated payers.
+      """
+    ]
+  ]
+
+  @build_opts_schema @select_opts_schema ++
+                       [
+                         valid_after_buffer: [
+                           type: :non_neg_integer,
+                           default: 60,
+                           doc: """
+                           Seconds subtracted from the current time for the EVM
+                           authorization's `validAfter` (clock-skew tolerance).
+                           """
+                         ]
+                       ]
+
+  @typedoc "Selection options — see `select_requirements/2`."
+  @type select_opts :: [
+          network: String.t(),
+          scheme: String.t(),
+          asset: String.t(),
+          max_amount: String.t() | non_neg_integer()
+        ]
+
+  @type select_error :: :no_acceptable_requirements | :invalid_payment_required
+
+  @type build_error ::
+          select_error()
+          | {:unsupported_kind, term(), term()}
+          | EIP3009.domain_error()
+          | EIP3009.encode_error()
+          | term()
+
+  @doc since: "0.6.0"
+  @doc """
+  Selects one payment requirements entry from a `PAYMENT-REQUIRED` payload.
+
+  Accepts a decoded `PaymentRequired` map (its `accepts` list is used) or a
+  bare list of requirements maps. Returns the first entry that passes the
+  option filters **and** that this client can sign: `exact` scheme on an
+  `eip155:*` network, structurally valid per
+  `X402.PaymentRequirements.validate/1`, with the EIP-712 domain fields
+  (`extra.name` / `extra.version`) present.
+
+  The selected entry is returned exactly as the server sent it, so it can be
+  echoed verbatim as the payload's `accepted` value.
+
+  ## Options
+
+  #{NimbleOptions.docs(@select_opts_schema)}
+
+  ## Examples
+
+      iex> requirements = %{
+      ...>   "scheme" => "exact",
+      ...>   "network" => "eip155:84532",
+      ...>   "amount" => "10000",
+      ...>   "asset" => "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      ...>   "payTo" => "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      ...>   "maxTimeoutSeconds" => 60,
+      ...>   "extra" => %{"name" => "USDC", "version" => "2"}
+      ...> }
+      iex> {:ok, selected} =
+      ...>   X402.Client.select_requirements(%{"x402Version" => 2, "accepts" => [requirements]})
+      iex> selected == requirements
+      true
+
+      iex> X402.Client.select_requirements(%{"x402Version" => 2, "accepts" => []})
+      {:error, :no_acceptable_requirements}
+  """
+  @spec select_requirements(map() | [map()], select_opts()) ::
+          {:ok, map()} | {:error, select_error()}
+  def select_requirements(payment_required, opts \\ []) do
+    opts = NimbleOptions.validate!(opts, @select_opts_schema)
+
+    with {:ok, accepts} <- fetch_accepts(payment_required) do
+      accepts
+      |> Enum.filter(&(is_map(&1) and matches_filters?(&1, opts)))
+      |> Enum.find(&supported?/1)
+      |> case do
+        nil ->
+          Telemetry.emit(:client, :select, :error, %{reason: :no_acceptable_requirements})
+          {:error, :no_acceptable_requirements}
+
+        selected ->
+          Telemetry.emit(:client, :select, :ok, %{
+            scheme: Utils.map_value(selected, {"scheme", :scheme}),
+            network: Utils.map_value(selected, {"network", :network})
+          })
+
+          {:ok, selected}
+      end
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Builds a complete v2 `PaymentPayload` for a payment-required response.
+
+  Accepts either a decoded `PaymentRequired` map — in which case one entry is
+  chosen via `select_requirements/2` and the server's `resource` and
+  `extensions` are echoed — or a single requirements map, which skips
+  selection (and carries no `resource`/`extensions` echo).
+
+  The chosen requirements are echoed in full (including `extra`) as
+  `accepted`, and server-advertised `extensions` are echoed unchanged,
+  following the spec's append-only rule: the client must preserve every
+  advertised value and may only add to them.
+
+  Signing dispatches on the scheme and network of the chosen requirements;
+  this release supports `exact` on `eip155:*` networks (EIP-3009). Other
+  combinations return `{:error, {:unsupported_kind, scheme, network}}`.
+
+  ## Options
+
+  #{NimbleOptions.docs(@build_opts_schema)}
+  """
+  @spec build_payment(map() | [map()], Signer.t(), keyword()) ::
+          {:ok, map()} | {:error, build_error()}
+  def build_payment(payment_required_or_requirements, signer, opts \\ []) do
+    opts = NimbleOptions.validate!(opts, @build_opts_schema)
+
+    result =
+      with {:ok, requirements, envelope} <-
+             resolve_requirements(payment_required_or_requirements, opts),
+           {:ok, scheme_payload} <- sign_for_kind(requirements, signer, opts) do
+        {:ok, assemble_payload(requirements, scheme_payload, envelope)}
+      end
+
+    case result do
+      {:ok, _payload} = ok ->
+        Telemetry.emit(:client, :build, :ok, %{})
+        ok
+
+      {:error, reason} = error ->
+        Telemetry.emit(:client, :build, :error, %{reason: reason})
+        error
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Encodes a `PaymentPayload` map to a `PAYMENT-SIGNATURE` header value.
+
+  The header value is Base64-encoded JSON, compatible with
+  `X402.PaymentSignature.decode/1` on the validation side.
+
+  ## Examples
+
+      iex> payload = %{"x402Version" => 2, "accepted" => %{"scheme" => "exact"}, "payload" => %{}}
+      iex> {:ok, header} = X402.Client.encode_payment(payload)
+      iex> X402.PaymentSignature.decode(header)
+      {:ok, payload}
+
+      iex> X402.Client.encode_payment(nil)
+      {:error, :invalid_payload}
+  """
+  @spec encode_payment(map()) :: {:ok, String.t()} | {:error, :invalid_payload | :invalid_json}
+  def encode_payment(payload) when is_map(payload) do
+    case Jason.encode(payload) do
+      {:ok, json} -> {:ok, Base.encode64(json)}
+      {:error, _reason} -> {:error, :invalid_json}
+    end
+  end
+
+  def encode_payment(_payload), do: {:error, :invalid_payload}
+
+  # -- Selection --------------------------------------------------------------
+
+  @spec fetch_accepts(term()) :: {:ok, [term()]} | {:error, :invalid_payment_required}
+  defp fetch_accepts(accepts) when is_list(accepts), do: {:ok, accepts}
+
+  defp fetch_accepts(payment_required) when is_map(payment_required) do
+    case Utils.map_value(payment_required, {"accepts", :accepts}) do
+      accepts when is_list(accepts) -> {:ok, accepts}
+      _accepts -> {:error, :invalid_payment_required}
+    end
+  end
+
+  defp fetch_accepts(_payment_required), do: {:error, :invalid_payment_required}
+
+  @spec matches_filters?(map(), keyword()) :: boolean()
+  defp matches_filters?(requirements, opts) do
+    Enum.all?(opts, fn
+      {:network, network} ->
+        matches_network?(network, Utils.map_value(requirements, {"network", :network}))
+
+      {:scheme, scheme} ->
+        Utils.map_value(requirements, {"scheme", :scheme}) == scheme
+
+      {:asset, asset} ->
+        matches_asset?(asset, Utils.map_value(requirements, {"asset", :asset}))
+
+      {:max_amount, max_amount} ->
+        within_max_amount?(Utils.map_value(requirements, {"amount", :amount}), max_amount)
+
+      {_key, _value} ->
+        true
+    end)
+  end
+
+  @spec matches_network?(String.t(), term()) :: boolean()
+  defp matches_network?(_filter, network) when not is_binary(network), do: false
+
+  defp matches_network?(filter, network) do
+    case String.split_at(filter, -1) do
+      {prefix, "*"} -> String.starts_with?(network, prefix)
+      _exact -> filter == network
+    end
+  end
+
+  @spec matches_asset?(String.t(), term()) :: boolean()
+  defp matches_asset?(filter, asset) when is_binary(asset),
+    do: String.downcase(filter) == String.downcase(asset)
+
+  defp matches_asset?(_filter, _asset), do: false
+
+  @spec within_max_amount?(term(), String.t() | non_neg_integer()) :: boolean()
+  defp within_max_amount?(amount, max_amount) do
+    with {:ok, amount_decimal} <- Utils.parse_decimal(amount),
+         {:ok, max_decimal} <- Utils.parse_decimal(max_amount) do
+      Utils.compare_decimal(amount_decimal, max_decimal) != :gt
+    else
+      :error -> false
+    end
+  end
+
+  @spec supported?(map()) :: boolean()
+  defp supported?(requirements) do
+    PaymentRequirements.validate(requirements) == :ok and
+      supported_kind?(
+        Utils.map_value(requirements, {"scheme", :scheme}),
+        Utils.map_value(requirements, {"network", :network})
+      ) and
+      match?({:ok, _domain}, EIP3009.domain(requirements))
+  end
+
+  @spec supported_kind?(term(), term()) :: boolean()
+  defp supported_kind?("exact", "eip155:" <> _chain_id), do: true
+  defp supported_kind?(_scheme, _network), do: false
+
+  # -- Payload assembly -------------------------------------------------------
+
+  @spec resolve_requirements(term(), keyword()) ::
+          {:ok, map(), %{resource: term(), extensions: term()}} | {:error, select_error()}
+  defp resolve_requirements(%{} = payment_required_or_requirements, opts) do
+    if payment_required?(payment_required_or_requirements) do
+      with {:ok, requirements} <-
+             select_requirements(payment_required_or_requirements, select_opts(opts)) do
+        {:ok, requirements,
+         %{
+           resource: Utils.map_value(payment_required_or_requirements, {"resource", :resource}),
+           extensions:
+             Utils.map_value(payment_required_or_requirements, {"extensions", :extensions})
+         }}
+      end
+    else
+      {:ok, payment_required_or_requirements, %{resource: nil, extensions: nil}}
+    end
+  end
+
+  defp resolve_requirements(_other, _opts), do: {:error, :invalid_payment_required}
+
+  @spec payment_required?(map()) :: boolean()
+  defp payment_required?(map), do: is_list(Utils.map_value(map, {"accepts", :accepts}))
+
+  @spec select_opts(keyword()) :: keyword()
+  defp select_opts(opts), do: Keyword.take(opts, Keyword.keys(@select_opts_schema))
+
+  @spec sign_for_kind(map(), Signer.t(), keyword()) :: {:ok, map()} | {:error, build_error()}
+  defp sign_for_kind(requirements, signer, opts) do
+    scheme = Utils.map_value(requirements, {"scheme", :scheme})
+    network = Utils.map_value(requirements, {"network", :network})
+
+    if supported_kind?(scheme, network) do
+      case EIP3009.sign(requirements, signer, valid_after_buffer: opts[:valid_after_buffer]) do
+        {:ok, scheme_payload} ->
+          Telemetry.emit(:client, :sign, :ok, %{scheme: scheme, network: network})
+          {:ok, scheme_payload}
+
+        {:error, reason} = error ->
+          Telemetry.emit(:client, :sign, :error, %{
+            reason: reason,
+            scheme: scheme,
+            network: network
+          })
+
+          error
+      end
+    else
+      Telemetry.emit(:client, :sign, :error, %{
+        reason: :unsupported_kind,
+        scheme: scheme,
+        network: network
+      })
+
+      {:error, {:unsupported_kind, scheme, network}}
+    end
+  end
+
+  @spec assemble_payload(map(), map(), %{resource: term(), extensions: term()}) :: map()
+  defp assemble_payload(requirements, scheme_payload, envelope) do
+    %{
+      "x402Version" => 2,
+      "accepted" => requirements,
+      "payload" => scheme_payload
+    }
+    |> maybe_put("resource", envelope.resource)
+    |> maybe_put("extensions", envelope.extensions)
+  end
+
+  @spec maybe_put(map(), String.t(), term()) :: map()
+  defp maybe_put(payload, _key, nil), do: payload
+  defp maybe_put(payload, key, value) when is_map(value), do: Map.put(payload, key, value)
+  defp maybe_put(payload, _key, _value), do: payload
+end

--- a/lib/x402/client/finch.ex
+++ b/lib/x402/client/finch.ex
@@ -1,0 +1,363 @@
+defmodule X402.Client.Finch do
+  @moduledoc """
+  Finch-backed payer client with an automatic 402 → sign → retry flow.
+
+  `request/3` performs an HTTP request; when the server answers `402` with a
+  `PAYMENT-REQUIRED` header, it decodes the payment requirements, builds and
+  signs a payment via `X402.Client.build_payment/3`, and retries the request
+  once with the `PAYMENT-SIGNATURE` header. A request is **never paid twice**:
+  at most one payment retry is made, and requests that already carry a
+  `payment-signature` header are refused.
+
+  Requires the optional `finch` dependency; without it every call returns
+  `{:error, :missing_dependency}`. Start your own Finch pool (with TLS peer
+  verification — see `X402.Facilitator.HTTP.secure_pool_opts/0`) and pass its
+  name.
+
+  ## Example
+
+      {:ok, signer} = X402.Signer.LocalKey.new(System.fetch_env!("PAYER_KEY"))
+
+      {:ok, %{status: 200, body: body, payment_response: receipt}} =
+        X402.Client.Finch.request(MyApp.Finch, "https://api.example.com/paid",
+          signer: signer,
+          max_amount: "10000",
+          on_payment_required: fn payment_required ->
+            IO.inspect(payment_required["accepts"], label: "about to pay")
+            :ok
+          end
+        )
+
+  ## Security
+
+  Like the facilitator client, URLs must use `https://` — payment
+  authorizations must never travel in plaintext. Loopback hosts
+  (`localhost`, `127.0.0.1`, `::1`) are exempt for local development.
+  """
+
+  alias X402.Client
+  alias X402.PaymentRequired
+  alias X402.PaymentResponse
+  alias X402.Telemetry
+
+  @loopback_hosts ["localhost", "127.0.0.1", "::1"]
+
+  @request_opts_schema [
+    signer: [
+      type: {:custom, __MODULE__, :validate_signer, []},
+      required: true,
+      doc: "A struct implementing `X402.Signer`, used to sign the payment."
+    ],
+    method: [
+      type: {:in, [:get, :post, :put, :patch, :delete, :head, :options]},
+      default: :get,
+      doc: "HTTP request method."
+    ],
+    headers: [
+      type: {:custom, __MODULE__, :validate_headers, []},
+      default: [],
+      doc: "Additional `{name, value}` request headers."
+    ],
+    body: [
+      type: {:or, [:string, nil]},
+      default: nil,
+      doc: "Request body."
+    ],
+    receive_timeout_ms: [
+      type: :non_neg_integer,
+      default: 5_000,
+      doc: "Finch receive timeout per attempt, in milliseconds."
+    ],
+    network: [
+      type: :string,
+      doc: "Payment selection filter — see `X402.Client.select_requirements/2`."
+    ],
+    scheme: [
+      type: :string,
+      doc: "Payment selection filter — see `X402.Client.select_requirements/2`."
+    ],
+    asset: [
+      type: :string,
+      doc: "Payment selection filter — see `X402.Client.select_requirements/2`."
+    ],
+    max_amount: [
+      type: {:or, [:string, :non_neg_integer]},
+      doc: """
+      Maximum `amount` (atomic units) this client will pay — the budget guard
+      for automated payers. Requirements above it are never selected.
+      """
+    ],
+    valid_after_buffer: [
+      type: :non_neg_integer,
+      default: 60,
+      doc: "Clock-skew buffer for the authorization's `validAfter`, in seconds."
+    ],
+    on_payment_required: [
+      type: {:or, [{:fun, 1}, nil]},
+      default: nil,
+      doc: """
+      Budget/consent hook invoked with the decoded `PaymentRequired` map
+      before any payment is signed. Return `:cancel` to abort with
+      `{:error, :payment_cancelled}`; any other return value continues.
+      """
+    ]
+  ]
+
+  @typedoc "A Finch pool name or pid."
+  @type finch_name :: atom() | pid() | {:via, module(), term()}
+
+  @typedoc """
+  A completed HTTP response.
+
+  `:payment_response` holds the decoded `PAYMENT-RESPONSE` header (the
+  settlement receipt) when the server sent a valid one, otherwise `nil`.
+  """
+  @type response :: %{
+          status: non_neg_integer(),
+          headers: [{String.t(), String.t()}],
+          body: binary(),
+          payment_response: map() | nil
+        }
+
+  @type request_error ::
+          :missing_dependency
+          | :insecure_url
+          | :payment_cancelled
+          | :payment_already_attempted
+          | {:transport_error, term()}
+          | {:invalid_payment_required, term()}
+          | Client.build_error()
+
+  @doc since: "0.6.0"
+  @doc """
+  Performs an HTTP request, paying for the resource if it requires payment.
+
+  Flow:
+
+  1. Perform the request. Anything other than a `402` with a
+     `PAYMENT-REQUIRED` header is returned as-is.
+  2. Decode the `PAYMENT-REQUIRED` header (`X402.PaymentRequired.decode/1`).
+  3. Invoke the `:on_payment_required` hook, which may cancel.
+  4. Build and sign a payment (`X402.Client.build_payment/3`) and retry the
+     request once with the `PAYMENT-SIGNATURE` header.
+  5. Return the retried response with the decoded `PAYMENT-RESPONSE`
+     settlement receipt, when present. A second `402` is returned as-is —
+     the payment is never re-signed or re-sent.
+
+  ## Options
+
+  #{NimbleOptions.docs(@request_opts_schema)}
+  """
+  @spec request(finch_name(), String.t(), keyword()) ::
+          {:ok, response()} | {:error, request_error()}
+  def request(finch_name, url, opts) when is_binary(url) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @request_opts_schema)
+
+    result =
+      with {:ok, finch_module} <- ensure_finch_module(),
+           :ok <- validate_url_scheme(url) do
+        ctx = %{
+          finch_module: finch_module,
+          finch_name: finch_name,
+          url: url,
+          opts: opts
+        }
+
+        with {:ok, response} <- perform(ctx, Keyword.fetch!(opts, :headers)) do
+          maybe_pay(ctx, response)
+        end
+      end
+
+    emit_request_telemetry(result)
+    result
+  end
+
+  @doc false
+  @spec validate_signer(term()) :: {:ok, struct()} | {:error, String.t()}
+  def validate_signer(%module{} = signer) do
+    case X402.Behaviour.implements?(module, address: 1, sign_eip712: 3) do
+      true -> {:ok, signer}
+      false -> {:error, "expected a struct implementing X402.Signer"}
+    end
+  end
+
+  def validate_signer(_signer), do: {:error, "expected a struct implementing X402.Signer"}
+
+  @doc false
+  @spec validate_headers(term()) :: {:ok, [{String.t(), String.t()}]} | {:error, String.t()}
+  def validate_headers(headers) when is_list(headers) do
+    case Enum.all?(headers, &valid_header?/1) do
+      true -> {:ok, headers}
+      false -> {:error, "expected a list of {name, value} binary tuples"}
+    end
+  end
+
+  def validate_headers(_headers), do: {:error, "expected a list of {name, value} binary tuples"}
+
+  # -- Request flow -----------------------------------------------------------
+
+  @spec perform(map(), [{String.t(), String.t()}]) ::
+          {:ok, %{status: non_neg_integer(), headers: list(), body: binary()}}
+          | {:error, {:transport_error, term()}}
+  defp perform(ctx, headers) do
+    opts = ctx.opts
+
+    request =
+      ctx.finch_module.build(
+        Keyword.fetch!(opts, :method),
+        ctx.url,
+        headers,
+        Keyword.fetch!(opts, :body)
+      )
+
+    finch_opts = [receive_timeout: Keyword.fetch!(opts, :receive_timeout_ms)]
+
+    response =
+      try do
+        ctx.finch_module.request(request, ctx.finch_name, finch_opts)
+      catch
+        :exit, reason -> {:error, reason}
+      end
+
+    case response do
+      {:ok, %{status: status, headers: response_headers, body: body}} ->
+        {:ok, %{status: status, headers: response_headers, body: body}}
+
+      {:error, reason} ->
+        {:error, {:transport_error, reason}}
+    end
+  end
+
+  @spec maybe_pay(map(), map()) :: {:ok, response()} | {:error, request_error()}
+  defp maybe_pay(ctx, %{status: 402} = response) do
+    case fetch_header(response.headers, "payment-required") do
+      nil -> {:ok, finalize(response)}
+      header_value -> pay_and_retry(ctx, header_value)
+    end
+  end
+
+  defp maybe_pay(_ctx, response), do: {:ok, finalize(response)}
+
+  @spec pay_and_retry(map(), String.t()) :: {:ok, response()} | {:error, request_error()}
+  defp pay_and_retry(ctx, header_value) do
+    headers = Keyword.fetch!(ctx.opts, :headers)
+
+    with :ok <- ensure_not_already_paid(headers),
+         {:ok, payment_required} <- decode_payment_required(header_value),
+         :ok <- consent(ctx.opts, payment_required),
+         {:ok, payload} <-
+           Client.build_payment(payment_required, ctx.opts[:signer], build_opts(ctx.opts)),
+         {:ok, payment_header} <- Client.encode_payment(payload),
+         {:ok, response} <- perform(ctx, headers ++ [{"payment-signature", payment_header}]) do
+      {:ok, finalize(response)}
+    end
+  end
+
+  @spec ensure_not_already_paid([{String.t(), String.t()}]) ::
+          :ok | {:error, :payment_already_attempted}
+  defp ensure_not_already_paid(headers) do
+    case fetch_header(headers, "payment-signature") do
+      nil -> :ok
+      _value -> {:error, :payment_already_attempted}
+    end
+  end
+
+  @spec decode_payment_required(String.t()) ::
+          {:ok, map()} | {:error, {:invalid_payment_required, term()}}
+  defp decode_payment_required(header_value) do
+    case PaymentRequired.decode(header_value) do
+      {:ok, payment_required} -> {:ok, payment_required}
+      {:error, reason} -> {:error, {:invalid_payment_required, reason}}
+    end
+  end
+
+  @spec consent(keyword(), map()) :: :ok | {:error, :payment_cancelled}
+  defp consent(opts, payment_required) do
+    case Keyword.fetch!(opts, :on_payment_required) do
+      nil ->
+        :ok
+
+      hook when is_function(hook, 1) ->
+        case hook.(payment_required) do
+          :cancel -> {:error, :payment_cancelled}
+          _other -> :ok
+        end
+    end
+  end
+
+  @spec build_opts(keyword()) :: keyword()
+  defp build_opts(opts),
+    do: Keyword.take(opts, [:network, :scheme, :asset, :max_amount, :valid_after_buffer])
+
+  @spec finalize(map()) :: response()
+  defp finalize(response) do
+    payment_response =
+      case fetch_header(response.headers, "payment-response") do
+        nil -> nil
+        header_value -> decode_payment_response(header_value)
+      end
+
+    %{
+      status: response.status,
+      headers: response.headers,
+      body: response.body,
+      payment_response: payment_response
+    }
+  end
+
+  @spec decode_payment_response(String.t()) :: map() | nil
+  defp decode_payment_response(header_value) do
+    case PaymentResponse.decode(header_value) do
+      {:ok, decoded} -> decoded
+      {:error, _reason} -> nil
+    end
+  end
+
+  @spec fetch_header([{String.t(), String.t()}], String.t()) :: String.t() | nil
+  defp fetch_header(headers, name) do
+    Enum.find_value(headers, fn
+      {header_name, value} when is_binary(header_name) and is_binary(value) ->
+        String.downcase(header_name) == name && value
+
+      _header ->
+        nil
+    end)
+  end
+
+  @spec emit_request_telemetry({:ok, response()} | {:error, term()}) :: :ok
+  defp emit_request_telemetry({:ok, response}),
+    do: Telemetry.emit(:client, :request, :ok, %{status: response.status})
+
+  defp emit_request_telemetry({:error, reason}),
+    do: Telemetry.emit(:client, :request, :error, %{reason: reason})
+
+  @spec valid_header?(term()) :: boolean()
+  defp valid_header?({name, value}) when is_binary(name) and is_binary(value), do: true
+  defp valid_header?(_header), do: false
+
+  # Enforces HTTPS on resource URLs: the PAYMENT-SIGNATURE header carries a
+  # signed, settleable payment authorization and must never travel in
+  # plaintext. Loopback is exempt for local development (mirrors
+  # X402.Facilitator.HTTP).
+  @spec validate_url_scheme(String.t()) :: :ok | {:error, :insecure_url}
+  defp validate_url_scheme(url) do
+    case URI.parse(url) do
+      %URI{scheme: "https"} -> :ok
+      %URI{scheme: "http", host: host} when host in @loopback_hosts -> :ok
+      _uri -> {:error, :insecure_url}
+    end
+  end
+
+  # Resolved at runtime via Module.concat so the library compiles without the
+  # optional Finch dependency (same pattern as X402.Facilitator.HTTP).
+  @spec ensure_finch_module() :: {:ok, module()} | {:error, :missing_dependency}
+  defp ensure_finch_module do
+    finch_module = Module.concat(["Finch"])
+
+    case Code.ensure_loaded?(finch_module) and function_exported?(finch_module, :request, 3) and
+           function_exported?(finch_module, :build, 4) do
+      true -> {:ok, finch_module}
+      false -> {:error, :missing_dependency}
+    end
+  end
+end

--- a/lib/x402/eip3009.ex
+++ b/lib/x402/eip3009.ex
@@ -1,0 +1,615 @@
+defmodule X402.EIP3009 do
+  @moduledoc """
+  EIP-3009 `TransferWithAuthorization` building and EIP-712 signing.
+
+  Implements the client half of the x402 `exact` scheme on EVM networks with
+  the default `eip3009` asset transfer method: building an authorization from
+  v2 payment requirements, computing its EIP-712 digest, and signing it
+  through the `X402.Signer` behaviour to produce the scheme `payload` map
+
+      %{"signature" => "0x...", "authorization" => %{...}}
+
+  carried inside a v2 `PaymentPayload` (see `X402.Client.build_payment/3` for
+  the full envelope).
+
+  The EIP-712 domain is derived from the payment requirements as specified by
+  the exact-EVM scheme: `name`/`version` from `extra`, the chain id from the
+  CAIP-2 `network`, and the verifying contract from `asset`.
+
+  Cryptographic operations require the optional `ex_secp256k1` and
+  `ex_keccak` dependencies and return `{:error, :missing_dependency}` when
+  they are unavailable; the library itself compiles without them.
+  """
+
+  alias X402.Signer
+  alias X402.Utils
+  alias X402.Wallet
+
+  @eip712_domain_type "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+  @transfer_with_authorization_type "TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+
+  @typed_data_types %{
+    "EIP712Domain" => [
+      %{"name" => "name", "type" => "string"},
+      %{"name" => "version", "type" => "string"},
+      %{"name" => "chainId", "type" => "uint256"},
+      %{"name" => "verifyingContract", "type" => "address"}
+    ],
+    "TransferWithAuthorization" => [
+      %{"name" => "from", "type" => "address"},
+      %{"name" => "to", "type" => "address"},
+      %{"name" => "value", "type" => "uint256"},
+      %{"name" => "validAfter", "type" => "uint256"},
+      %{"name" => "validBefore", "type" => "uint256"},
+      %{"name" => "nonce", "type" => "bytes32"}
+    ]
+  }
+
+  @authorization_opts_schema [
+    valid_after_buffer: [
+      type: :non_neg_integer,
+      default: 60,
+      doc: """
+      Seconds subtracted from the current time for the authorization's
+      `validAfter`, tolerating clock skew between payer, facilitator, and
+      chain.
+      """
+    ]
+  ]
+
+  @typedoc """
+  An EIP-712 domain map with `:name`, `:version`, `:chain_id`, and
+  `:verifying_contract` keys.
+
+  Functions accepting a domain also take the wire-style keys
+  (`"name"`, `"version"`, `"chainId"`, `"verifyingContract"`).
+  """
+  @type domain :: %{
+          name: String.t(),
+          version: String.t(),
+          chain_id: non_neg_integer(),
+          verifying_contract: String.t()
+        }
+
+  @typedoc """
+  A `TransferWithAuthorization` authorization in wire shape: string keys
+  `"from"`, `"to"`, `"value"`, `"validAfter"`, `"validBefore"`, `"nonce"`.
+  """
+  @type authorization :: %{optional(String.t()) => String.t()}
+
+  @typedoc "The scheme `payload` map for a signed EIP-3009 payment."
+  @type payload :: %{optional(String.t()) => String.t() | authorization()}
+
+  @type domain_error ::
+          :invalid_requirements
+          | {:missing_extra, String.t()}
+          | {:unsupported_transfer_method, term()}
+          | :unsupported_network
+
+  @type encode_error ::
+          :missing_dependency
+          | :invalid_address
+          | :invalid_amount
+          | :invalid_bytes32
+          | {:missing_field, String.t()}
+
+  @doc since: "0.6.0"
+  @doc """
+  Signs the `exact`/`eip3009` scheme payload for the given requirements.
+
+  Derives the EIP-712 domain from the requirements, builds a fresh
+  authorization from the signer's address (`from`), `payTo` (`to`), and
+  `amount` (`value`) with a random 32-byte nonce, computes the EIP-712
+  digest, and signs it through `signer`.
+
+  ## Options
+
+  #{NimbleOptions.docs(@authorization_opts_schema)}
+
+  ## Examples
+
+      {:ok, signer} = X402.Signer.LocalKey.new(private_key)
+
+      {:ok, %{"signature" => _, "authorization" => _}} =
+        X402.EIP3009.sign(
+          %{
+            "scheme" => "exact",
+            "network" => "eip155:84532",
+            "amount" => "10000",
+            "asset" => "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+            "payTo" => "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+            "maxTimeoutSeconds" => 60,
+            "extra" => %{"name" => "USDC", "version" => "2"}
+          },
+          signer
+        )
+  """
+  @spec sign(map(), Signer.t(), keyword()) ::
+          {:ok, payload()} | {:error, domain_error() | encode_error() | term()}
+  def sign(requirements, signer, opts \\ []) when is_map(requirements) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @authorization_opts_schema)
+
+    with {:ok, domain} <- domain(requirements),
+         {:ok, from} <- Signer.address(signer),
+         {:ok, authorization} <- build_authorization(requirements, from, opts),
+         {:ok, signature} <- sign_authorization(signer, domain, authorization) do
+      {:ok, %{"signature" => signature, "authorization" => authorization}}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Derives the EIP-712 domain from v2 payment requirements.
+
+  Per the exact-EVM scheme specification, `extra.name` and `extra.version`
+  are required, the chain id comes from the CAIP-2 `network`, and the
+  verifying contract is the `asset` address. Requirements selecting a
+  non-default `extra.assetTransferMethod` are rejected.
+
+  ## Examples
+
+      iex> X402.EIP3009.domain(%{
+      ...>   "network" => "eip155:84532",
+      ...>   "asset" => "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      ...>   "extra" => %{"name" => "USDC", "version" => "2"}
+      ...> })
+      {:ok,
+       %{
+         name: "USDC",
+         version: "2",
+         chain_id: 84532,
+         verifying_contract: "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+       }}
+
+      iex> X402.EIP3009.domain(%{"network" => "eip155:84532", "asset" => "0xasset", "extra" => %{}})
+      {:error, {:missing_extra, "name"}}
+  """
+  @spec domain(map()) :: {:ok, domain()} | {:error, domain_error()}
+  def domain(requirements) when is_map(requirements) do
+    extra = Utils.map_value(requirements, {"extra", :extra}) || %{}
+    network = Utils.map_value(requirements, {"network", :network})
+    asset = Utils.map_value(requirements, {"asset", :asset})
+
+    with :ok <- ensure_map(extra),
+         :ok <- ensure_transfer_method(extra),
+         {:ok, name} <- fetch_extra(extra, {"name", :name}),
+         {:ok, version} <- fetch_extra(extra, {"version", :version}),
+         {:ok, chain_id} <- chain_id_from_caip2(network),
+         :ok <- ensure_binary(asset) do
+      {:ok, %{name: name, version: version, chain_id: chain_id, verifying_contract: asset}}
+    end
+  end
+
+  def domain(_requirements), do: {:error, :invalid_requirements}
+
+  @doc since: "0.6.0"
+  @doc """
+  Builds a `TransferWithAuthorization` authorization map in wire shape.
+
+  `value` and `to` come from the requirements' `amount` and `payTo`;
+  `validAfter` is `now - valid_after_buffer`, `validBefore` is
+  `now + maxTimeoutSeconds`, and `nonce` is a fresh random 32-byte value.
+
+  Field values are validated when the digest is computed, not here.
+
+  ## Options
+
+  #{NimbleOptions.docs(@authorization_opts_schema)}
+  """
+  @spec build_authorization(map(), String.t(), keyword()) ::
+          {:ok, authorization()} | {:error, :invalid_requirements}
+  def build_authorization(requirements, from, opts \\ [])
+      when is_map(requirements) and is_binary(from) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @authorization_opts_schema)
+    value = Utils.map_value(requirements, {"amount", :amount})
+    to = Utils.map_value(requirements, {"payTo", :payTo})
+    max_timeout = Utils.map_value(requirements, {"maxTimeoutSeconds", :maxTimeoutSeconds})
+
+    if is_binary(value) and is_binary(to) and is_integer(max_timeout) and max_timeout > 0 do
+      now = System.os_time(:second)
+
+      {:ok,
+       %{
+         "from" => from,
+         "to" => to,
+         "value" => value,
+         "validAfter" => Integer.to_string(now - Keyword.fetch!(opts, :valid_after_buffer)),
+         "validBefore" => Integer.to_string(now + max_timeout),
+         "nonce" => random_nonce()
+       }}
+    else
+      {:error, :invalid_requirements}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Signs an authorization's EIP-712 digest with a signer.
+
+  Returns the `0x`-prefixed 65-byte `r || s || v` signature.
+  """
+  @spec sign_authorization(Signer.t(), map(), map()) ::
+          {:ok, String.t()} | {:error, encode_error() | term()}
+  def sign_authorization(signer, domain, authorization)
+      when is_map(domain) and is_map(authorization) do
+    with {:ok, digest} <- eip712_digest(domain, authorization),
+         {:ok, signature} <- Signer.sign_eip712(signer, digest, typed_data(domain, authorization)) do
+      {:ok, "0x" <> Base.encode16(signature, case: :lower)}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Computes the EIP-712 digest of a `TransferWithAuthorization`.
+
+  Returns `keccak256(0x19 0x01 || domainSeparator || structHash)` as a
+  32-byte binary. `domain` and `authorization` accept both the internal
+  snake-case atom keys and the wire-style string keys.
+  """
+  @spec eip712_digest(map(), map()) :: {:ok, <<_::256>>} | {:error, encode_error()}
+  def eip712_digest(domain, authorization) when is_map(domain) and is_map(authorization) do
+    with {:ok, keccak_module} <- keccak_module(),
+         {:ok, domain_separator} <- domain_separator(domain, keccak_module),
+         {:ok, struct_hash} <- struct_hash(authorization, keccak_module) do
+      {:ok, keccak_module.hash_256(<<0x19, 0x01>> <> domain_separator <> struct_hash)}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Derives the lowercase EVM address for a 32-byte secp256k1 private key.
+  """
+  @spec derive_address(binary()) ::
+          {:ok, String.t()} | {:error, :missing_dependency | :invalid_private_key}
+  def derive_address(private_key) when is_binary(private_key) and byte_size(private_key) == 32 do
+    with {:ok, secp256k1_module, keccak_module} <- crypto_modules(),
+         {:ok, public_key} <- create_public_key(secp256k1_module, private_key) do
+      public_key_to_address(public_key, keccak_module)
+    end
+  end
+
+  def derive_address(_private_key), do: {:error, :invalid_private_key}
+
+  @doc since: "0.6.0"
+  @doc """
+  Converts a 65-byte uncompressed (or 64-byte) secp256k1 public key to a
+  lowercase `0x`-prefixed EVM address.
+  """
+  @spec public_key_to_address(binary()) ::
+          {:ok, String.t()} | {:error, :missing_dependency | :invalid_public_key}
+  def public_key_to_address(public_key) when is_binary(public_key) do
+    with {:ok, _secp256k1_module, keccak_module} <- crypto_modules() do
+      public_key_to_address(public_key, keccak_module)
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Recovers the signer address from an EIP-712 digest and a 65-byte signature.
+
+  Accepts the `0x`-prefixed hex signature produced by `sign_authorization/3`
+  or the raw 65-byte binary. Useful for verifying a signed payment locally.
+  """
+  @spec recover_signer(binary(), binary()) ::
+          {:ok, String.t()} | {:error, :missing_dependency | :invalid_signature | term()}
+  def recover_signer(digest, signature)
+      when is_binary(digest) and byte_size(digest) == 32 and is_binary(signature) do
+    with {:ok, secp256k1_module, keccak_module} <- crypto_modules(),
+         {:ok, <<compact::binary-size(64), v>>} <- decode_signature(signature),
+         {:ok, public_key} <- secp256k1_module.recover_compact(digest, compact, v - 27) do
+      public_key_to_address(public_key, keccak_module)
+    end
+  end
+
+  def recover_signer(_digest, _signature), do: {:error, :invalid_signature}
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns a fresh random 32-byte nonce as a `0x`-prefixed hex string.
+
+  ## Examples
+
+      iex> nonce = X402.EIP3009.random_nonce()
+      iex> String.match?(nonce, ~r/^0x[0-9a-f]{64}$/)
+      true
+  """
+  @spec random_nonce() :: String.t()
+  def random_nonce do
+    "0x" <> Base.encode16(:crypto.strong_rand_bytes(32), case: :lower)
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Extracts the chain id from an `eip155:<chainId>` CAIP-2 network identifier.
+
+  ## Examples
+
+      iex> X402.EIP3009.chain_id_from_caip2("eip155:84532")
+      {:ok, 84532}
+
+      iex> X402.EIP3009.chain_id_from_caip2("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp")
+      {:error, :unsupported_network}
+  """
+  @spec chain_id_from_caip2(term()) :: {:ok, non_neg_integer()} | {:error, :unsupported_network}
+  def chain_id_from_caip2("eip155:" <> chain_id) do
+    case Integer.parse(chain_id) do
+      {parsed, ""} when parsed >= 0 -> {:ok, parsed}
+      _parsed -> {:error, :unsupported_network}
+    end
+  end
+
+  def chain_id_from_caip2(_network), do: {:error, :unsupported_network}
+
+  @doc since: "0.6.0"
+  @doc """
+  ABI-encodes a `0x`-prefixed EVM address into a 32-byte word.
+
+  ## Examples
+
+      iex> {:ok, word} = X402.EIP3009.encode_address("0x1111111111111111111111111111111111111111")
+      iex> byte_size(word)
+      32
+
+      iex> X402.EIP3009.encode_address("0x123")
+      {:error, :invalid_address}
+  """
+  @spec encode_address(term()) :: {:ok, <<_::256>>} | {:error, :invalid_address}
+  def encode_address(address) when is_binary(address) do
+    case Wallet.valid_evm?(address) do
+      true ->
+        "0x" <> hex = address
+        {:ok, bytes} = Base.decode16(hex, case: :mixed)
+        {:ok, <<0::unsigned-big-integer-size(96), bytes::binary>>}
+
+      false ->
+        {:error, :invalid_address}
+    end
+  end
+
+  def encode_address(_address), do: {:error, :invalid_address}
+
+  @doc since: "0.6.0"
+  @doc """
+  ABI-encodes a non-negative integer (or decimal string) into a 32-byte word.
+
+  ## Examples
+
+      iex> X402.EIP3009.encode_uint256(1)
+      {:ok, <<1::unsigned-big-integer-size(256)>>}
+
+      iex> X402.EIP3009.encode_uint256("not a number")
+      {:error, :invalid_amount}
+  """
+  @spec encode_uint256(term()) :: {:ok, <<_::256>>} | {:error, :invalid_amount}
+  def encode_uint256(integer) when is_integer(integer) and integer >= 0,
+    do: {:ok, <<integer::unsigned-big-integer-size(256)>>}
+
+  def encode_uint256(string) when is_binary(string) do
+    case Integer.parse(string) do
+      {integer, ""} when integer >= 0 -> encode_uint256(integer)
+      _parsed -> {:error, :invalid_amount}
+    end
+  end
+
+  def encode_uint256(_value), do: {:error, :invalid_amount}
+
+  @doc since: "0.6.0"
+  @doc """
+  Decodes a `0x`-prefixed hex string into a 32-byte binary.
+
+  ## Examples
+
+      iex> {:ok, bytes} = X402.EIP3009.encode_bytes32("0x" <> String.duplicate("ab", 32))
+      iex> byte_size(bytes)
+      32
+
+      iex> X402.EIP3009.encode_bytes32("0xdead")
+      {:error, :invalid_bytes32}
+  """
+  @spec encode_bytes32(term()) :: {:ok, <<_::256>>} | {:error, :invalid_bytes32}
+  def encode_bytes32("0x" <> hex) do
+    case Base.decode16(hex, case: :mixed) do
+      {:ok, bytes} when byte_size(bytes) == 32 -> {:ok, bytes}
+      _decoded -> {:error, :invalid_bytes32}
+    end
+  end
+
+  def encode_bytes32(_value), do: {:error, :invalid_bytes32}
+
+  # -- Domain / struct hashing ------------------------------------------------
+
+  @spec domain_separator(map(), module()) :: {:ok, binary()} | {:error, encode_error()}
+  defp domain_separator(domain, keccak_module) do
+    with {:ok, name} <- fetch_field(domain, {"name", :name}),
+         {:ok, version} <- fetch_field(domain, {"version", :version}),
+         {:ok, chain_id} <- fetch_chain_id(domain),
+         {:ok, contract} <- fetch_field(domain, {"verifyingContract", :verifying_contract}),
+         {:ok, chain_id_word} <- encode_uint256(chain_id),
+         {:ok, contract_word} <- encode_address(contract) do
+      {:ok,
+       keccak_module.hash_256(
+         keccak_module.hash_256(@eip712_domain_type) <>
+           keccak_module.hash_256(name) <>
+           keccak_module.hash_256(version) <>
+           chain_id_word <>
+           contract_word
+       )}
+    end
+  end
+
+  @spec struct_hash(map(), module()) :: {:ok, binary()} | {:error, encode_error()}
+  defp struct_hash(authorization, keccak_module) do
+    with {:ok, from} <- fetch_field(authorization, {"from", :from}),
+         {:ok, to} <- fetch_field(authorization, {"to", :to}),
+         {:ok, value} <- fetch_field(authorization, {"value", :value}),
+         {:ok, valid_after} <- fetch_field(authorization, {"validAfter", :valid_after}),
+         {:ok, valid_before} <- fetch_field(authorization, {"validBefore", :valid_before}),
+         {:ok, nonce} <- fetch_field(authorization, {"nonce", :nonce}),
+         {:ok, from_word} <- encode_address(from),
+         {:ok, to_word} <- encode_address(to),
+         {:ok, value_word} <- encode_uint256(value),
+         {:ok, valid_after_word} <- encode_uint256(valid_after),
+         {:ok, valid_before_word} <- encode_uint256(valid_before),
+         {:ok, nonce_word} <- encode_bytes32(nonce) do
+      {:ok,
+       keccak_module.hash_256(
+         keccak_module.hash_256(@transfer_with_authorization_type) <>
+           from_word <>
+           to_word <>
+           value_word <>
+           valid_after_word <>
+           valid_before_word <>
+           nonce_word
+       )}
+    end
+  end
+
+  @spec typed_data(map(), map()) :: Signer.typed_data()
+  defp typed_data(domain, authorization) do
+    %{
+      "types" => @typed_data_types,
+      "primaryType" => "TransferWithAuthorization",
+      "domain" => %{
+        "name" => Utils.map_value(domain, {"name", :name}),
+        "version" => Utils.map_value(domain, {"version", :version}),
+        "chainId" => Utils.map_value(domain, {"chainId", :chain_id}),
+        "verifyingContract" => Utils.map_value(domain, {"verifyingContract", :verifying_contract})
+      },
+      "message" => %{
+        "from" => Utils.map_value(authorization, {"from", :from}),
+        "to" => Utils.map_value(authorization, {"to", :to}),
+        "value" => Utils.map_value(authorization, {"value", :value}),
+        "validAfter" => Utils.map_value(authorization, {"validAfter", :valid_after}),
+        "validBefore" => Utils.map_value(authorization, {"validBefore", :valid_before}),
+        "nonce" => Utils.map_value(authorization, {"nonce", :nonce})
+      }
+    }
+  end
+
+  # -- Field access -----------------------------------------------------------
+
+  @spec fetch_field(map(), {String.t(), atom()}) ::
+          {:ok, term()} | {:error, {:missing_field, String.t()}}
+  defp fetch_field(map, {string_key, _atom_key} = key) do
+    case Utils.map_value(map, key) do
+      nil -> {:error, {:missing_field, string_key}}
+      value -> {:ok, value}
+    end
+  end
+
+  @spec fetch_chain_id(map()) :: {:ok, term()} | {:error, {:missing_field, String.t()}}
+  defp fetch_chain_id(domain) do
+    case Utils.map_value(domain, {"chainId", :chain_id}) do
+      nil -> {:error, {:missing_field, "chainId"}}
+      value -> {:ok, value}
+    end
+  end
+
+  @spec fetch_extra(map(), {String.t(), atom()}) ::
+          {:ok, String.t()} | {:error, {:missing_extra, String.t()}}
+  defp fetch_extra(extra, {string_key, _atom_key} = key) do
+    case Utils.map_value(extra, key) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _value -> {:error, {:missing_extra, string_key}}
+    end
+  end
+
+  @spec ensure_map(term()) :: :ok | {:error, :invalid_requirements}
+  defp ensure_map(value) when is_map(value), do: :ok
+  defp ensure_map(_value), do: {:error, :invalid_requirements}
+
+  @spec ensure_binary(term()) :: :ok | {:error, :invalid_requirements}
+  defp ensure_binary(value) when is_binary(value) and value != "", do: :ok
+  defp ensure_binary(_value), do: {:error, :invalid_requirements}
+
+  @spec ensure_transfer_method(map()) :: :ok | {:error, {:unsupported_transfer_method, term()}}
+  defp ensure_transfer_method(extra) do
+    case Utils.map_value(extra, {"assetTransferMethod", :assetTransferMethod}) do
+      nil -> :ok
+      "eip3009" -> :ok
+      method -> {:error, {:unsupported_transfer_method, method}}
+    end
+  end
+
+  @spec decode_signature(binary()) :: {:ok, binary()} | {:error, :invalid_signature}
+  defp decode_signature("0x" <> hex), do: decode_signature_hex(hex)
+
+  defp decode_signature(signature) when byte_size(signature) == 65,
+    do: check_recovery_byte(signature)
+
+  defp decode_signature(_signature), do: {:error, :invalid_signature}
+
+  @spec decode_signature_hex(binary()) :: {:ok, binary()} | {:error, :invalid_signature}
+  defp decode_signature_hex(hex) do
+    case Base.decode16(hex, case: :mixed) do
+      {:ok, signature} when byte_size(signature) == 65 -> check_recovery_byte(signature)
+      _decoded -> {:error, :invalid_signature}
+    end
+  end
+
+  @spec check_recovery_byte(binary()) :: {:ok, binary()} | {:error, :invalid_signature}
+  defp check_recovery_byte(<<_compact::binary-size(64), v>> = signature) when v in [27, 28],
+    do: {:ok, signature}
+
+  defp check_recovery_byte(<<compact::binary-size(64), v>>) when v in [0, 1],
+    do: {:ok, compact <> <<v + 27>>}
+
+  defp check_recovery_byte(_signature), do: {:error, :invalid_signature}
+
+  # -- Optional dependency resolution ----------------------------------------
+  #
+  # Modules are resolved at runtime via Module.concat so the library compiles
+  # without ex_secp256k1/ex_keccak (same pattern as
+  # X402.Extensions.SIWX.Verifier.Default and X402.Facilitator.HTTP).
+
+  @spec public_key_to_address(binary(), module()) ::
+          {:ok, String.t()} | {:error, :invalid_public_key}
+  defp public_key_to_address(<<4, public_key::binary-size(64)>>, keccak_module),
+    do: hashed_public_key_to_address(public_key, keccak_module)
+
+  defp public_key_to_address(<<public_key::binary-size(64)>>, keccak_module),
+    do: hashed_public_key_to_address(public_key, keccak_module)
+
+  defp public_key_to_address(_public_key, _keccak_module), do: {:error, :invalid_public_key}
+
+  @spec hashed_public_key_to_address(binary(), module()) :: {:ok, String.t()}
+  defp hashed_public_key_to_address(public_key, keccak_module) do
+    hash = keccak_module.hash_256(public_key)
+    address = binary_part(hash, byte_size(hash) - 20, 20)
+    {:ok, "0x" <> Base.encode16(address, case: :lower)}
+  end
+
+  @spec create_public_key(module(), binary()) ::
+          {:ok, binary()} | {:error, :invalid_private_key}
+  defp create_public_key(secp256k1_module, private_key) do
+    case secp256k1_module.create_public_key(private_key) do
+      {:ok, public_key} -> {:ok, public_key}
+      {:error, _reason} -> {:error, :invalid_private_key}
+    end
+  end
+
+  @spec crypto_modules() :: {:ok, module(), module()} | {:error, :missing_dependency}
+  defp crypto_modules do
+    secp256k1_module = Module.concat(["ExSecp256k1"])
+
+    with {:ok, keccak_module} <- keccak_module(),
+         true <-
+           Code.ensure_loaded?(secp256k1_module) and
+             function_exported?(secp256k1_module, :create_public_key, 1) and
+             function_exported?(secp256k1_module, :recover_compact, 3) do
+      {:ok, secp256k1_module, keccak_module}
+    else
+      _unavailable -> {:error, :missing_dependency}
+    end
+  end
+
+  @spec keccak_module() :: {:ok, module()} | {:error, :missing_dependency}
+  defp keccak_module do
+    keccak_module = Module.concat(["ExKeccak"])
+
+    case Code.ensure_loaded?(keccak_module) and function_exported?(keccak_module, :hash_256, 1) do
+      true -> {:ok, keccak_module}
+      false -> {:error, :missing_dependency}
+    end
+  end
+end

--- a/lib/x402/signer.ex
+++ b/lib/x402/signer.ex
@@ -1,0 +1,104 @@
+defmodule X402.Signer do
+  @moduledoc """
+  Behaviour for client-side payment signers.
+
+  A signer produces the cryptographic signatures a payer client needs to
+  authorize x402 payments. Implementations are structs whose module implements
+  this behaviour; the library dispatches on the struct's module, so custom
+  signers (KMS-backed, hardware wallets, remote signing services) can be
+  supplied anywhere the library takes a signer.
+
+  ## Callback design
+
+  The reference SDKs expose two shapes: the TypeScript `ClientEvmSigner`
+  signs full EIP-712 *typed data* (`signTypedData`), because wallet-backed and
+  remote signers refuse raw digests, while the Go client signer signs the
+  precomputed EIP-712 *digest* from a local private key. This behaviour
+  supports both: `c:sign_eip712/3` receives the precomputed 32-byte digest
+  (sufficient for local keys and raw-signing KMS APIs) *and* the full typed
+  data map (domain/types/primaryType/message, mirroring the EIP-712 JSON
+  representation) for implementations that must reconstruct the message.
+
+  Implementations return the raw 65-byte `r || s || v` signature. `v` may be
+  `0`/`1` or `27`/`28`; the dispatcher normalizes it to `27`/`28` as expected
+  by EIP-3009 contracts.
+
+  ## Built-in implementation
+
+  `X402.Signer.LocalKey` signs with a raw secp256k1 private key and requires
+  the optional `ex_secp256k1` and `ex_keccak` dependencies.
+  """
+
+  @typedoc "A struct whose module implements `X402.Signer`."
+  @type t :: struct()
+
+  @typedoc """
+  EIP-712 typed data in its JSON representation.
+
+  Contains the `"domain"`, `"types"`, `"primaryType"`, and `"message"` keys.
+  """
+  @type typed_data :: map()
+
+  @typedoc "A raw 65-byte `r || s || v` signature."
+  @type signature :: <<_::520>>
+
+  @doc """
+  Returns the signer's payment address (for EVM, a `0x`-prefixed hex address).
+  """
+  @callback address(signer :: t()) :: {:ok, String.t()} | {:error, term()}
+
+  @doc """
+  Signs an EIP-712 digest and returns the 65-byte `r || s || v` signature.
+
+  `digest` is the precomputed 32-byte EIP-712 digest
+  (`keccak256(0x19 0x01 || domainSeparator || structHash)`). `typed_data` is
+  the full EIP-712 typed data for implementations that cannot sign raw
+  digests.
+  """
+  @callback sign_eip712(signer :: t(), digest :: binary(), typed_data :: typed_data()) ::
+              {:ok, signature()} | {:error, term()}
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the address of a signer, dispatching on its struct module.
+
+  ## Examples
+
+      iex> X402.Signer.address(:not_a_signer)
+      {:error, :invalid_signer}
+  """
+  @spec address(t()) :: {:ok, String.t()} | {:error, term()}
+  def address(%module{} = signer), do: module.address(signer)
+  def address(_signer), do: {:error, :invalid_signer}
+
+  @doc since: "0.6.0"
+  @doc """
+  Signs an EIP-712 digest with a signer, dispatching on its struct module.
+
+  Normalizes the recovery byte to `27`/`28` and rejects signatures that are
+  not 65 bytes with `{:error, :invalid_signature_format}`.
+
+  ## Examples
+
+      iex> X402.Signer.sign_eip712(:not_a_signer, <<0::256>>, %{})
+      {:error, :invalid_signer}
+  """
+  @spec sign_eip712(t(), binary(), typed_data()) :: {:ok, signature()} | {:error, term()}
+  def sign_eip712(%module{} = signer, digest, typed_data)
+      when is_binary(digest) and is_map(typed_data) do
+    with {:ok, signature} <- module.sign_eip712(signer, digest, typed_data) do
+      normalize_signature(signature)
+    end
+  end
+
+  def sign_eip712(_signer, _digest, _typed_data), do: {:error, :invalid_signer}
+
+  @spec normalize_signature(term()) :: {:ok, signature()} | {:error, :invalid_signature_format}
+  defp normalize_signature(<<compact::binary-size(64), v>>) when v in [0, 1],
+    do: {:ok, compact <> <<v + 27>>}
+
+  defp normalize_signature(<<_compact::binary-size(64), v>> = signature) when v in [27, 28],
+    do: {:ok, signature}
+
+  defp normalize_signature(_signature), do: {:error, :invalid_signature_format}
+end

--- a/lib/x402/signer/local_key.ex
+++ b/lib/x402/signer/local_key.ex
@@ -1,0 +1,119 @@
+defmodule X402.Signer.LocalKey do
+  @moduledoc """
+  `X402.Signer` backed by a raw secp256k1 private key held in memory.
+
+  Requires the optional `ex_secp256k1` and `ex_keccak` dependencies;
+  `new/1` returns `{:error, :missing_dependency}` when they are unavailable.
+
+  The struct redacts the private key when inspected, but the key still lives
+  in process memory — prefer an external signer implementation (KMS, hardware
+  wallet) for production payers holding significant funds.
+
+  ## Examples
+
+      {:ok, signer} = X402.Signer.LocalKey.new("0x" <> String.duplicate("11", 32))
+      {:ok, address} = X402.Signer.LocalKey.address(signer)
+  """
+
+  @behaviour X402.Signer
+
+  alias X402.EIP3009
+
+  @enforce_keys [:private_key, :address]
+  defstruct [:private_key, :address]
+
+  @typedoc "A local secp256k1 signing key with its derived EVM address."
+  @type t :: %__MODULE__{private_key: binary(), address: String.t()}
+
+  @doc since: "0.6.0"
+  @doc """
+  Builds a signer from a 32-byte secp256k1 private key.
+
+  Accepts the raw 32-byte binary or its hex encoding (with or without a
+  leading `0x`). The EVM address is derived once at construction.
+
+  Returns `{:error, :invalid_private_key}` for malformed keys and
+  `{:error, :missing_dependency}` when the optional `ex_secp256k1` /
+  `ex_keccak` dependencies are unavailable.
+
+  ## Examples
+
+      iex> X402.Signer.LocalKey.new("not hex")
+      {:error, :invalid_private_key}
+
+      iex> {:ok, signer} = X402.Signer.LocalKey.new("0x" <> String.duplicate("11", 32))
+      iex> signer.address
+      "0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a"
+  """
+  @spec new(binary()) :: {:ok, t()} | {:error, :invalid_private_key | :missing_dependency}
+  def new(private_key) when is_binary(private_key) do
+    with {:ok, key_bytes} <- normalize_key(private_key),
+         {:ok, address} <- EIP3009.derive_address(key_bytes) do
+      {:ok, %__MODULE__{private_key: key_bytes, address: address}}
+    end
+  end
+
+  def new(_private_key), do: {:error, :invalid_private_key}
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the EVM address derived from the private key.
+  """
+  @impl X402.Signer
+  @spec address(t()) :: {:ok, String.t()}
+  def address(%__MODULE__{address: address}), do: {:ok, address}
+
+  @doc since: "0.6.0"
+  @doc """
+  Signs the precomputed EIP-712 digest with the local key.
+
+  The typed data is ignored — a local key can sign the digest directly.
+  """
+  @impl X402.Signer
+  @spec sign_eip712(t(), binary(), X402.Signer.typed_data()) ::
+          {:ok, X402.Signer.signature()} | {:error, term()}
+  def sign_eip712(%__MODULE__{private_key: private_key}, digest, _typed_data)
+      when is_binary(digest) and byte_size(digest) == 32 do
+    with {:ok, secp256k1_module} <- secp256k1_module(),
+         {:ok, {signature, recovery_id}} <- secp256k1_module.sign_compact(digest, private_key) do
+      {:ok, signature <> <<recovery_id + 27>>}
+    end
+  end
+
+  def sign_eip712(%__MODULE__{}, _digest, _typed_data), do: {:error, :invalid_digest}
+
+  @spec normalize_key(binary()) :: {:ok, binary()} | {:error, :invalid_private_key}
+  defp normalize_key(key) when byte_size(key) == 32, do: {:ok, key}
+  defp normalize_key("0x" <> hex), do: decode_key_hex(hex)
+  defp normalize_key(hex) when byte_size(hex) == 64, do: decode_key_hex(hex)
+  defp normalize_key(_key), do: {:error, :invalid_private_key}
+
+  @spec decode_key_hex(binary()) :: {:ok, binary()} | {:error, :invalid_private_key}
+  defp decode_key_hex(hex) do
+    case Base.decode16(hex, case: :mixed) do
+      {:ok, key_bytes} when byte_size(key_bytes) == 32 -> {:ok, key_bytes}
+      _decoded -> {:error, :invalid_private_key}
+    end
+  end
+
+  # Resolved at runtime via Module.concat so the library compiles without the
+  # optional dependency (same pattern as X402.Extensions.SIWX.Verifier.Default).
+  @spec secp256k1_module() :: {:ok, module()} | {:error, :missing_dependency}
+  defp secp256k1_module do
+    secp256k1_module = Module.concat(["ExSecp256k1"])
+
+    case Code.ensure_loaded?(secp256k1_module) and
+           function_exported?(secp256k1_module, :sign_compact, 2) do
+      true -> {:ok, secp256k1_module}
+      false -> {:error, :missing_dependency}
+    end
+  end
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(%{address: address}, opts) do
+      concat(["#X402.Signer.LocalKey<address: ", to_doc(address, opts), ", ...>"])
+    end
+  end
+end

--- a/lib/x402/telemetry.ex
+++ b/lib/x402/telemetry.ex
@@ -14,15 +14,26 @@ defmodule X402.Telemetry do
   - `[:x402, :payment_signature, :decode_and_validate]`
   - `[:x402, :payment_response, :encode]`
   - `[:x402, :payment_response, :decode]`
+  - `[:x402, :client, :select]`
+  - `[:x402, :client, :sign]`
+  - `[:x402, :client, :build]`
+  - `[:x402, :client, :request]`
 
   Metadata always includes `:status` (`:ok` or `:error`) and may include
   additional operation-specific fields such as `:reason`, `:header`, or
   `:fields`.
   """
 
-  @type module_name :: :payment_required | :payment_signature | :payment_response
+  @type module_name :: :payment_required | :payment_signature | :payment_response | :client
   @type operation ::
-          :encode | :decode | :validate | :decode_and_validate
+          :encode
+          | :decode
+          | :validate
+          | :decode_and_validate
+          | :select
+          | :sign
+          | :build
+          | :request
   @type status :: :ok | :error
 
   @doc since: "0.1.0"

--- a/mix.exs
+++ b/mix.exs
@@ -116,6 +116,7 @@ defmodule X402.MixProject do
         "CHANGELOG.md": [title: "Changelog"],
         LICENSE: [title: "License"],
         "guides/getting-started.md": [title: "Getting Started"],
+        "guides/client.md": [title: "Paying for Resources"],
         "guides/plug-integration.md": [title: "Plug/Phoenix Integration"],
         "guides/live-smoke-tests.md": [title: "Live Smoke Tests"]
       ],
@@ -129,6 +130,13 @@ defmodule X402.MixProject do
           X402.PaymentRequired,
           X402.PaymentSignature,
           X402.PaymentResponse
+        ],
+        "Payer Client": [
+          X402.Client,
+          X402.Client.Finch,
+          X402.Signer,
+          X402.Signer.LocalKey,
+          X402.EIP3009
         ],
         "Facilitator Client": [
           X402.Facilitator,

--- a/test/support/x402_test_payments.ex
+++ b/test/support/x402_test_payments.ex
@@ -20,12 +20,14 @@ defmodule X402.TestPayments do
   #
   # The burner key lives in the `Config` so the receiver is resolved once and
   # `payload/2` and `requirements/1` agree even when called separately.
+  #
+  # All EIP-712/EIP-3009 cryptography delegates to `X402.EIP3009` — the
+  # library's payer-client signing code — so the logic exists exactly once.
+  # This module keeps its original raising/bare-value API for test ergonomics.
 
-  alias ExKeccak
-  alias ExSecp256k1
+  alias X402.EIP3009
+  alias X402.Signer.LocalKey
 
-  @eip712_domain_type "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
-  @transfer_with_authorization_type "TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
   @zero_address "0x0000000000000000000000000000000000000000"
 
   defmodule Config do
@@ -143,32 +145,14 @@ defmodule X402.TestPayments do
   """
   @spec payload(Config.t(), binary()) :: map()
   def payload(%Config{} = config, signer_key) when is_binary(signer_key) do
-    from = derive_address(signer_key)
-    now = System.os_time(:second)
-
-    authorization = %{
-      from: from,
-      to: receiver_for(config),
-      value: config.amount,
-      valid_after: Integer.to_string(now - 60),
-      valid_before: Integer.to_string(now + config.max_timeout),
-      nonce: random_nonce()
-    }
-
-    domain = %{
-      name: config.token_name,
-      version: config.token_version,
-      chain_id: chain_id_from_caip2(config.network),
-      verifying_contract: config.contract
-    }
+    {:ok, signer} = LocalKey.new(signer_key)
+    requirements = requirements(config)
+    {:ok, scheme_payload} = EIP3009.sign(requirements, signer, valid_after_buffer: 60)
 
     %{
       "x402Version" => 2,
-      "accepted" => requirements(config),
-      "payload" => %{
-        "signature" => sign_transfer_with_authorization(signer_key, domain, authorization),
-        "authorization" => authorization_map(authorization)
-      },
+      "accepted" => requirements,
+      "payload" => scheme_payload,
       "resource" => %{
         "url" => config.resource,
         "mimeType" => "application/json"
@@ -192,9 +176,9 @@ defmodule X402.TestPayments do
   """
   @spec sign_transfer_with_authorization(binary(), map(), map()) :: String.t()
   def sign_transfer_with_authorization(private_key, domain, authorization) do
-    digest = eip712_digest(domain, authorization)
-    {:ok, {signature, recovery_id}} = ExSecp256k1.sign_compact(digest, private_key)
-    "0x" <> Base.encode16(signature <> <<recovery_id + 27>>, case: :lower)
+    {:ok, signer} = LocalKey.new(private_key)
+    {:ok, signature} = EIP3009.sign_authorization(signer, domain, authorization)
+    signature
   end
 
   @doc """
@@ -202,7 +186,8 @@ defmodule X402.TestPayments do
   """
   @spec eip712_digest(map(), map()) :: binary()
   def eip712_digest(domain, authorization) do
-    ExKeccak.hash_256(<<0x19, 0x01>> <> domain_separator(domain) <> struct_hash(authorization))
+    {:ok, digest} = EIP3009.eip712_digest(domain, authorization)
+    digest
   end
 
   @doc """
@@ -210,8 +195,8 @@ defmodule X402.TestPayments do
   """
   @spec derive_address(binary()) :: String.t()
   def derive_address(private_key) do
-    {:ok, public_key} = ExSecp256k1.create_public_key(private_key)
-    public_key_to_address(public_key)
+    {:ok, address} = EIP3009.derive_address(private_key)
+    address
   end
 
   @doc """
@@ -219,37 +204,42 @@ defmodule X402.TestPayments do
   lowercase `0x`-prefixed EVM address.
   """
   @spec public_key_to_address(binary()) :: String.t()
-  def public_key_to_address(<<4, public_key::binary-size(64)>>), do: hash_to_address(public_key)
-  def public_key_to_address(<<public_key::binary-size(64)>>), do: hash_to_address(public_key)
+  def public_key_to_address(public_key) do
+    {:ok, address} = EIP3009.public_key_to_address(public_key)
+    address
+  end
 
   @doc """
   Returns a fresh random 32-byte nonce as a `0x`-prefixed hex string.
   """
   @spec random_nonce() :: String.t()
-  def random_nonce do
-    "0x" <> Base.encode16(:crypto.strong_rand_bytes(32), case: :lower)
-  end
+  defdelegate random_nonce, to: EIP3009
 
   @doc """
   Extracts the chain id from an `eip155:<chainId>` CAIP-2 network identifier.
   """
   @spec chain_id_from_caip2(String.t()) :: non_neg_integer()
-  def chain_id_from_caip2("eip155:" <> chain_id) when chain_id != "",
-    do: String.to_integer(chain_id)
+  def chain_id_from_caip2(network) do
+    case EIP3009.chain_id_from_caip2(network) do
+      {:ok, chain_id} ->
+        chain_id
 
-  def chain_id_from_caip2(other),
-    do: raise(ArgumentError, "expected an eip155: CAIP-2 network, got: #{inspect(other)}")
+      {:error, :unsupported_network} ->
+        raise(ArgumentError, "expected an eip155: CAIP-2 network, got: #{inspect(network)}")
+    end
+  end
 
   @doc """
   ABI-encodes an address into a 32-byte word.
   """
   @spec encode_address(String.t()) :: binary()
-  def encode_address("0x" <> hex) do
-    {:ok, address} = Base.decode16(String.upcase(hex), case: :mixed)
+  def encode_address(address) do
+    case EIP3009.encode_address(address) do
+      {:ok, word} ->
+        word
 
-    case byte_size(address) do
-      20 -> <<0::unsigned-big-integer-size(96), address::binary>>
-      _ -> raise(ArgumentError, "invalid EVM address: 0x#{hex}")
+      {:error, :invalid_address} ->
+        raise(ArgumentError, "invalid EVM address: #{inspect(address)}")
     end
   end
 
@@ -257,63 +247,27 @@ defmodule X402.TestPayments do
   ABI-encodes a non-negative integer (or decimal string) into a 32-byte word.
   """
   @spec encode_uint256(integer() | String.t()) :: binary()
-  def encode_uint256(integer) when is_integer(integer) and integer >= 0,
-    do: <<integer::unsigned-big-integer-size(256)>>
-
-  def encode_uint256(string) when is_binary(string),
-    do: encode_uint256(String.to_integer(string))
+  def encode_uint256(value) do
+    case EIP3009.encode_uint256(value) do
+      {:ok, word} -> word
+      {:error, :invalid_amount} -> raise(ArgumentError, "invalid uint256: #{inspect(value)}")
+    end
+  end
 
   @doc """
-  Decodes a `0x`-prefixed hex string into its raw bytes.
+  Decodes a `0x`-prefixed hex string into its raw 32 bytes.
   """
   @spec encode_bytes32(String.t()) :: binary()
-  def encode_bytes32("0x" <> hex) do
-    {:ok, bytes} = Base.decode16(String.upcase(hex), case: :mixed)
-    bytes
+  def encode_bytes32(value) do
+    case EIP3009.encode_bytes32(value) do
+      {:ok, bytes} -> bytes
+      {:error, :invalid_bytes32} -> raise(ArgumentError, "invalid bytes32: #{inspect(value)}")
+    end
   end
 
   defp receiver_for(%Config{receiver: receiver}) when is_binary(receiver), do: receiver
   defp receiver_for(%Config{receiver_key: key}) when is_binary(key), do: derive_address(key)
   defp receiver_for(%Config{}), do: @zero_address
-
-  defp domain_separator(domain) do
-    ExKeccak.hash_256(
-      ExKeccak.hash_256(@eip712_domain_type) <>
-        ExKeccak.hash_256(domain.name) <>
-        ExKeccak.hash_256(domain.version) <>
-        encode_uint256(domain.chain_id) <>
-        encode_address(domain.verifying_contract)
-    )
-  end
-
-  defp struct_hash(authorization) do
-    ExKeccak.hash_256(
-      ExKeccak.hash_256(@transfer_with_authorization_type) <>
-        encode_address(authorization.from) <>
-        encode_address(authorization.to) <>
-        encode_uint256(authorization.value) <>
-        encode_uint256(authorization.valid_after) <>
-        encode_uint256(authorization.valid_before) <>
-        encode_bytes32(authorization.nonce)
-    )
-  end
-
-  defp authorization_map(authorization) do
-    %{
-      "from" => authorization.from,
-      "to" => authorization.to,
-      "value" => authorization.value,
-      "validAfter" => authorization.valid_after,
-      "validBefore" => authorization.valid_before,
-      "nonce" => authorization.nonce
-    }
-  end
-
-  defp hash_to_address(public_key) do
-    hash = ExKeccak.hash_256(public_key)
-    address = binary_part(hash, byte_size(hash) - 20, 20)
-    "0x" <> Base.encode16(address, case: :lower)
-  end
 
   defp fetch(env, name) do
     case env.(name) do

--- a/test/x402/client/finch_test.exs
+++ b/test/x402/client/finch_test.exs
@@ -1,0 +1,391 @@
+defmodule X402.Client.FinchTest do
+  use ExUnit.Case, async: false
+
+  alias Plug.Conn
+  alias X402.Client
+  alias X402.Client.Finch, as: FinchClient
+  alias X402.Extensions.PaymentIdentifier.ETSCache
+  alias X402.PaymentRequired
+  alias X402.PaymentResponse
+  alias X402.PaymentSignature
+  alias X402.Plug.PaymentGate
+  alias X402.Signer.LocalKey
+
+  import X402.TestHelpers
+
+  @receiver "0x2222222222222222222222222222222222222222"
+  @contract "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+
+  @requirements %{
+    "scheme" => "exact",
+    "network" => "eip155:84532",
+    "amount" => "10000",
+    "asset" => @contract,
+    "payTo" => @receiver,
+    "maxTimeoutSeconds" => 300,
+    "extra" => %{"name" => "USDC", "version" => "2"}
+  }
+
+  @payment_required %{
+    "x402Version" => 2,
+    "error" => "PAYMENT-SIGNATURE header is required",
+    "resource" => %{"url" => "https://api.example.com/paid", "mimeType" => "application/json"},
+    "accepts" => [@requirements],
+    "extensions" => %{}
+  }
+
+  @settlement %{
+    "success" => true,
+    "transaction" => "0x" <> String.duplicate("ab", 32),
+    "network" => "eip155:84532",
+    "payer" => "0x1111111111111111111111111111111111111111"
+  }
+
+  defmodule StubFacilitator do
+    @moduledoc false
+    # Speaks the X402.Facilitator call protocol so X402.Plug.PaymentGate can be
+    # exercised end-to-end without HTTP round-trips to a facilitator.
+    use GenServer
+
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl true
+    def init(opts), do: {:ok, %{owner: Keyword.fetch!(opts, :owner)}}
+
+    @impl true
+    def handle_call({:verify, payload, requirements}, _from, state) do
+      send(state.owner, {:facilitator_verify, payload, requirements})
+
+      {:reply,
+       {:ok,
+        %{
+          status: 200,
+          body: %{"isValid" => true, "payer" => payload["payload"]["authorization"]["from"]}
+        }}, state}
+    end
+
+    def handle_call({:settle, payload, requirements}, _from, state) do
+      send(state.owner, {:facilitator_settle, payload, requirements})
+
+      {:reply,
+       {:ok,
+        %{
+          status: 200,
+          body: %{
+            "success" => true,
+            "transaction" => "0x" <> String.duplicate("cd", 32),
+            "network" => requirements["network"],
+            "payer" => payload["payload"]["authorization"]["from"]
+          }
+        }}, state}
+    end
+  end
+
+  setup :setup_bypass
+  setup :setup_finch
+
+  setup do
+    {:ok, signer} = LocalKey.new(:crypto.strong_rand_bytes(32))
+    {:ok, signer: signer}
+  end
+
+  defp url(bypass, path), do: "http://localhost:#{bypass.port}#{path}"
+
+  defp respond_402(conn) do
+    {:ok, header} = PaymentRequired.encode(@payment_required)
+
+    conn
+    |> Conn.put_resp_header("payment-required", header)
+    |> Conn.resp(402, "{}")
+  end
+
+  describe "request/3 payment flow" do
+    test "pays a 402 and returns the settled response", %{
+      bypass: bypass,
+      finch: finch,
+      signer: signer
+    } do
+      test_pid = self()
+
+      Bypass.expect(bypass, "GET", "/paid", fn conn ->
+        case Conn.get_req_header(conn, "payment-signature") do
+          [] ->
+            respond_402(conn)
+
+          [header] ->
+            send(test_pid, {:payment_header, header})
+            {:ok, response_header} = PaymentResponse.encode(@settlement)
+
+            conn
+            |> Conn.put_resp_header("payment-response", response_header)
+            |> Conn.resp(200, ~s({"data":42}))
+        end
+      end)
+
+      assert {:ok, response} =
+               FinchClient.request(finch, url(bypass, "/paid"), signer: signer)
+
+      assert response.status == 200
+      assert response.body == ~s({"data":42})
+      assert response.payment_response == @settlement
+
+      # The wire header we sent validates against the advertised requirements.
+      assert_received {:payment_header, header}
+      assert {:ok, payload} = PaymentSignature.decode_and_validate(header, @requirements)
+      assert payload["accepted"] == @requirements
+      assert payload["payload"]["authorization"]["to"] == @receiver
+    end
+
+    test "returns non-402 responses untouched, without paying", %{
+      bypass: bypass,
+      finch: finch,
+      signer: signer
+    } do
+      Bypass.expect_once(bypass, "GET", "/free", fn conn ->
+        Conn.resp(conn, 200, "free")
+      end)
+
+      assert {:ok, %{status: 200, body: "free", payment_response: nil}} =
+               FinchClient.request(finch, url(bypass, "/free"), signer: signer)
+    end
+
+    test "returns a 402 without a PAYMENT-REQUIRED header as-is", %{
+      bypass: bypass,
+      finch: finch,
+      signer: signer
+    } do
+      Bypass.expect_once(bypass, "GET", "/not-x402", fn conn ->
+        Conn.resp(conn, 402, "nope")
+      end)
+
+      assert {:ok, %{status: 402, body: "nope", payment_response: nil}} =
+               FinchClient.request(finch, url(bypass, "/not-x402"), signer: signer)
+    end
+
+    test "never pays twice: a second 402 is returned without another attempt", %{
+      bypass: bypass,
+      finch: finch,
+      signer: signer
+    } do
+      counter = :counters.new(1, [])
+
+      Bypass.expect(bypass, "GET", "/always-402", fn conn ->
+        :counters.add(counter, 1, 1)
+        respond_402(conn)
+      end)
+
+      assert {:ok, %{status: 402}} =
+               FinchClient.request(finch, url(bypass, "/always-402"), signer: signer)
+
+      assert :counters.get(counter, 1) == 2
+    end
+
+    test "refuses to pay when the request already carries a payment", %{
+      bypass: bypass,
+      finch: finch,
+      signer: signer
+    } do
+      Bypass.expect_once(bypass, "GET", "/paid", fn conn -> respond_402(conn) end)
+
+      assert FinchClient.request(finch, url(bypass, "/paid"),
+               signer: signer,
+               headers: [{"PAYMENT-SIGNATURE", "stale"}]
+             ) == {:error, :payment_already_attempted}
+    end
+
+    test "the on_payment_required hook sees the offer and can cancel", %{
+      bypass: bypass,
+      finch: finch,
+      signer: signer
+    } do
+      test_pid = self()
+      Bypass.expect_once(bypass, "GET", "/paid", fn conn -> respond_402(conn) end)
+
+      assert FinchClient.request(finch, url(bypass, "/paid"),
+               signer: signer,
+               on_payment_required: fn payment_required ->
+                 send(test_pid, {:offer, payment_required})
+                 :cancel
+               end
+             ) == {:error, :payment_cancelled}
+
+      assert_received {:offer, offer}
+      assert offer["accepts"] == [@requirements]
+    end
+
+    test "selection options narrow what the client will pay", %{
+      bypass: bypass,
+      finch: finch,
+      signer: signer
+    } do
+      Bypass.expect_once(bypass, "GET", "/paid", fn conn -> respond_402(conn) end)
+
+      assert FinchClient.request(finch, url(bypass, "/paid"),
+               signer: signer,
+               max_amount: "100"
+             ) == {:error, :no_acceptable_requirements}
+    end
+
+    test "returns a structured error for an invalid PAYMENT-REQUIRED header", %{
+      bypass: bypass,
+      finch: finch,
+      signer: signer
+    } do
+      Bypass.expect_once(bypass, "GET", "/paid", fn conn ->
+        conn
+        |> Conn.put_resp_header("payment-required", "%%%not-base64%%%")
+        |> Conn.resp(402, "{}")
+      end)
+
+      assert FinchClient.request(finch, url(bypass, "/paid"), signer: signer) ==
+               {:error, {:invalid_payment_required, :invalid_base64}}
+    end
+
+    test "returns transport errors", %{bypass: bypass, finch: finch, signer: signer} do
+      Bypass.down(bypass)
+
+      assert {:error, {:transport_error, _reason}} =
+               FinchClient.request(finch, url(bypass, "/paid"), signer: signer)
+    end
+
+    test "a hook returning anything but :cancel continues the payment", %{
+      bypass: bypass,
+      finch: finch,
+      signer: signer
+    } do
+      Bypass.expect(bypass, "GET", "/paid", fn conn ->
+        case Conn.get_req_header(conn, "payment-signature") do
+          [] -> respond_402(conn)
+          [_header] -> Conn.resp(conn, 200, "paid")
+        end
+      end)
+
+      assert {:ok, %{status: 200, body: "paid"}} =
+               FinchClient.request(finch, url(bypass, "/paid"),
+                 signer: signer,
+                 on_payment_required: fn _payment_required -> :ok end
+               )
+    end
+
+    test "an unparseable PAYMENT-RESPONSE header yields payment_response: nil", %{
+      bypass: bypass,
+      finch: finch,
+      signer: signer
+    } do
+      Bypass.expect_once(bypass, "GET", "/paid", fn conn ->
+        conn
+        |> Conn.put_resp_header("payment-response", "%%%")
+        |> Conn.resp(200, "ok")
+      end)
+
+      assert {:ok, %{status: 200, payment_response: nil}} =
+               FinchClient.request(finch, url(bypass, "/paid"), signer: signer)
+    end
+
+    test "rejects plaintext non-loopback URLs", %{finch: finch, signer: signer} do
+      assert FinchClient.request(finch, "http://example.com/paid", signer: signer) ==
+               {:error, :insecure_url}
+    end
+
+    test "accepts https URLs", %{finch: finch, signer: signer} do
+      # TLS to a closed local port: passes URL validation, fails at transport.
+      assert {:error, {:transport_error, _reason}} =
+               FinchClient.request(finch, "https://localhost:1", signer: signer)
+    end
+
+    test "validates options", %{finch: finch} do
+      assert_raise NimbleOptions.ValidationError, fn ->
+        FinchClient.request(finch, "https://example.com", [])
+      end
+
+      assert_raise NimbleOptions.ValidationError, fn ->
+        FinchClient.request(finch, "https://example.com", signer: :nope)
+      end
+
+      assert_raise NimbleOptions.ValidationError, fn ->
+        FinchClient.request(finch, "https://example.com", signer: %URI{})
+      end
+
+      {:ok, signer} = LocalKey.new(:crypto.strong_rand_bytes(32))
+
+      assert_raise NimbleOptions.ValidationError, fn ->
+        FinchClient.request(finch, "https://example.com",
+          signer: signer,
+          headers: [{"name", 1}]
+        )
+      end
+
+      assert_raise NimbleOptions.ValidationError, fn ->
+        FinchClient.request(finch, "https://example.com",
+          signer: signer,
+          headers: "nope"
+        )
+      end
+    end
+  end
+
+  describe "end-to-end against X402.Plug.PaymentGate" do
+    test "full 402 → sign → verify → settle loop through this SDK's own gate", %{
+      bypass: bypass,
+      finch: finch,
+      signer: signer
+    } do
+      facilitator = start_supervised!({StubFacilitator, owner: self()})
+      cache = start_supervised!({ETSCache, []})
+
+      gate_opts =
+        PaymentGate.init(
+          facilitator: facilitator,
+          payment_identifier_cache: cache,
+          routes: [
+            %{
+              method: :get,
+              path: "/premium",
+              price: "10000",
+              network: "eip155:84532",
+              asset: @contract,
+              pay_to: @receiver,
+              max_timeout_seconds: 300,
+              extra: %{"name" => "USDC", "version" => "2"}
+            }
+          ]
+        )
+
+      Bypass.expect(bypass, "GET", "/premium", fn conn ->
+        conn = PaymentGate.call(conn, gate_opts)
+
+        case conn.halted do
+          true -> conn
+          false -> Conn.send_resp(conn, 200, ~s({"premium":true}))
+        end
+      end)
+
+      assert {:ok, response} =
+               FinchClient.request(finch, url(bypass, "/premium"), signer: signer)
+
+      assert response.status == 200
+      assert response.body == ~s({"premium":true})
+
+      assert %{"success" => true, "transaction" => "0x" <> _tx, "network" => "eip155:84532"} =
+               response.payment_response
+
+      # The gate verified and settled the exact payload we signed.
+      assert_received {:facilitator_verify, verify_payload, verify_requirements}
+      assert verify_payload["payload"]["authorization"]["from"] == signer.address
+      assert verify_requirements["payTo"] == @receiver
+
+      assert_received {:facilitator_settle, settle_payload, _settle_requirements}
+      assert settle_payload["payload"]["authorization"]["value"] == "10000"
+    end
+  end
+
+  describe "without the Finch dependency" do
+    test "build_payment and encode_payment stay usable with any HTTP client", %{signer: signer} do
+      # The transport-agnostic core drives the same flow without Finch:
+      {:ok, payload} = Client.build_payment(@payment_required, signer)
+      {:ok, header} = Client.encode_payment(payload)
+
+      assert {:ok, _decoded} = PaymentSignature.decode_and_validate(header, @requirements)
+    end
+  end
+end

--- a/test/x402/client_test.exs
+++ b/test/x402/client_test.exs
@@ -1,0 +1,271 @@
+defmodule X402.ClientTest do
+  use ExUnit.Case, async: true
+
+  doctest X402.Client
+
+  alias X402.Client
+  alias X402.PaymentRequirements
+  alias X402.PaymentSignature
+  alias X402.Signer.LocalKey
+
+  @receiver "0x2222222222222222222222222222222222222222"
+  @contract "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+
+  @evm_requirements %{
+    "scheme" => "exact",
+    "network" => "eip155:84532",
+    "amount" => "10000",
+    "asset" => @contract,
+    "payTo" => @receiver,
+    "maxTimeoutSeconds" => 300,
+    "extra" => %{"name" => "USDC", "version" => "2"}
+  }
+
+  @solana_requirements %{
+    "scheme" => "exact",
+    "network" => "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+    "amount" => "10000",
+    "asset" => "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "payTo" => "9xQeWvG816bUx9EPfQmQTYnC16hHhV6bQf8kX6y4YB9",
+    "maxTimeoutSeconds" => 300,
+    "extra" => %{}
+  }
+
+  @payment_required %{
+    "x402Version" => 2,
+    "error" => "PAYMENT-SIGNATURE header is required",
+    "resource" => %{"url" => "https://api.example.com/paid", "mimeType" => "application/json"},
+    "accepts" => [@evm_requirements],
+    "extensions" => %{}
+  }
+
+  defp signer do
+    {:ok, signer} = LocalKey.new(:crypto.strong_rand_bytes(32))
+    signer
+  end
+
+  describe "select_requirements/2" do
+    test "skips unsupported kinds and picks the first signable entry" do
+      payment_required = %{
+        "x402Version" => 2,
+        "accepts" => [
+          @solana_requirements,
+          Map.put(@evm_requirements, "scheme", "upto"),
+          @evm_requirements
+        ]
+      }
+
+      assert Client.select_requirements(payment_required) == {:ok, @evm_requirements}
+    end
+
+    test "skips entries missing the EIP-712 domain fields" do
+      no_domain = Map.put(@evm_requirements, "extra", %{})
+      payment_required = %{"accepts" => [no_domain, @evm_requirements]}
+
+      assert Client.select_requirements(payment_required) == {:ok, @evm_requirements}
+    end
+
+    test "skips structurally invalid entries and non-map entries" do
+      invalid = Map.delete(@evm_requirements, "payTo")
+      payment_required = %{"accepts" => ["nope", invalid, @evm_requirements]}
+
+      assert Client.select_requirements(payment_required) == {:ok, @evm_requirements}
+    end
+
+    test "accepts a bare list of requirements" do
+      assert Client.select_requirements([@evm_requirements]) == {:ok, @evm_requirements}
+    end
+
+    test "filters by exact and wildcard network" do
+      base = Map.put(@evm_requirements, "network", "eip155:8453")
+      testnet = @evm_requirements
+      payment_required = %{"accepts" => [base, testnet]}
+
+      assert Client.select_requirements(payment_required, network: "eip155:84532") ==
+               {:ok, testnet}
+
+      assert Client.select_requirements(payment_required, network: "eip155:*") == {:ok, base}
+
+      assert Client.select_requirements(payment_required, network: "eip155:1") ==
+               {:error, :no_acceptable_requirements}
+    end
+
+    test "filters by scheme" do
+      upto = Map.put(@evm_requirements, "scheme", "upto")
+      payment_required = %{"accepts" => [upto, @evm_requirements]}
+
+      assert Client.select_requirements(payment_required, scheme: "exact") ==
+               {:ok, @evm_requirements}
+
+      # The only upto entry is filtered in but cannot be signed.
+      assert Client.select_requirements(%{"accepts" => [upto]}, scheme: "upto") ==
+               {:error, :no_acceptable_requirements}
+    end
+
+    test "filters by asset, case-insensitively" do
+      assert Client.select_requirements([@evm_requirements],
+               asset: String.downcase(@contract)
+             ) == {:ok, @evm_requirements}
+
+      assert Client.select_requirements([@evm_requirements], asset: "0xother") ==
+               {:error, :no_acceptable_requirements}
+    end
+
+    test "filters by max_amount as budget guard" do
+      cheap = Map.put(@evm_requirements, "amount", "100")
+      payment_required = %{"accepts" => [@evm_requirements, cheap]}
+
+      assert Client.select_requirements(payment_required, max_amount: "500") == {:ok, cheap}
+      assert Client.select_requirements(payment_required, max_amount: 500) == {:ok, cheap}
+
+      assert Client.select_requirements(payment_required, max_amount: 10_000) ==
+               {:ok, @evm_requirements}
+
+      assert Client.select_requirements(payment_required, max_amount: 50) ==
+               {:error, :no_acceptable_requirements}
+    end
+
+    test "returns structured errors for malformed input" do
+      assert Client.select_requirements(%{"accepts" => "nope"}) ==
+               {:error, :invalid_payment_required}
+
+      assert Client.select_requirements("nope") == {:error, :invalid_payment_required}
+
+      assert Client.select_requirements(%{"accepts" => []}) ==
+               {:error, :no_acceptable_requirements}
+    end
+
+    test "raises on invalid options" do
+      assert_raise NimbleOptions.ValidationError, fn ->
+        Client.select_requirements(@payment_required, network: 123)
+      end
+    end
+  end
+
+  describe "build_payment/3" do
+    test "builds a v2 payload echoing the full requirements, resource, and extensions" do
+      payment_required =
+        Map.put(@payment_required, "extensions", %{
+          "example" => %{"info" => %{"required" => true}, "schema" => %{}}
+        })
+
+      signer = signer()
+
+      assert {:ok, payload} = Client.build_payment(payment_required, signer)
+
+      assert payload["x402Version"] == 2
+      assert payload["accepted"] == @evm_requirements
+      assert payload["resource"] == payment_required["resource"]
+      assert payload["extensions"] == payment_required["extensions"]
+
+      assert %{"signature" => "0x" <> _hex, "authorization" => authorization} =
+               payload["payload"]
+
+      assert authorization["from"] == signer.address
+      assert authorization["to"] == @receiver
+      assert authorization["value"] == "10000"
+    end
+
+    test "round-trips through the validation side of this library" do
+      signer = signer()
+
+      assert {:ok, payload} = Client.build_payment(@payment_required, signer)
+      assert {:ok, header} = Client.encode_payment(payload)
+
+      # Prove self-interop: the server-side validator accepts what we built.
+      assert {:ok, decoded} = PaymentSignature.decode_and_validate(header, @evm_requirements)
+      assert decoded == payload
+
+      # And the extension echo passes the same check the gate applies.
+      assert PaymentRequirements.extensions_match?(
+               @payment_required["extensions"],
+               payload["extensions"]
+             )
+    end
+
+    test "omits resource and extensions when the server sent none" do
+      payment_required = Map.drop(@payment_required, ["resource", "extensions"])
+
+      assert {:ok, payload} = Client.build_payment(payment_required, signer())
+      refute Map.has_key?(payload, "resource")
+      refute Map.has_key?(payload, "extensions")
+    end
+
+    test "accepts a single requirements map, skipping selection" do
+      assert {:ok, payload} = Client.build_payment(@evm_requirements, signer())
+
+      assert payload["accepted"] == @evm_requirements
+      refute Map.has_key?(payload, "resource")
+      refute Map.has_key?(payload, "extensions")
+    end
+
+    test "applies selection filters" do
+      cheap = Map.put(@evm_requirements, "amount", "100")
+      payment_required = Map.put(@payment_required, "accepts", [@evm_requirements, cheap])
+
+      assert {:ok, payload} = Client.build_payment(payment_required, signer(), max_amount: 500)
+      assert payload["accepted"] == cheap
+
+      assert Client.build_payment(payment_required, signer(), max_amount: 50) ==
+               {:error, :no_acceptable_requirements}
+    end
+
+    test "returns unsupported_kind for schemes and networks it cannot sign" do
+      upto = Map.put(@evm_requirements, "scheme", "upto")
+
+      assert Client.build_payment(upto, signer()) ==
+               {:error, {:unsupported_kind, "upto", "eip155:84532"}}
+
+      assert Client.build_payment(@solana_requirements, signer()) ==
+               {:error, {:unsupported_kind, "exact", "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"}}
+    end
+
+    test "propagates signing errors for bare requirements" do
+      missing_domain = Map.put(@evm_requirements, "extra", %{})
+
+      assert Client.build_payment(missing_domain, signer()) ==
+               {:error, {:missing_extra, "name"}}
+    end
+
+    test "rejects malformed input" do
+      assert Client.build_payment("nope", signer()) == {:error, :invalid_payment_required}
+    end
+
+    test "emits telemetry for select, sign, and build" do
+      ref = make_ref()
+      test_pid = self()
+
+      events = [
+        [:x402, :client, :select],
+        [:x402, :client, :sign],
+        [:x402, :client, :build]
+      ]
+
+      :telemetry.attach_many(
+        {__MODULE__, ref},
+        events,
+        fn event, _measurements, metadata, _config ->
+          send(test_pid, {:telemetry, event, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach({__MODULE__, ref}) end)
+
+      assert {:ok, _payload} = Client.build_payment(@payment_required, signer())
+
+      assert_received {:telemetry, [:x402, :client, :select], %{status: :ok}}
+      assert_received {:telemetry, [:x402, :client, :sign], %{status: :ok}}
+      assert_received {:telemetry, [:x402, :client, :build], %{status: :ok}}
+
+      assert {:error, _reason} = Client.build_payment(%{"accepts" => []}, signer())
+      assert_received {:telemetry, [:x402, :client, :build], %{status: :error}}
+    end
+  end
+
+  describe "encode_payment/1" do
+    test "returns invalid_json for unencodable payloads" do
+      assert Client.encode_payment(%{"pid" => self()}) == {:error, :invalid_json}
+    end
+  end
+end

--- a/test/x402/eip3009_test.exs
+++ b/test/x402/eip3009_test.exs
@@ -1,0 +1,298 @@
+defmodule X402.EIP3009Test do
+  use ExUnit.Case, async: true
+
+  doctest X402.EIP3009
+
+  alias X402.EIP3009
+  alias X402.Signer.LocalKey
+  alias X402.TestPayments
+
+  @receiver "0x2222222222222222222222222222222222222222"
+  @contract "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+
+  @requirements %{
+    "scheme" => "exact",
+    "network" => "eip155:84532",
+    "amount" => "10000",
+    "asset" => @contract,
+    "payTo" => @receiver,
+    "maxTimeoutSeconds" => 300,
+    "extra" => %{"name" => "USDC", "version" => "2"}
+  }
+
+  @domain %{
+    name: "USDC",
+    version: "2",
+    chain_id: 84_532,
+    verifying_contract: @contract
+  }
+
+  defp signer(key \\ :crypto.strong_rand_bytes(32)) do
+    {:ok, signer} = LocalKey.new(key)
+    signer
+  end
+
+  describe "domain/1" do
+    test "derives the EIP-712 domain from requirements" do
+      assert EIP3009.domain(@requirements) ==
+               {:ok,
+                %{
+                  name: "USDC",
+                  version: "2",
+                  chain_id: 84_532,
+                  verifying_contract: @contract
+                }}
+    end
+
+    test "accepts an explicit eip3009 assetTransferMethod" do
+      requirements =
+        put_in(@requirements, ["extra", "assetTransferMethod"], "eip3009")
+
+      assert {:ok, _domain} = EIP3009.domain(requirements)
+    end
+
+    test "rejects non-default transfer methods" do
+      requirements = put_in(@requirements, ["extra", "assetTransferMethod"], "permit2")
+
+      assert EIP3009.domain(requirements) == {:error, {:unsupported_transfer_method, "permit2"}}
+    end
+
+    test "requires extra.name and extra.version" do
+      assert EIP3009.domain(Map.put(@requirements, "extra", %{"version" => "2"})) ==
+               {:error, {:missing_extra, "name"}}
+
+      assert EIP3009.domain(Map.put(@requirements, "extra", %{"name" => "USDC"})) ==
+               {:error, {:missing_extra, "version"}}
+
+      assert EIP3009.domain(Map.delete(@requirements, "extra")) ==
+               {:error, {:missing_extra, "name"}}
+    end
+
+    test "rejects non-EVM networks and malformed chain ids" do
+      solana = Map.put(@requirements, "network", "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp")
+      assert EIP3009.domain(solana) == {:error, :unsupported_network}
+
+      assert EIP3009.domain(Map.put(@requirements, "network", "eip155:")) ==
+               {:error, :unsupported_network}
+
+      assert EIP3009.domain(Map.put(@requirements, "network", "eip155:abc")) ==
+               {:error, :unsupported_network}
+    end
+
+    test "rejects malformed requirements" do
+      assert EIP3009.domain("not a map") == {:error, :invalid_requirements}
+
+      assert EIP3009.domain(Map.put(@requirements, "extra", "nope")) ==
+               {:error, :invalid_requirements}
+
+      assert EIP3009.domain(Map.delete(@requirements, "asset")) == {:error, :invalid_requirements}
+    end
+  end
+
+  describe "build_authorization/3" do
+    test "builds a wire-shape authorization from requirements" do
+      from = "0x1111111111111111111111111111111111111111"
+      now = System.os_time(:second)
+
+      assert {:ok, authorization} = EIP3009.build_authorization(@requirements, from)
+
+      assert authorization["from"] == from
+      assert authorization["to"] == @receiver
+      assert authorization["value"] == "10000"
+      assert String.match?(authorization["nonce"], ~r/^0x[0-9a-f]{64}$/)
+
+      valid_after = String.to_integer(authorization["validAfter"])
+      valid_before = String.to_integer(authorization["validBefore"])
+      assert_in_delta valid_after, now - 60, 2
+      assert_in_delta valid_before, now + 300, 2
+    end
+
+    test "honors the valid_after_buffer option" do
+      from = "0x1111111111111111111111111111111111111111"
+      now = System.os_time(:second)
+
+      assert {:ok, authorization} =
+               EIP3009.build_authorization(@requirements, from, valid_after_buffer: 0)
+
+      assert_in_delta String.to_integer(authorization["validAfter"]), now, 2
+    end
+
+    test "generates a fresh nonce per authorization" do
+      from = "0x1111111111111111111111111111111111111111"
+      {:ok, first} = EIP3009.build_authorization(@requirements, from)
+      {:ok, second} = EIP3009.build_authorization(@requirements, from)
+
+      assert first["nonce"] != second["nonce"]
+    end
+
+    test "rejects requirements missing amount, payTo, or maxTimeoutSeconds" do
+      from = "0x1111111111111111111111111111111111111111"
+
+      for missing <- ["amount", "payTo", "maxTimeoutSeconds"] do
+        assert EIP3009.build_authorization(Map.delete(@requirements, missing), from) ==
+                 {:error, :invalid_requirements}
+      end
+    end
+  end
+
+  describe "eip712_digest/2" do
+    test "matches the battle-tested test-support digest for the same vectors" do
+      authorization = %{
+        from: "0x1111111111111111111111111111111111111111",
+        to: @receiver,
+        value: "1",
+        valid_after: "0",
+        valid_before: "9999999999",
+        nonce: "0x" <> String.duplicate("ab", 32)
+      }
+
+      assert {:ok, digest} = EIP3009.eip712_digest(@domain, authorization)
+      assert byte_size(digest) == 32
+      assert digest == TestPayments.eip712_digest(@domain, authorization)
+    end
+
+    test "wire-style keys and internal keys produce the same digest" do
+      wire_authorization = %{
+        "from" => "0x1111111111111111111111111111111111111111",
+        "to" => @receiver,
+        "value" => "1",
+        "validAfter" => "0",
+        "validBefore" => "9999999999",
+        "nonce" => "0x" <> String.duplicate("ab", 32)
+      }
+
+      internal_authorization = %{
+        from: "0x1111111111111111111111111111111111111111",
+        to: @receiver,
+        value: "1",
+        valid_after: "0",
+        valid_before: "9999999999",
+        nonce: "0x" <> String.duplicate("ab", 32)
+      }
+
+      wire_domain = %{
+        "name" => "USDC",
+        "version" => "2",
+        "chainId" => 84_532,
+        "verifyingContract" => @contract
+      }
+
+      assert EIP3009.eip712_digest(wire_domain, wire_authorization) ==
+               EIP3009.eip712_digest(@domain, internal_authorization)
+    end
+
+    test "returns structured errors for malformed fields" do
+      authorization = %{
+        "from" => "0x1111111111111111111111111111111111111111",
+        "to" => @receiver,
+        "value" => "1",
+        "validAfter" => "0",
+        "validBefore" => "1",
+        "nonce" => "0x" <> String.duplicate("ab", 32)
+      }
+
+      assert EIP3009.eip712_digest(@domain, Map.put(authorization, "from", "0xnope")) ==
+               {:error, :invalid_address}
+
+      assert EIP3009.eip712_digest(@domain, Map.put(authorization, "value", "-1")) ==
+               {:error, :invalid_amount}
+
+      assert EIP3009.eip712_digest(@domain, Map.put(authorization, "nonce", "0xdead")) ==
+               {:error, :invalid_bytes32}
+
+      assert EIP3009.eip712_digest(@domain, Map.delete(authorization, "from")) ==
+               {:error, {:missing_field, "from"}}
+
+      assert EIP3009.eip712_digest(Map.delete(@domain, :chain_id), authorization) ==
+               {:error, {:missing_field, "chainId"}}
+    end
+  end
+
+  describe "sign/3" do
+    test "produces the scheme payload with a recoverable signature" do
+      key = :crypto.strong_rand_bytes(32)
+      signer = signer(key)
+
+      assert {:ok, %{"signature" => signature, "authorization" => authorization}} =
+               EIP3009.sign(@requirements, signer)
+
+      assert authorization["from"] == signer.address
+      assert authorization["to"] == @receiver
+      assert authorization["value"] == "10000"
+
+      {:ok, digest} = EIP3009.eip712_digest(@domain, authorization)
+      assert EIP3009.recover_signer(digest, signature) == {:ok, signer.address}
+    end
+
+    test "signature verifies against an independently computed digest" do
+      key = :crypto.strong_rand_bytes(32)
+      signer = signer(key)
+
+      {:ok, %{"signature" => "0x" <> signature_hex, "authorization" => authorization}} =
+        EIP3009.sign(@requirements, signer)
+
+      digest = TestPayments.eip712_digest(@domain, authorization)
+      <<compact::binary-size(64), v>> = Base.decode16!(signature_hex, case: :lower)
+      assert v in [27, 28]
+
+      {:ok, public_key} = ExSecp256k1.recover_compact(digest, compact, v - 27)
+      assert TestPayments.public_key_to_address(public_key) == signer.address
+    end
+
+    test "propagates domain errors" do
+      requirements = Map.put(@requirements, "extra", %{})
+
+      assert EIP3009.sign(requirements, signer()) == {:error, {:missing_extra, "name"}}
+    end
+
+    test "propagates signer errors" do
+      assert EIP3009.sign(@requirements, :not_a_signer) == {:error, :invalid_signer}
+    end
+  end
+
+  describe "recover_signer/2" do
+    test "accepts hex and raw signatures, with 0/1 or 27/28 recovery bytes" do
+      key = :crypto.strong_rand_bytes(32)
+      signer = signer(key)
+      digest = :crypto.strong_rand_bytes(32)
+
+      {:ok, <<compact::binary-size(64), v>> = raw} =
+        LocalKey.sign_eip712(signer, digest, %{})
+
+      hex = "0x" <> Base.encode16(raw, case: :lower)
+
+      assert EIP3009.recover_signer(digest, raw) == {:ok, signer.address}
+      assert EIP3009.recover_signer(digest, hex) == {:ok, signer.address}
+      assert EIP3009.recover_signer(digest, compact <> <<v - 27>>) == {:ok, signer.address}
+    end
+
+    test "rejects malformed signatures and digests" do
+      digest = :crypto.strong_rand_bytes(32)
+
+      assert EIP3009.recover_signer(digest, "0xdead") == {:error, :invalid_signature}
+
+      assert EIP3009.recover_signer(digest, :crypto.strong_rand_bytes(64)) ==
+               {:error, :invalid_signature}
+
+      assert EIP3009.recover_signer(<<1, 2>>, :crypto.strong_rand_bytes(65)) ==
+               {:error, :invalid_signature}
+    end
+  end
+
+  describe "address helpers" do
+    test "derive_address/1 rejects malformed keys" do
+      assert EIP3009.derive_address(<<1, 2, 3>>) == {:error, :invalid_private_key}
+      assert EIP3009.derive_address(<<0::256>>) == {:error, :invalid_private_key}
+    end
+
+    test "public_key_to_address/1 handles 64- and 65-byte keys" do
+      key = :crypto.strong_rand_bytes(32)
+      {:ok, address} = EIP3009.derive_address(key)
+      {:ok, <<4, uncompressed::binary-size(64)>>} = ExSecp256k1.create_public_key(key)
+
+      assert EIP3009.public_key_to_address(<<4, uncompressed::binary>>) == {:ok, address}
+      assert EIP3009.public_key_to_address(uncompressed) == {:ok, address}
+      assert EIP3009.public_key_to_address(<<1, 2, 3>>) == {:error, :invalid_public_key}
+    end
+  end
+end

--- a/test/x402/signer_test.exs
+++ b/test/x402/signer_test.exs
@@ -1,0 +1,171 @@
+defmodule X402.SignerTest do
+  use ExUnit.Case, async: true
+
+  doctest X402.Signer
+  doctest X402.Signer.LocalKey
+
+  alias X402.EIP3009
+  alias X402.Signer
+  alias X402.Signer.LocalKey
+
+  @typed_data %{"domain" => %{}, "types" => %{}, "primaryType" => "T", "message" => %{}}
+
+  defmodule ZeroVSigner do
+    @moduledoc false
+    # Wraps a LocalKey but reports the recovery byte as 0/1, the way some
+    # external signing APIs do — exercises the dispatcher's normalization.
+    @behaviour X402.Signer
+
+    alias X402.Signer.LocalKey
+
+    defstruct [:inner]
+
+    @impl true
+    def address(%{inner: inner}), do: LocalKey.address(inner)
+
+    @impl true
+    def sign_eip712(%{inner: inner}, digest, typed_data) do
+      {:ok, <<compact::binary-size(64), v>>} = LocalKey.sign_eip712(inner, digest, typed_data)
+
+      {:ok, compact <> <<v - 27>>}
+    end
+  end
+
+  defmodule MalformedSigner do
+    @moduledoc false
+    @behaviour X402.Signer
+
+    defstruct []
+
+    @impl true
+    def address(_signer), do: {:ok, "0x1111111111111111111111111111111111111111"}
+
+    @impl true
+    def sign_eip712(_signer, _digest, _typed_data), do: {:ok, <<1, 2, 3>>}
+  end
+
+  defmodule RecordingSigner do
+    @moduledoc false
+    @behaviour X402.Signer
+
+    alias X402.Signer.LocalKey
+
+    defstruct [:owner, :inner]
+
+    @impl true
+    def address(%{inner: inner}), do: LocalKey.address(inner)
+
+    @impl true
+    def sign_eip712(%{owner: owner, inner: inner}, digest, typed_data) do
+      send(owner, {:signed, digest, typed_data})
+      LocalKey.sign_eip712(inner, digest, typed_data)
+    end
+  end
+
+  defp local_key(key \\ :crypto.strong_rand_bytes(32)) do
+    {:ok, signer} = LocalKey.new(key)
+    signer
+  end
+
+  describe "LocalKey.new/1" do
+    test "accepts a raw 32-byte key, bare hex, and 0x-prefixed hex" do
+      key = :crypto.strong_rand_bytes(32)
+      hex = Base.encode16(key, case: :lower)
+
+      {:ok, from_raw} = LocalKey.new(key)
+      {:ok, from_hex} = LocalKey.new(hex)
+      {:ok, from_prefixed} = LocalKey.new("0x" <> hex)
+
+      assert from_raw.address == from_hex.address
+      assert from_hex.address == from_prefixed.address
+      assert String.match?(from_raw.address, ~r/^0x[0-9a-f]{40}$/)
+    end
+
+    test "rejects malformed keys" do
+      assert LocalKey.new("0x1234") == {:error, :invalid_private_key}
+      assert LocalKey.new(:crypto.strong_rand_bytes(31)) == {:error, :invalid_private_key}
+      assert LocalKey.new(:crypto.strong_rand_bytes(33)) == {:error, :invalid_private_key}
+      assert LocalKey.new(String.duplicate("zz", 32)) == {:error, :invalid_private_key}
+      assert LocalKey.new(nil) == {:error, :invalid_private_key}
+    end
+
+    test "matches the address derived by X402.EIP3009" do
+      key = :crypto.strong_rand_bytes(32)
+      {:ok, signer} = LocalKey.new(key)
+
+      assert EIP3009.derive_address(key) == {:ok, signer.address}
+    end
+  end
+
+  describe "LocalKey signing" do
+    test "produces a 65-byte signature recovering to the signer address" do
+      signer = local_key()
+      digest = :crypto.strong_rand_bytes(32)
+
+      assert {:ok, signature} = LocalKey.sign_eip712(signer, digest, @typed_data)
+      assert byte_size(signature) == 65
+      assert <<_compact::binary-size(64), v>> = signature
+      assert v in [27, 28]
+
+      assert EIP3009.recover_signer(digest, signature) == {:ok, signer.address}
+    end
+
+    test "rejects digests that are not 32 bytes" do
+      signer = local_key()
+
+      assert LocalKey.sign_eip712(signer, <<1, 2, 3>>, @typed_data) ==
+               {:error, :invalid_digest}
+    end
+
+    test "redacts the private key when inspected" do
+      key = :crypto.strong_rand_bytes(32)
+      signer = local_key(key)
+      rendered = inspect(signer)
+
+      assert rendered =~ signer.address
+      refute rendered =~ Base.encode16(key, case: :lower)
+      refute rendered =~ Base.encode16(key, case: :upper)
+    end
+  end
+
+  describe "Signer dispatch" do
+    test "address/1 dispatches on the struct module" do
+      signer = local_key()
+      assert Signer.address(signer) == {:ok, signer.address}
+    end
+
+    test "address/1 rejects non-struct signers" do
+      assert Signer.address(%{}) == {:error, :invalid_signer}
+      assert Signer.address("signer") == {:error, :invalid_signer}
+    end
+
+    test "sign_eip712/3 normalizes a 0/1 recovery byte to 27/28" do
+      inner = local_key()
+      signer = %ZeroVSigner{inner: inner}
+      digest = :crypto.strong_rand_bytes(32)
+
+      assert {:ok, <<_compact::binary-size(64), v>> = signature} =
+               Signer.sign_eip712(signer, digest, @typed_data)
+
+      assert v in [27, 28]
+      assert EIP3009.recover_signer(digest, signature) == {:ok, inner.address}
+    end
+
+    test "sign_eip712/3 rejects malformed implementation output" do
+      assert Signer.sign_eip712(%MalformedSigner{}, :crypto.strong_rand_bytes(32), @typed_data) ==
+               {:error, :invalid_signature_format}
+    end
+
+    test "sign_eip712/3 rejects non-struct signers" do
+      assert Signer.sign_eip712(:signer, <<0::256>>, @typed_data) == {:error, :invalid_signer}
+    end
+
+    test "passes the digest and full typed data to the implementation" do
+      signer = %RecordingSigner{owner: self(), inner: local_key()}
+      digest = :crypto.strong_rand_bytes(32)
+
+      assert {:ok, _signature} = Signer.sign_eip712(signer, digest, @typed_data)
+      assert_received {:signed, ^digest, @typed_data}
+    end
+  end
+end


### PR DESCRIPTION
## What

Implements the payer (buyer) side of x402 — the biggest role gap identified in [docs/ecosystem-comparison.md](https://github.com/cardotrejos/x402/blob/main/docs/ecosystem-comparison.md) §8 P0.4: until now this SDK could only *sell* (resource server + facilitator client), not *pay*.

Four layers, one per commit:

1. **`X402.Signer`** — the client-side signing seam: `address/1` + `sign_eip712(signer, digest, typed_data)`. Passing both the precomputed digest (Go-style, enough for local keys/KMS) and full typed data (TS `signTypedData`-style, for wallet-backed signers) lets any signer implement whichever it can. Ships `X402.Signer.LocalKey` (raw secp256k1 key; `{:error, :missing_dependency}` without the optional crypto deps; key redacted from `inspect/1`).
2. **`X402.EIP3009`** — the EIP-712/EIP-3009 signing core, promoted from `test/support/x402_test_payments.ex` (battle-tested against the live CDP facilitator; test support now delegates so the logic exists once). Builds `TransferWithAuthorization` per `scheme_exact_evm.md`, derives the domain from requirements `extra`, random 32-byte nonce, structured errors.
3. **`X402.Client`** — transport-agnostic core: `select_requirements/2` (network/scheme/asset filters + `max_amount:` budget guard), `build_payment/3` (echoes the full chosen requirements as `accepted` and server `resource`/`extensions` verbatim per the spec's append-only rule), `encode_payment/1`. Telemetry `[:x402, :client, *]`.
4. **`X402.Client.Finch`** — `request/3`: request → 402 + PAYMENT-REQUIRED → `on_payment_required` consent/budget hook (can veto with `:cancel`) → sign → retry **once** (never pays twice), returns the decoded PAYMENT-RESPONSE receipt. Enforces https on non-loopback URLs, mirroring the facilitator transport. Compile-guarded on Finch like the rest of the SDK.

## Scope

EVM `exact` via EIP-3009 only — `upto`/Permit2, SVM, and ERC-7710 return `{:error, {:unsupported_kind, scheme, network}}` and arrive with the `X402.Scheme` registry (roadmap P1.1).

## Testing

97 doctests + 428 tests, 0 failures; coverage 91.1%. Highlights:
- Signature correctness proven by **address recovery** against the digest vectors the old test-support code produced
- Self-interop: built payloads round-trip through `X402.PaymentSignature.decode_and_validate/2`
- **True end-to-end loop:** `X402.Client.Finch` → Bypass server mounting `X402.Plug.PaymentGate` + stub facilitator → 402 → sign → verify → settle → receipt

Gates: format, compile --warnings-as-errors, credo --strict, dialyzer (0 errors), compile --no-optional-deps all green.

## Notes for review

- Touches no files modified by stack #55 (#50–#54, #56); CHANGELOG will need a trivial merge when whichever lands second rebases.
- New guide: `guides/client.md`. New ExDoc group "Payer Client".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New signing and automated payment paths handle private keys and settleable authorizations; safeguards (max_amount, consent hook, HTTPS, single retry) reduce but do not eliminate misuse or key-handling risk in production payers.
> 
> **Overview**
> Adds the **payer (buyer) side** of x402 so Elixir apps can pay for protected APIs, not only sell through the Plug gate and facilitator client.
> 
> **`X402.Client`** is a transport-agnostic layer: **`select_requirements/2`** picks a signable `accepts` entry (network/scheme/asset filters plus **`max_amount`** budget), **`build_payment/3`** assembles a v2 payload (full **`accepted`** echo, **`resource`** / **`extensions`** when present) and signs **`exact`** on **`eip155:*`** via EIP-3009, and **`encode_payment/1`** produces the **`PAYMENT-SIGNATURE`** header.
> 
> **`X402.Signer`** is the signing seam (**`address/1`**, **`sign_eip712/3`** with digest + typed data for KMS/wallet backends); **`X402.Signer.LocalKey`** is the in-memory key helper (key redacted in **`inspect/1`**). **`X402.EIP3009`** centralizes **`TransferWithAuthorization`**, EIP-712 domain/digest, signing, and recovery—promoted from test support, which now delegates so crypto lives in one place.
> 
> **`X402.Client.Finch.request/3`** runs **402 → decode `PAYMENT-REQUIRED` → optional `on_payment_required` consent → sign → single retry** (refuses double pay / pre-existing **`payment-signature`**), decodes **`PAYMENT-RESPONSE`**, and requires **HTTPS** off loopback. New **`[:x402, :client, *]`** telemetry and **`guides/client.md`** document the flow; README and ExDoc gain a **Payer Client** group.
> 
> Scope is **EVM `exact` / EIP-3009 only**; Solana, **`upto`**, and other kinds return **`{:unsupported_kind, ...}`**. Tests cover self-interop with **`PaymentSignature.decode_and_validate/2`** and an end-to-end Finch → **`PaymentGate`** loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 874f59da8de69dcf5c29dc9b398966836caf40eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->