### PR TITLE
feat: add GET /supported and /discovery/resources to the facilitator client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `{module, cache}` adapter tuple implementing
   `X402.Extensions.PaymentIdentifier.Cache`; a bare pid/name keeps working and
   is normalized to the bundled `ETSCache` adapter
+- `X402.Facilitator.supported/0..1` — `GET /supported` returning the
+  facilitator's payment kinds, extensions, and signers as
+  `{:ok, %{kinds: [...], extensions: [...], signers: %{...}}}`, validated
+  fail-closed (`{:error, %Error{type: :malformed_facilitator_response}}` on a
+  malformed body). Unlocks startup route validation, SVM `feePayer` discovery,
+  and `upto` `facilitatorAddress` discovery
+- `X402.Facilitator.list_resources/0..2` — `GET /discovery/resources` with
+  NimbleOptions-validated filter and pagination parameters (`type`, `pay_to`,
+  `scheme`, `network`, `extensions`, `limit`, `offset`), returning fail-closed
+  parsed `{:ok, %{items: [...], pagination: ..., x402_version: ...}}`
+- `X402.Facilitator.HTTP.get/3..4` — GET transport with optional `:query`
+  parameters, sharing the retry/backoff/TLS pipeline with `request/5`
+- Telemetry spans `[:x402, :facilitator, :supported]` and
+  `[:x402, :facilitator, :list_resources]`, consistent with the existing
+  verify/settle spans
+- Facilitator auth implementations now receive the real request method
+  (`:get` for the new endpoints) in `request_info`, so CDP JWTs bind
+  `GET host path` in their `uris` claim
 
 ### Changed
 

--- a/lib/x402/facilitator.ex
+++ b/lib/x402/facilitator.ex
@@ -1,14 +1,15 @@
 defmodule X402.Facilitator do
   @moduledoc """
-  Client for x402 facilitator verify and settle operations.
+  Client for the x402 facilitator API: verify, settle, supported, discovery.
 
   The facilitator process is a supervised configuration holder: it resolves
   and stores connection settings (URL, Finch pool, hooks, retry policy, auth
-  state) once at startup. The HTTP work for `verify/2` and `settle/2` —
-  including retries with backoff, lifecycle hooks, telemetry spans, and
-  per-request auth header minting — executes in the **calling process**.
-  Concurrent payment operations therefore never serialize behind the
-  facilitator process; throughput is bounded only by the Finch pool.
+  state) once at startup. The HTTP work for `verify/2`, `settle/2`,
+  `supported/1`, and `list_resources/2` — including retries with backoff,
+  lifecycle hooks, telemetry spans, and per-request auth header minting —
+  executes in the **calling process**. Concurrent payment operations
+  therefore never serialize behind the facilitator process; throughput is
+  bounded only by the Finch pool.
 
   Because operations run in the caller, `X402.Hooks` callbacks are invoked in
   the calling process (not in the facilitator process), and the duration of an
@@ -93,6 +94,39 @@ defmodule X402.Facilitator do
   @type operation_result :: map()
 
   @type response :: {:ok, operation_result()} | {:error, Error.t() | Hooks.hook_error() | term()}
+
+  @typedoc "One supported payment kind advertised by `GET /supported`."
+  @type supported_kind :: %{
+          x402_version: integer(),
+          scheme: String.t(),
+          network: String.t(),
+          extra: map() | nil
+        }
+
+  @typedoc "Validated response of `supported/1`."
+  @type supported_response :: %{
+          kinds: [supported_kind()],
+          extensions: [String.t()],
+          signers: %{optional(String.t()) => [String.t()]}
+        }
+
+  @typedoc "Pagination metadata returned by `GET /discovery/resources`."
+  @type discovery_pagination :: %{
+          limit: non_neg_integer(),
+          offset: non_neg_integer(),
+          total: non_neg_integer()
+        }
+
+  @typedoc """
+  Validated response of `list_resources/2`.
+
+  Each item is the raw, string-keyed discovered-resource map from the wire.
+  """
+  @type discovery_resources_response :: %{
+          x402_version: integer() | nil,
+          items: [map()],
+          pagination: discovery_pagination() | nil
+        }
 
   @type state :: %{
           url: String.t(),
@@ -264,6 +298,122 @@ defmodule X402.Facilitator do
     request_with_telemetry(config, :settle, payment_payload, requirements, hooks_module)
   end
 
+  @list_resources_params_schema [
+    type: [
+      type: :string,
+      doc: "Filter by resource type (for example `\"http\"` or `\"mcp\"`)."
+    ],
+    pay_to: [
+      type: :string,
+      doc: "Filter by payment recipient address (sent as `payTo`)."
+    ],
+    scheme: [
+      type: :string,
+      doc: "Filter by payment scheme (for example `\"exact\"`)."
+    ],
+    network: [
+      type: :string,
+      doc: "Filter by CAIP-2 payment network (for example `\"eip155:8453\"`)."
+    ],
+    extensions: [
+      type: :string,
+      doc: "Filter by extension key present on each discovered resource."
+    ],
+    limit: [
+      type: {:in, 1..100},
+      doc: "Maximum number of results to return (1–100; server default 20)."
+    ],
+    offset: [
+      type: :non_neg_integer,
+      doc: "Number of results to skip for pagination."
+    ]
+  ]
+
+  @doc """
+  Fetches the payment kinds, extensions, and signers a facilitator supports.
+
+  Performs `GET /supported` in the calling process and validates the response
+  fail-closed: a malformed body returns
+  `{:error, %X402.Facilitator.Error{type: :malformed_facilitator_response}}`
+  rather than partial data. Missing `extensions` and `signers` fields default
+  to `[]` and `%{}` (matching the reference TypeScript client); a missing or
+  malformed `kinds` field is an error.
+
+  `X402.Hooks` callbacks do not apply to this read-only operation.
+
+  ## Examples
+
+      {:ok, %{kinds: kinds, extensions: _, signers: signers}} =
+        X402.Facilitator.supported(MyFacilitator)
+
+      Enum.any?(kinds, &(&1.scheme == "exact" and &1.network == "eip155:8453"))
+  """
+  @doc group: :discovery
+  @doc since: "0.6.0"
+  @spec supported(server()) :: {:ok, supported_response()} | {:error, Error.t()}
+  def supported(server \\ @default_name) do
+    config = fetch_config(server)
+    get_with_telemetry(config, :supported, "/supported", [], &parse_supported/1)
+  end
+
+  @doc """
+  Lists discoverable x402 resources from the facilitator's bazaar.
+
+  Performs `GET /discovery/resources` in the calling process. Filter and
+  pagination parameters are validated with `NimbleOptions` and encoded as
+  query string parameters. The response is validated fail-closed: a malformed
+  body returns
+  `{:error, %X402.Facilitator.Error{type: :malformed_facilitator_response}}`.
+
+  Items are returned as raw, string-keyed maps exactly as sent by the
+  facilitator. `X402.Hooks` callbacks do not apply to this read-only
+  operation.
+
+  When called with just a keyword list — `list_resources(limit: 20)` — the
+  parameters apply to the default facilitator process name.
+
+  ## Parameters
+
+  #{NimbleOptions.docs(@list_resources_params_schema)}
+
+  ## Examples
+
+      {:ok, %{items: items, pagination: pagination}} =
+        X402.Facilitator.list_resources(MyFacilitator,
+          network: "eip155:8453",
+          limit: 20
+        )
+  """
+  @doc group: :discovery
+  @doc since: "0.6.0"
+  @spec list_resources(server() | keyword(), keyword()) ::
+          {:ok, discovery_resources_response()}
+          | {:error, Error.t() | NimbleOptions.ValidationError.t()}
+  def list_resources(server_or_params \\ @default_name, params \\ [])
+
+  def list_resources(params, []) when is_list(params) do
+    list_resources(@default_name, params)
+  end
+
+  def list_resources(server, params) when is_list(params) do
+    case NimbleOptions.validate(params, @list_resources_params_schema) do
+      {:ok, validated_params} ->
+        config = fetch_config(server)
+        query = discovery_query(validated_params)
+
+        get_with_telemetry(
+          config,
+          :list_resources,
+          "/discovery/resources",
+          query,
+          &parse_discovery_resources/1
+        )
+
+      {:error, %NimbleOptions.ValidationError{} = error} ->
+        {:error, error}
+    end
+  end
+
   @doc false
   @spec validate_auth(nil | module() | {module(), keyword()}) ::
           {:ok, nil | module() | {module(), keyword()}} | {:error, String.t()}
@@ -360,7 +510,7 @@ defmodule X402.Facilitator do
                    before_context.payload,
                    before_context.requirements
                  ),
-               {:ok, headers} <- auth_headers(state, endpoint) do
+               {:ok, headers} <- auth_headers(state, endpoint, :post) do
             HTTP.request(
               state.finch,
               state.url,
@@ -385,9 +535,9 @@ defmodule X402.Facilitator do
     end
   end
 
-  defp auth_headers(state, endpoint) do
+  defp auth_headers(state, endpoint, method) do
     request_info = %{
-      method: :post,
+      method: method,
       host: request_host(state.url),
       path: request_path(state.url) <> endpoint
     }
@@ -644,6 +794,161 @@ defmodule X402.Facilitator do
     end
   end
 
+  # --- read-only GET operations (supported / discovery) ---
+
+  defp get_with_telemetry(config, operation, endpoint, query, parser) do
+    :telemetry.span(
+      [:x402, :facilitator, operation],
+      %{operation: operation, endpoint: endpoint},
+      fn ->
+        result = get_operation(config, endpoint, query, parser)
+        log_failure(result, operation, endpoint)
+        {result, telemetry_result_metadata(result)}
+      end
+    )
+  end
+
+  defp get_operation(config, endpoint, query, parser) do
+    with {:ok, headers} <- auth_headers(config, endpoint, :get),
+         {:ok, %{status: status, body: body}} <-
+           HTTP.get(config.finch, config.url, endpoint,
+             query: query,
+             max_retries: config.max_retries,
+             retry_backoff_ms: config.retry_backoff_ms,
+             receive_timeout_ms: config.receive_timeout_ms,
+             headers: headers
+           ) do
+      parse_body(parser, status, body)
+    end
+  end
+
+  defp parse_body(parser, status, body) do
+    case parser.(body) do
+      {:ok, parsed} ->
+        {:ok, parsed}
+
+      {:error, reason} ->
+        {:error,
+         %Error{
+           type: :malformed_facilitator_response,
+           status: status,
+           body: body,
+           reason: reason,
+           retryable: false,
+           attempt: nil
+         }}
+    end
+  end
+
+  defp discovery_query(params) do
+    Enum.flat_map(params, fn
+      {:pay_to, value} -> [{"payTo", value}]
+      {key, value} -> [{Atom.to_string(key), value}]
+    end)
+  end
+
+  defp parse_supported(body) do
+    with {:ok, kinds} <- parse_supported_kinds(Map.get(body, "kinds")),
+         {:ok, extensions} <- parse_supported_extensions(Map.get(body, "extensions", [])),
+         {:ok, signers} <- parse_supported_signers(Map.get(body, "signers", %{})) do
+      {:ok, %{kinds: kinds, extensions: extensions, signers: signers}}
+    end
+  end
+
+  defp parse_supported_kinds(nil), do: {:error, {:missing_field, "kinds"}}
+
+  defp parse_supported_kinds(kinds) when is_list(kinds) do
+    kinds
+    |> Enum.reduce_while([], fn kind, acc ->
+      case parse_supported_kind(kind) do
+        {:ok, parsed} -> {:cont, [parsed | acc]}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:error, reason} -> {:error, reason}
+      parsed -> {:ok, Enum.reverse(parsed)}
+    end
+  end
+
+  defp parse_supported_kinds(_kinds), do: {:error, {:invalid_field, "kinds"}}
+
+  defp parse_supported_kind(
+         %{"x402Version" => x402_version, "scheme" => scheme, "network" => network} = kind
+       )
+       when is_integer(x402_version) and is_binary(scheme) and is_binary(network) do
+    case Map.get(kind, "extra") do
+      nil ->
+        {:ok, %{x402_version: x402_version, scheme: scheme, network: network, extra: nil}}
+
+      extra when is_map(extra) ->
+        {:ok, %{x402_version: x402_version, scheme: scheme, network: network, extra: extra}}
+
+      _invalid ->
+        {:error, {:invalid_kind, kind}}
+    end
+  end
+
+  defp parse_supported_kind(kind), do: {:error, {:invalid_kind, kind}}
+
+  defp parse_supported_extensions(extensions) when is_list(extensions) do
+    if Enum.all?(extensions, &is_binary/1) do
+      {:ok, extensions}
+    else
+      {:error, {:invalid_field, "extensions"}}
+    end
+  end
+
+  defp parse_supported_extensions(_extensions), do: {:error, {:invalid_field, "extensions"}}
+
+  defp parse_supported_signers(signers) when is_map(signers) do
+    valid? =
+      Enum.all?(signers, fn
+        {pattern, addresses} when is_binary(pattern) and is_list(addresses) ->
+          Enum.all?(addresses, &is_binary/1)
+
+        _entry ->
+          false
+      end)
+
+    if valid?, do: {:ok, signers}, else: {:error, {:invalid_field, "signers"}}
+  end
+
+  defp parse_supported_signers(_signers), do: {:error, {:invalid_field, "signers"}}
+
+  defp parse_discovery_resources(body) do
+    with {:ok, items} <- parse_discovery_items(Map.get(body, "items")),
+         {:ok, pagination} <- parse_discovery_pagination(Map.get(body, "pagination")),
+         {:ok, x402_version} <- parse_discovery_version(Map.get(body, "x402Version")) do
+      {:ok, %{x402_version: x402_version, items: items, pagination: pagination}}
+    end
+  end
+
+  defp parse_discovery_items(nil), do: {:error, {:missing_field, "items"}}
+
+  defp parse_discovery_items(items) when is_list(items) do
+    if Enum.all?(items, &is_map/1) do
+      {:ok, items}
+    else
+      {:error, {:invalid_field, "items"}}
+    end
+  end
+
+  defp parse_discovery_items(_items), do: {:error, {:invalid_field, "items"}}
+
+  defp parse_discovery_pagination(nil), do: {:ok, nil}
+
+  defp parse_discovery_pagination(%{"limit" => limit, "offset" => offset, "total" => total})
+       when is_integer(limit) and is_integer(offset) and is_integer(total) do
+    {:ok, %{limit: limit, offset: offset, total: total}}
+  end
+
+  defp parse_discovery_pagination(_pagination), do: {:error, {:invalid_field, "pagination"}}
+
+  defp parse_discovery_version(nil), do: {:ok, nil}
+  defp parse_discovery_version(version) when is_integer(version), do: {:ok, version}
+  defp parse_discovery_version(_version), do: {:error, {:invalid_field, "x402Version"}}
+
   defp before_callback(:verify), do: :before_verify
   defp before_callback(:settle), do: :before_settle
 
@@ -670,6 +975,8 @@ defmodule X402.Facilitator do
 
   defp telemetry_result_metadata({:ok, %{status: status}}),
     do: %{status: status, success: true}
+
+  defp telemetry_result_metadata({:ok, _result}), do: %{success: true}
 
   defp telemetry_result_metadata({:error, %Error{} = error}) do
     %{

--- a/lib/x402/facilitator/error.ex
+++ b/lib/x402/facilitator/error.ex
@@ -1,6 +1,6 @@
 defmodule X402.Facilitator.Error do
   @moduledoc """
-  Structured error returned by facilitator verify/settle operations.
+  Structured error returned by facilitator client operations.
   """
 
   @typedoc """
@@ -13,6 +13,7 @@ defmodule X402.Facilitator.Error do
           | :insecure_scheme
           | :invalid_json
           | :invalid_option
+          | :malformed_facilitator_response
           | :request_setup_failed
           | :timeout
           | :transport_error

--- a/lib/x402/facilitator/http.ex
+++ b/lib/x402/facilitator/http.ex
@@ -1,15 +1,22 @@
 defmodule X402.Facilitator.HTTP do
   @moduledoc """
-  HTTP transport for facilitator verify and settle requests.
+  HTTP transport for facilitator requests.
+
+  `request/5` performs the POST requests used by verify and settle; `get/4`
+  performs the GET requests used by `/supported` and `/discovery/resources`.
   """
 
   alias X402.Facilitator.Error
 
   @transient_statuses [408, 429, 500, 502, 503, 504]
   @json_headers [{"content-type", "application/json"}, {"accept", "application/json"}]
+  @accept_json_headers [{"accept", "application/json"}]
 
   @type finch_name :: atom() | pid() | {:via, module(), term()}
   @type response :: {:ok, %{status: non_neg_integer(), body: map()}} | {:error, Error.t()}
+
+  @typedoc "Query string parameters accepted by `get/4`."
+  @type query :: [{String.t(), String.t() | integer()}]
 
   @doc """
   Performs a facilitator HTTP POST request.
@@ -51,37 +58,74 @@ defmodule X402.Facilitator.HTTP do
   @spec request(finch_name(), String.t(), String.t(), map(), keyword()) :: response()
   def request(finch_name, base_url, path, payload, opts \\ [])
       when is_binary(base_url) and is_binary(path) and is_map(payload) and is_list(opts) do
-    with :ok <- validate_https_scheme(base_url),
+    with {:ok, ctx} <- build_context(finch_name, base_url, path, opts),
          {:ok, max_retries} <- fetch_non_negative_integer(opts, :max_retries, 2),
-         {:ok, retry_backoff_ms} <- fetch_non_negative_integer(opts, :retry_backoff_ms, 100),
-         {:ok, receive_timeout_ms} <- fetch_non_negative_integer(opts, :receive_timeout_ms, 5_000),
-         {:ok, headers} <- fetch_headers(opts),
-         {:ok, finch_module} <- ensure_finch_module(),
          {:ok, encoded_payload} <- Jason.encode(payload) do
-      ctx = %{
-        finch_module: finch_module,
-        finch_name: finch_name,
-        url: join_url(base_url, path),
-        payload: encoded_payload,
-        headers: headers,
-        receive_timeout_ms: receive_timeout_ms,
-        retry_backoff_ms: retry_backoff_ms
-      }
+      ctx = Map.merge(ctx, %{method: :post, payload: encoded_payload})
+      do_request(ctx, 1, max_retries + 1)
+    else
+      error -> setup_error(error)
+    end
+  end
+
+  @doc """
+  Performs a facilitator HTTP GET request.
+
+  Used for the read-only facilitator endpoints (`GET /supported` and
+  `GET /discovery/resources`). No request body is sent.
+
+  In addition to the options accepted by `request/5`, `opts` supports:
+
+  - `:query` (default: `[]`) — query string parameters as a list of
+    `{name, value}` tuples with string names and string or integer values,
+    encoded with `URI.encode_query/1`.
+
+  The same TLS requirements as `request/5` apply; see `secure_pool_opts/0`.
+  """
+  @doc since: "0.6.0"
+  @spec get(finch_name(), String.t(), String.t(), keyword()) :: response()
+  def get(finch_name, base_url, path, opts \\ [])
+      when is_binary(base_url) and is_binary(path) and is_list(opts) do
+    with {:ok, ctx} <- build_context(finch_name, base_url, path, opts),
+         {:ok, max_retries} <- fetch_non_negative_integer(opts, :max_retries, 2),
+         {:ok, query} <- fetch_query(opts) do
+      ctx =
+        Map.merge(ctx, %{method: :get, payload: nil, url: append_query(ctx.url, query)})
 
       do_request(ctx, 1, max_retries + 1)
     else
-      {:error, %Error{} = error} ->
-        {:error, error}
-
-      {:error, reason} ->
-        {:error,
-         %Error{
-           type: :request_setup_failed,
-           reason: reason,
-           retryable: false,
-           attempt: 1
-         }}
+      error -> setup_error(error)
     end
+  end
+
+  defp build_context(finch_name, base_url, path, opts) do
+    with :ok <- validate_https_scheme(base_url),
+         {:ok, retry_backoff_ms} <- fetch_non_negative_integer(opts, :retry_backoff_ms, 100),
+         {:ok, receive_timeout_ms} <- fetch_non_negative_integer(opts, :receive_timeout_ms, 5_000),
+         {:ok, headers} <- fetch_headers(opts),
+         {:ok, finch_module} <- ensure_finch_module() do
+      {:ok,
+       %{
+         finch_module: finch_module,
+         finch_name: finch_name,
+         url: join_url(base_url, path),
+         headers: headers,
+         receive_timeout_ms: receive_timeout_ms,
+         retry_backoff_ms: retry_backoff_ms
+       }}
+    end
+  end
+
+  defp setup_error({:error, %Error{} = error}), do: {:error, error}
+
+  defp setup_error({:error, reason}) do
+    {:error,
+     %Error{
+       type: :request_setup_failed,
+       reason: reason,
+       retryable: false,
+       attempt: 1
+     }}
   end
 
   @doc """
@@ -120,6 +164,7 @@ defmodule X402.Facilitator.HTTP do
          %{
            finch_module: finch_module,
            finch_name: finch_name,
+           method: method,
            url: url,
            payload: encoded_payload,
            headers: headers,
@@ -127,7 +172,7 @@ defmodule X402.Facilitator.HTTP do
          },
          attempt
        ) do
-    request = finch_module.build(:post, url, @json_headers ++ headers, encoded_payload)
+    request = finch_module.build(method, url, base_headers(method) ++ headers, encoded_payload)
     finch_opts = [receive_timeout: receive_timeout_ms]
 
     response =
@@ -297,6 +342,32 @@ defmodule X402.Facilitator.HTTP do
 
   defp valid_header?({name, value}) when is_binary(name) and is_binary(value), do: true
   defp valid_header?(_header), do: false
+
+  defp base_headers(:post), do: @json_headers
+  defp base_headers(:get), do: @accept_json_headers
+
+  defp fetch_query(opts) do
+    case Keyword.get(opts, :query, []) do
+      query when is_list(query) ->
+        if Enum.all?(query, &valid_query_param?/1) do
+          {:ok, query}
+        else
+          {:error, invalid_option_error(:query, query)}
+        end
+
+      invalid ->
+        {:error, invalid_option_error(:query, invalid)}
+    end
+  end
+
+  defp valid_query_param?({name, value})
+       when is_binary(name) and (is_binary(value) or is_integer(value)),
+       do: true
+
+  defp valid_query_param?(_param), do: false
+
+  defp append_query(url, []), do: url
+  defp append_query(url, query), do: url <> "?" <> URI.encode_query(query)
 
   defp invalid_option_error(key, invalid) do
     %Error{

--- a/mix.exs
+++ b/mix.exs
@@ -165,7 +165,8 @@ defmodule X402.MixProject do
       groups_for_docs: [
         "Header Encoding": &(&1[:group] == :headers),
         "Payment Verification": &(&1[:group] == :verification),
-        "Payment Settlement": &(&1[:group] == :settlement)
+        "Payment Settlement": &(&1[:group] == :settlement),
+        "Facilitator Discovery": &(&1[:group] == :discovery)
       ]
     ]
   end

--- a/test/x402/facilitator/http_test.exs
+++ b/test/x402/facilitator/http_test.exs
@@ -352,6 +352,122 @@ defmodule X402.Facilitator.HTTPTest do
     )
   end
 
+  test "get/4 performs a GET request without a body" do
+    with_stubbed_finch(fn ->
+      parent = self()
+
+      Process.put(
+        :http_test_finch_response,
+        {:fun,
+         fn request, _finch_name, _opts ->
+           send(parent, {:request, request})
+           {:ok, %{status: 200, body: Jason.encode!(%{"kinds" => []})}}
+         end}
+      )
+
+      assert {:ok, %{status: 200, body: %{"kinds" => []}}} =
+               HTTP.get(:stub, "https://facilitator.test", "/supported")
+
+      assert_receive {:request, request}
+      assert request.method == :get
+      assert request.url == "https://facilitator.test/supported"
+      assert request.body == nil
+      assert {"accept", "application/json"} in request.headers
+      refute Enum.any?(request.headers, fn {name, _value} -> name == "content-type" end)
+    end)
+  end
+
+  test "get/4 encodes query parameters" do
+    with_stubbed_finch(fn ->
+      parent = self()
+
+      Process.put(
+        :http_test_finch_response,
+        {:fun,
+         fn request, _finch_name, _opts ->
+           send(parent, {:request_url, request.url})
+           {:ok, %{status: 200, body: Jason.encode!(%{"items" => []})}}
+         end}
+      )
+
+      query = [{"network", "eip155:8453"}, {"limit", 20}, {"offset", 0}]
+
+      assert {:ok, %{status: 200}} =
+               HTTP.get(:stub, "https://facilitator.test", "/discovery/resources", query: query)
+
+      assert_receive {:request_url, url}
+
+      assert url ==
+               "https://facilitator.test/discovery/resources?network=eip155%3A8453&limit=20&offset=0"
+    end)
+  end
+
+  test "get/4 sends custom headers after the accept header" do
+    with_stubbed_finch(fn ->
+      parent = self()
+
+      Process.put(
+        :http_test_finch_response,
+        {:fun,
+         fn request, _finch_name, _opts ->
+           send(parent, {:headers, request.headers})
+           {:ok, %{status: 200, body: "{}"}}
+         end}
+      )
+
+      assert {:ok, %{status: 200}} =
+               HTTP.get(:stub, "https://facilitator.test", "/supported",
+                 headers: [{"authorization", "Bearer token"}]
+               )
+
+      assert_receive {:headers, headers}
+      assert {"authorization", "Bearer token"} in headers
+    end)
+  end
+
+  test "get/4 retries transient statuses" do
+    with_stubbed_finch(fn ->
+      Process.put(
+        :http_test_finch_response,
+        {:fun,
+         fn _request, _finch_name, _opts ->
+           attempt = Process.get(:http_test_get_attempt, 1)
+           Process.put(:http_test_get_attempt, attempt + 1)
+
+           case attempt do
+             1 -> {:ok, %{status: 429, body: Jason.encode!(%{"error" => "rate limited"})}}
+             _later -> {:ok, %{status: 200, body: Jason.encode!(%{"kinds" => []})}}
+           end
+         end}
+      )
+
+      assert {:ok, %{status: 200, body: %{"kinds" => []}}} =
+               HTTP.get(:stub, "https://facilitator.test", "/supported",
+                 max_retries: 2,
+                 retry_backoff_ms: 1
+               )
+
+      Process.delete(:http_test_get_attempt)
+    end)
+  end
+
+  test "get/4 rejects invalid query options" do
+    with_stubbed_finch(fn ->
+      assert {:error, %Error{type: :invalid_option, reason: {:query, :nope}}} =
+               HTTP.get(:stub, "https://facilitator.test", "/supported", query: :nope)
+
+      assert {:error, %Error{type: :invalid_option, reason: {:query, [{:atom_name, "x"}]}}} =
+               HTTP.get(:stub, "https://facilitator.test", "/supported",
+                 query: [{:atom_name, "x"}]
+               )
+    end)
+  end
+
+  test "get/4 enforces https on the base url" do
+    assert {:error, %Error{type: :insecure_scheme}} =
+             HTTP.get(:stub, "http://facilitator.test", "/supported")
+  end
+
   test "secure_pool_opts/0 returns default TLS configuration" do
     assert [
              conn_opts: [

--- a/test/x402/facilitator_test.exs
+++ b/test/x402/facilitator_test.exs
@@ -878,6 +878,364 @@ defmodule X402.FacilitatorTest do
              Facilitator.verify(facilitator, %{}, %{})
   end
 
+  describe "supported/1" do
+    test "fetches and validates the supported payment kinds", %{
+      bypass: bypass,
+      finch: finch,
+      facilitator_url: facilitator_url
+    } do
+      Bypass.expect(bypass, "GET", "/supported", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            "kinds" => [
+              %{"x402Version" => 2, "scheme" => "exact", "network" => "eip155:8453"},
+              %{
+                "x402Version" => 2,
+                "scheme" => "exact",
+                "network" => "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "extra" => %{"feePayer" => "CKPKJWNdJEqa81x7CkZ14BVPiY6y16Sxs7owznqtWYp5"}
+              }
+            ],
+            "extensions" => ["bazaar"],
+            "signers" => %{"eip155:*" => ["0x1234567890abcdef1234567890abcdef12345678"]}
+          })
+        )
+      end)
+
+      facilitator =
+        start_supervised!(
+          {Facilitator, name: unique_name("facilitator"), finch: finch, url: facilitator_url}
+        )
+
+      assert {:ok, %{kinds: kinds, extensions: ["bazaar"], signers: signers}} =
+               Facilitator.supported(facilitator)
+
+      assert [
+               %{x402_version: 2, scheme: "exact", network: "eip155:8453", extra: nil},
+               %{scheme: "exact", extra: %{"feePayer" => fee_payer}}
+             ] = kinds
+
+      assert fee_payer == "CKPKJWNdJEqa81x7CkZ14BVPiY6y16Sxs7owznqtWYp5"
+      assert signers == %{"eip155:*" => ["0x1234567890abcdef1234567890abcdef12345678"]}
+    end
+
+    test "defaults missing extensions and signers", %{
+      bypass: bypass,
+      finch: finch,
+      facilitator_url: facilitator_url
+    } do
+      Bypass.expect(bypass, "GET", "/supported", fn conn ->
+        Plug.Conn.resp(conn, 200, Jason.encode!(%{"kinds" => []}))
+      end)
+
+      facilitator =
+        start_supervised!(
+          {Facilitator, name: unique_name("facilitator"), finch: finch, url: facilitator_url}
+        )
+
+      assert {:ok, %{kinds: [], extensions: [], signers: %{}}} =
+               Facilitator.supported(facilitator)
+    end
+
+    test "supported/0 and list_resources/1 use the default registered name", %{
+      bypass: bypass,
+      finch: finch,
+      facilitator_url: facilitator_url
+    } do
+      Bypass.expect(bypass, "GET", "/supported", fn conn ->
+        Plug.Conn.resp(conn, 200, Jason.encode!(%{"kinds" => []}))
+      end)
+
+      Bypass.expect(bypass, "GET", "/discovery/resources", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params == %{"limit" => "5"}
+        Plug.Conn.resp(conn, 200, Jason.encode!(%{"items" => []}))
+      end)
+
+      start_supervised!({Facilitator, finch: finch, url: facilitator_url})
+
+      assert {:ok, %{kinds: []}} = Facilitator.supported()
+      assert {:ok, %{items: []}} = Facilitator.list_resources(limit: 5)
+    end
+
+    test "fails closed on malformed responses", %{finch: finch} do
+      malformed_bodies = [
+        %{},
+        %{"kinds" => "exact"},
+        %{"kinds" => [%{"x402Version" => "2", "scheme" => "exact", "network" => "eip155:1"}]},
+        %{"kinds" => [%{"scheme" => "exact", "network" => "eip155:1"}]},
+        %{"kinds" => [], "extensions" => "bazaar"},
+        %{"kinds" => [], "signers" => %{"eip155:*" => "0xabc"}},
+        %{"kinds" => [], "signers" => ["0xabc"]}
+      ]
+
+      for body <- malformed_bodies do
+        bypass = Bypass.open()
+
+        Bypass.expect(bypass, "GET", "/supported", fn conn ->
+          Plug.Conn.resp(conn, 200, Jason.encode!(body))
+        end)
+
+        facilitator =
+          start_supervised!(
+            {Facilitator,
+             name: unique_name("facilitator"),
+             finch: finch,
+             url: "http://localhost:#{bypass.port}"}
+          )
+
+        assert {:error, %Error{type: :malformed_facilitator_response, status: 200}} =
+                 Facilitator.supported(facilitator)
+      end
+    end
+
+    test "propagates HTTP errors", %{
+      bypass: bypass,
+      finch: finch,
+      facilitator_url: facilitator_url
+    } do
+      Bypass.expect(bypass, "GET", "/supported", fn conn ->
+        Plug.Conn.resp(conn, 404, Jason.encode!(%{"error" => "not found"}))
+      end)
+
+      facilitator =
+        start_supervised!(
+          {Facilitator, name: unique_name("facilitator"), finch: finch, url: facilitator_url}
+        )
+
+      assert {:error, %Error{type: :http_error, status: 404, retryable: false}} =
+               Facilitator.supported(facilitator)
+    end
+
+    test "sends a CDP JWT bound to the GET method and path", %{
+      bypass: bypass,
+      finch: finch,
+      facilitator_url: facilitator_url
+    } do
+      {secret, public_key} = X402.TestAuthKeys.ed25519()
+
+      Bypass.expect(bypass, "GET", "/supported", fn conn ->
+        [authorization] = Plug.Conn.get_req_header(conn, "authorization")
+        token = String.replace_prefix(authorization, "Bearer ", "")
+        assert verify_jwt(token, public_key)
+        assert jwt_payload(token)["uris"] == ["GET localhost:#{bypass.port}/supported"]
+        Plug.Conn.resp(conn, 200, Jason.encode!(%{"kinds" => []}))
+      end)
+
+      facilitator =
+        start_supervised!(
+          {Facilitator,
+           name: unique_name("facilitator"),
+           finch: finch,
+           url: facilitator_url,
+           auth: {X402.Facilitator.Auth.CDP, api_key_id: "key-123", api_key_secret: secret}}
+        )
+
+      assert {:ok, %{kinds: []}} = Facilitator.supported(facilitator)
+    end
+
+    test "emits telemetry span events", %{
+      bypass: bypass,
+      finch: finch,
+      facilitator_url: facilitator_url
+    } do
+      parent = self()
+      handler_id = "facilitator-supported-span-#{System.unique_integer([:positive, :monotonic])}"
+
+      :ok =
+        :telemetry.attach_many(
+          handler_id,
+          [[:x402, :facilitator, :supported, :start], [:x402, :facilitator, :supported, :stop]],
+          fn event, measurements, metadata, _config ->
+            send(parent, {:telemetry, event, measurements, metadata})
+          end,
+          nil
+        )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      Bypass.expect(bypass, "GET", "/supported", fn conn ->
+        Plug.Conn.resp(conn, 200, Jason.encode!(%{"kinds" => []}))
+      end)
+
+      facilitator =
+        start_supervised!(
+          {Facilitator, name: unique_name("facilitator"), finch: finch, url: facilitator_url}
+        )
+
+      assert {:ok, %{kinds: []}} = Facilitator.supported(facilitator)
+
+      assert_receive {:telemetry, [:x402, :facilitator, :supported, :start], _measurements,
+                      %{operation: :supported, endpoint: "/supported"}}
+
+      assert_receive {:telemetry, [:x402, :facilitator, :supported, :stop], _measurements,
+                      %{success: true}}
+    end
+  end
+
+  describe "list_resources/2" do
+    test "fetches discovery resources with encoded query parameters", %{
+      bypass: bypass,
+      finch: finch,
+      facilitator_url: facilitator_url
+    } do
+      item = %{
+        "resource" => "https://api.example.com/premium-data",
+        "type" => "http",
+        "x402Version" => 2,
+        "accepts" => [%{"scheme" => "exact", "network" => "eip155:8453"}],
+        "lastUpdated" => 1_703_123_456
+      }
+
+      Bypass.expect(bypass, "GET", "/discovery/resources", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+
+        assert conn.query_params == %{
+                 "type" => "http",
+                 "payTo" => "0x1111111111111111111111111111111111111111",
+                 "scheme" => "exact",
+                 "network" => "eip155:8453",
+                 "limit" => "10",
+                 "offset" => "20"
+               }
+
+        Plug.Conn.resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            "x402Version" => 2,
+            "items" => [item],
+            "pagination" => %{"limit" => 10, "offset" => 20, "total" => 1}
+          })
+        )
+      end)
+
+      facilitator =
+        start_supervised!(
+          {Facilitator, name: unique_name("facilitator"), finch: finch, url: facilitator_url}
+        )
+
+      assert {:ok,
+              %{
+                x402_version: 2,
+                items: [returned_item],
+                pagination: %{limit: 10, offset: 20, total: 1}
+              }} =
+               Facilitator.list_resources(facilitator,
+                 type: "http",
+                 pay_to: "0x1111111111111111111111111111111111111111",
+                 scheme: "exact",
+                 network: "eip155:8453",
+                 limit: 10,
+                 offset: 20
+               )
+
+      assert returned_item == item
+    end
+
+    test "omits query string without parameters and defaults pagination to nil", %{
+      bypass: bypass,
+      finch: finch,
+      facilitator_url: facilitator_url
+    } do
+      Bypass.expect(bypass, "GET", "/discovery/resources", fn conn ->
+        assert conn.query_string == ""
+        Plug.Conn.resp(conn, 200, Jason.encode!(%{"items" => []}))
+      end)
+
+      facilitator =
+        start_supervised!(
+          {Facilitator, name: unique_name("facilitator"), finch: finch, url: facilitator_url}
+        )
+
+      assert {:ok, %{x402_version: nil, items: [], pagination: nil}} =
+               Facilitator.list_resources(facilitator)
+    end
+
+    test "rejects invalid parameters before any HTTP request", %{
+      finch: finch,
+      facilitator_url: facilitator_url
+    } do
+      facilitator =
+        start_supervised!(
+          {Facilitator, name: unique_name("facilitator"), finch: finch, url: facilitator_url}
+        )
+
+      assert {:error, %NimbleOptions.ValidationError{}} =
+               Facilitator.list_resources(facilitator, limit: 0)
+
+      assert {:error, %NimbleOptions.ValidationError{}} =
+               Facilitator.list_resources(facilitator, limit: 101)
+
+      assert {:error, %NimbleOptions.ValidationError{}} =
+               Facilitator.list_resources(facilitator, network: :base)
+
+      assert {:error, %NimbleOptions.ValidationError{}} =
+               Facilitator.list_resources(facilitator, unknown: "option")
+    end
+
+    test "fails closed on malformed responses", %{finch: finch} do
+      malformed_bodies = [
+        %{},
+        %{"items" => %{}},
+        %{"items" => ["not-a-map"]},
+        %{"items" => [], "pagination" => %{"limit" => "10"}},
+        %{"items" => [], "x402Version" => "2"}
+      ]
+
+      for body <- malformed_bodies do
+        bypass = Bypass.open()
+
+        Bypass.expect(bypass, "GET", "/discovery/resources", fn conn ->
+          Plug.Conn.resp(conn, 200, Jason.encode!(body))
+        end)
+
+        facilitator =
+          start_supervised!(
+            {Facilitator,
+             name: unique_name("facilitator"),
+             finch: finch,
+             url: "http://localhost:#{bypass.port}"}
+          )
+
+        assert {:error, %Error{type: :malformed_facilitator_response, status: 200}} =
+                 Facilitator.list_resources(facilitator)
+      end
+    end
+
+    test "sends a CDP JWT bound to the GET method and discovery path", %{
+      bypass: bypass,
+      finch: finch,
+      facilitator_url: facilitator_url
+    } do
+      {secret, public_key} = X402.TestAuthKeys.ed25519()
+
+      Bypass.expect(bypass, "GET", "/discovery/resources", fn conn ->
+        [authorization] = Plug.Conn.get_req_header(conn, "authorization")
+        token = String.replace_prefix(authorization, "Bearer ", "")
+        assert verify_jwt(token, public_key)
+
+        assert jwt_payload(token)["uris"] ==
+                 ["GET localhost:#{bypass.port}/discovery/resources"]
+
+        Plug.Conn.resp(conn, 200, Jason.encode!(%{"items" => []}))
+      end)
+
+      facilitator =
+        start_supervised!(
+          {Facilitator,
+           name: unique_name("facilitator"),
+           finch: finch,
+           url: facilitator_url,
+           auth: {X402.Facilitator.Auth.CDP, api_key_id: "key-123", api_key_secret: secret}}
+        )
+
+      assert {:ok, %{items: []}} = Facilitator.list_resources(facilitator, limit: 5)
+    end
+  end
+
   test "hook context struct includes payload and requirements" do
     assert %Context{payload: %{a: 1}, requirements: %{b: 2}, result: nil, error: nil} =
              Context.new(%{a: 1}, %{b: 2})


### PR DESCRIPTION
The facilitator client previously spoke only 2 of the 4 facilitator
endpoints (POST /verify and /settle), so startup route validation, SVM
feePayer discovery, and upto facilitatorAddress discovery were impossible
(ecosystem comparison report §8 P0.2; matrix/C2).

- X402.Facilitator.HTTP.get/3..4: GET transport with optional :query
  parameters, sharing the retry/backoff/TLS/header pipeline with the
  existing request/5 (which previously hardcoded :post at the Finch build
  call). No body is sent on GET.
- X402.Facilitator.supported/0..1: GET /supported returning
  {:ok, %{kinds: [...], extensions: [...], signers: %{...}}} with
  fail-closed validation following the foundation-HEAD TypeScript client
  and the v2 spec §7.3: kinds entries must be well-typed, and missing
  extensions/signers default to []/%{} while mistyped values are rejected
  with {:error, %Error{type: :malformed_facilitator_response}}.
- X402.Facilitator.list_resources/0..2: GET /discovery/resources with
  NimbleOptions-validated filters (type, pay_to, scheme, network,
  extensions, limit 1..100, offset) mapped to the spec's query parameters,
  fail-closed parsing of items/pagination/x402Version.
- Telemetry spans [:x402, :facilitator, :supported] and
  [:x402, :facilitator, :list_resources], consistent with verify/settle.
- Auth implementations now receive the real request method in
  request_info, so CDP JWTs mint a 'GET host path' uris claim for the new
  endpoints (X402.Facilitator.Auth.CDP already handled :get).

Bypass tests cover the success shapes, default fields, malformed-response
fail-closed cases for both endpoints, HTTP error propagation, query
encoding, and JWT method/path binding on GET.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive client APIs and HTTP refactor; auth method binding is a small behavioral fix for GET but verify/settle still use POST unchanged.
> 
> **Overview**
> Adds **read-only facilitator discovery** so callers can hit `GET /supported` and `GET /discovery/resources` alongside the existing verify/settle POSTs.
> 
> **`X402.Facilitator.HTTP.get/4`** shares the POST pipeline (HTTPS, retries, TLS) with optional `:query`, no body, and `Accept: application/json` only. **`supported/1`** and **`list_resources/2`** run in the caller like verify/settle, validate responses fail-closed (`:malformed_facilitator_response`), and skip hooks. Discovery filters use NimbleOptions (`pay_to` → `payTo`, `limit` 1–100).
> 
> **Auth** passes the real HTTP method into `request_info` (`:get` vs `:post`) so CDP JWT `uris` bind correctly on the new endpoints. New telemetry spans `[:x402, :facilitator, :supported]` and `[:x402, :facilitator, :list_resources]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 498f95fd5538269d2f135be64aba74a1027d8597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->