### PR TITLE
feat: MCP transport — paid tool calls per transports-v2/mcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `:extensions` option — client extension enrichers applied to the
   assembled payload (how gas-sponsoring data is attached opt-in)
 - `integration/e2e_server/` — resource-server component for the official x402 cross-language e2e interop harness (`X402.Plug.PaymentGate` + `X402.Facilitator` behind Bandit), including a ready-to-copy `e2e/servers/elixir/http/bandit/` tree for the foundation repo, the upstream patch list, and a local smoke suite (`verify.sh`)
+- MCP transport (report §8 P1.6): `X402.MCP` — library-agnostic pure
+  functions implementing the x402 MCP transport over plain tool-call
+  request/result maps (`_meta["x402/payment"]` payloads,
+  `_meta["x402/payment-response"]` receipts, payment-required results with
+  `structuredContent` + `content[0].text`, and `402`/`-32042` JSON-RPC
+  payment errors)
+- `X402.MCP.Server` — wraps any MCP tool handler with the
+  verify → execute → settle flow against `X402.Facilitator`, validating
+  payloads as strictly as `X402.Plug.PaymentGate` (v2 version check,
+  `accepted` matching, extension echo) with optional replay protection via
+  the same `payment_identifier_cache` option
+- `X402.MCP.Client` — drives any tool-call function through the
+  detect → sign → retry-once loop (never pays twice) with the same
+  `on_payment_required` veto hook and `max_amount` budget guard as
+  `X402.Client.Finch`, plus `build_payment_meta/3` for manual retries
+- `[:x402, :mcp, :payment_required | :payment_verified | :payment_rejected | :call]`
+  telemetry events
+- `guides/mcp.md` — "Paid MCP Tools in Elixir"
 
 ## [0.5.0] - 2026-08-26
 

--- a/guides/mcp.md
+++ b/guides/mcp.md
@@ -1,0 +1,196 @@
+# Paid MCP Tools in Elixir
+
+The [x402 MCP transport](https://github.com/x402-foundation/x402/blob/main/specs/transports-v2/mcp.md)
+lets AI agents pay for MCP tool calls: a paid tool advertises its price in a
+payment-required tool result, the client retries the call with a signed
+payment in request `_meta`, and the settlement receipt comes back in result
+`_meta`. This guide covers both halves — charging for a tool you serve, and
+paying for a tool you call.
+
+## How a paid tool call happens
+
+1. The client calls a paid tool without payment. The server returns a tool
+   result with `isError: true` whose `structuredContent` (and JSON-encoded
+   `content[0].text`) carry the `PaymentRequired` object — the price list.
+2. The client picks a payment option, signs it (EIP-3009 for `exact` on EVM
+   networks — an off-chain signature, no gas), and retries the tool call with
+   the `PaymentPayload` in request params `_meta["x402/payment"]`.
+3. The server verifies the payment through its facilitator, runs the tool,
+   settles, and attaches the settlement receipt to result
+   `_meta["x402/payment-response"]`.
+
+The SDK implements this as **library-agnostic pure functions over plain
+maps** — `X402.MCP`, `X402.MCP.Server`, and `X402.MCP.Client` work with any
+Elixir MCP library (Anubis/Hermes, Phantom, gen_mcp, a hand-rolled JSON-RPC
+loop) because MCP tool-call requests and results are just maps.
+
+## Serving a paid tool
+
+Compile the pricing once (at boot or module level), then wrap your tool
+handler with `X402.MCP.Server.call/3`:
+
+```elixir
+# In your application supervision tree:
+children = [
+  {X402.Facilitator, name: MyApp.Facilitator, finch: MyApp.Finch},
+  {X402.Extensions.PaymentIdentifier.ETSCache, name: MyApp.PaymentCache}
+]
+
+config =
+  X402.MCP.Server.init(
+    tool: "premium_search",
+    description: "Premium search with fresh data",
+    accepts: [
+      %{
+        price: "10000",                                        # atomic units
+        network: "eip155:84532",                               # Base Sepolia
+        asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",   # USDC
+        pay_to: "0xYourReceivingWallet",
+        extra: %{"name" => "USDC", "version" => "2"}
+      }
+    ],
+    facilitator: MyApp.Facilitator,
+    payment_identifier_cache: MyApp.PaymentCache
+  )
+
+def handle_tool_call("premium_search", params) do
+  X402.MCP.Server.call(params, config, fn request ->
+    results = MyApp.Search.run(request["arguments"]["query"])
+    %{"content" => [%{"type" => "text", "text" => results}]}
+  end)
+end
+```
+
+`call/3` always returns a tool result map, so it drops straight into any
+dispatch function:
+
+- **No payment** (or an invalid one) → the spec's payment-required result.
+  The wrapped handler never runs.
+- **Valid payment** → verified against the facilitator, the handler runs,
+  the payment is settled, and the receipt lands in
+  `_meta["x402/payment-response"]`.
+- **Handler returns `"isError" => true`** → returned unchanged, nothing is
+  settled, and the replay claim is released so the client can retry with the
+  same payment.
+- **Settlement fails after execution** → only the payment error is returned,
+  never the tool's content (per the spec).
+
+Validation is as strict as `X402.Plug.PaymentGate`: the payload must be
+x402 v2, its `accepted` must match an advertised option exactly (including
+`extra` preservation), and advertised `extensions` must be echoed without
+dropping values.
+
+`payment_identifier_cache:` enables replay protection — the same
+`X402.Extensions.PaymentIdentifier.ETSCache` option the Plug gate takes. Each
+payment proof is atomically claimed before settlement, so the same signed
+payment cannot be settled twice.
+
+To advertise the price outside a rejection (for example in a `tools/list`
+response), use `X402.MCP.Server.payment_required_result/2`.
+
+### Wiring into an MCP library
+
+The wrapper needs the raw `tools/call` **params map including `_meta`** —
+that is where the payment travels. Run it at whatever layer of your MCP stack
+sees those params, and return the resulting map through the library's
+tool-result path (results are plain maps on the wire, and `_meta` on a result
+is standard MCP). The wrapper never touches the transport, so stdio, SSE, and
+streamable HTTP all work unchanged.
+
+With a hand-rolled JSON-RPC loop (or any library that hands you the request):
+
+```elixir
+def handle_request(%{"method" => "tools/call", "params" => params} = rpc) do
+  result =
+    case params["name"] do
+      "premium_search" ->
+        X402.MCP.Server.call(params, MyServer.Pricing.premium_search(), fn req ->
+          %{"content" => [%{"type" => "text", "text" => search(req["arguments"])}]}
+        end)
+
+      other ->
+        free_tool(other, params)
+    end
+
+  %{"jsonrpc" => "2.0", "id" => rpc["id"], "result" => result}
+end
+```
+
+Support for exposing per-call `_meta` to tool handlers varies across the
+current Elixir MCP libraries — as of Anubis MCP 2.0 (`anubis_mcp`, the
+successor to `hermes_mcp`), component callbacks receive the initialize-time
+`_meta` (`frame.context.init_meta`) but not the tool call's own `_meta`, so
+the wrapper belongs in a lower-level handler or plug in front of tool
+dispatch. If your library of choice surfaces the raw `tools/call` params
+anywhere, the integration is the one-liner above.
+
+## Paying for a paid tool
+
+`X402.MCP.Client.call/3` drives any tool-call function through the
+detect → sign → retry-once loop. Add `ex_secp256k1` and `ex_keccak` for
+signing:
+
+```elixir
+{:ok, signer} = X402.Signer.LocalKey.new(System.fetch_env!("PAYER_PRIVATE_KEY"))
+
+request = %{"name" => "premium_search", "arguments" => %{"query" => "x402"}}
+
+{:ok, %{result: result, payment_response: receipt, paid: true}} =
+  X402.MCP.Client.call(request, &MyMCP.call_tool/1,
+    signer: signer,
+    max_amount: "10000",
+    on_payment_required: fn payment_required ->
+      Logger.info("paying for tool", accepts: payment_required["accepts"])
+      :ok
+    end
+  )
+
+IO.inspect(receipt["transaction"], label: "settlement tx")
+```
+
+The tool-call function receives the (possibly payment-carrying) request map
+and may return the tool result map directly, `{:ok, result}`, or
+`{:error, reason}`. Payment challenges are detected in payment-required tool
+results and in `402`/`-32042` JSON-RPC errors (the SEP-1036 elicitation code
+some MCP stacks use for payment flows).
+
+Guardrails, matching `X402.Client.Finch`:
+
+- **`max_amount:`** — the budget guard; options above it are never selected.
+  `network:`, `scheme:`, and `asset:` filter selection the same way.
+- **`on_payment_required:`** — a veto hook invoked with the decoded
+  `PaymentRequired` before anything is signed. Return `:cancel` to abort with
+  `{:error, :payment_cancelled}`.
+- **Never pays twice** — at most one payment retry per call; a second
+  payment-required response is returned as-is, and requests that already
+  carry `_meta["x402/payment"]` are refused with
+  `{:error, :payment_already_attempted}`.
+
+If your MCP client library exposes request `_meta` but you want to drive the
+retry yourself, `X402.MCP.Client.build_payment_meta/3` turns a
+payment-required response (tool result or bare `PaymentRequired`) into the
+`_meta` entries for the retried call:
+
+```elixir
+with {:ok, result} <- MyMCP.call_tool(request),
+     {:ok, payment_required} <- X402.MCP.fetch_payment_required(result),
+     {:ok, meta} <- X402.MCP.Client.build_payment_meta(payment_required, signer) do
+  MyMCP.call_tool(request, meta: meta)
+end
+```
+
+## Telemetry
+
+- `[:x402, :mcp, :payment_required]` — server advertised payment requirements
+- `[:x402, :mcp, :payment_verified]` — server verified and settled a payment
+- `[:x402, :mcp, :payment_rejected]` — server rejected a payment (`:reason`)
+- `[:x402, :mcp, :call]` — client drove a tool call (`:status`, `:paid`)
+
+All events carry `%{count: 1}` measurements.
+
+## References
+
+- [MCP transport specification](https://github.com/x402-foundation/x402/blob/main/specs/transports-v2/mcp.md)
+- [x402 v2 specification](https://github.com/x402-foundation/x402/blob/main/specs/x402-specification-v2.md)
+- [Paying for x402 Resources from Elixir](client.html) — the HTTP payer client
+- [Plug/Phoenix Integration](plug-integration.html) — the HTTP server half

--- a/lib/x402/mcp.ex
+++ b/lib/x402/mcp.ex
@@ -1,0 +1,383 @@
+defmodule X402.MCP do
+  @moduledoc """
+  x402 v2 payment flows over the Model Context Protocol (MCP transport).
+
+  This module implements the
+  [x402 MCP transport](https://github.com/x402-foundation/x402/blob/main/specs/transports-v2/mcp.md)
+  as pure functions over plain MCP tool-call request/result maps, so it works
+  with any Elixir MCP library (or none). The payment data rides in three
+  well-known places:
+
+  1. A paid tool called without payment returns a tool result with
+     `"isError" => true` whose `"structuredContent"` (and JSON-encoded
+     `content[0].text`) carry the `PaymentRequired` object.
+  2. The client retries the tool call with the signed `PaymentPayload` in
+     request params `_meta["x402/payment"]`.
+  3. The server verifies, runs the tool, settles, and attaches the settlement
+     receipt to result `_meta["x402/payment-response"]`.
+
+  `X402.MCP.Server` wraps a tool handler with verify → execute → settle;
+  `X402.MCP.Client` drives an arbitrary tool-call function through the
+  detect → sign → retry-once loop. The helpers here are shared by both halves
+  and useful on their own when wiring a concrete MCP library.
+
+  All functions accept maps with string keys (as decoded from JSON) or atom
+  keys, but the x402 `_meta` entries themselves always use the spec's string
+  keys `"x402/payment"` and `"x402/payment-response"`.
+
+  ## Telemetry
+
+  The MCP transport emits the following events, each with `%{count: 1}`
+  measurements:
+
+  - `[:x402, :mcp, :payment_required]` — server advertised payment requirements
+  - `[:x402, :mcp, :payment_verified]` — server verified and settled a payment
+  - `[:x402, :mcp, :payment_rejected]` — server rejected a payment
+    (metadata includes `:reason`)
+  - `[:x402, :mcp, :call]` — client drove a tool call
+    (metadata includes `:status` and `:paid` or `:reason`)
+  """
+
+  alias X402.Utils
+
+  @payment_meta_key "x402/payment"
+  @payment_response_meta_key "x402/payment-response"
+
+  # Legacy x402 JSON-RPC error code carrying PaymentRequired in error data.
+  @payment_required_code 402
+  # SEP-1036 UrlElicitationRequired, designated by MCP for payment flows.
+  @elicitation_required_code -32_042
+
+  @meta_keys {"_meta", :_meta}
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the request `_meta` key carrying the client's `PaymentPayload`.
+
+  ## Examples
+
+      iex> X402.MCP.payment_meta_key()
+      "x402/payment"
+  """
+  @spec payment_meta_key() :: String.t()
+  def payment_meta_key, do: @payment_meta_key
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the result `_meta` key carrying the server's settlement receipt.
+
+  ## Examples
+
+      iex> X402.MCP.payment_response_meta_key()
+      "x402/payment-response"
+  """
+  @spec payment_response_meta_key() :: String.t()
+  def payment_response_meta_key, do: @payment_response_meta_key
+
+  @doc since: "0.6.0"
+  @doc """
+  Fetches the `PaymentPayload` from a tool-call request's `_meta`.
+
+  Performs the same minimal structural check as the upstream SDKs — the value
+  must be a map with `x402Version` and `payload` — full validation happens
+  during verification.
+
+  ## Examples
+
+      iex> payment = %{"x402Version" => 2, "accepted" => %{}, "payload" => %{}}
+      iex> request = %{"name" => "search", "_meta" => %{"x402/payment" => payment}}
+      iex> X402.MCP.fetch_payment(request)
+      {:ok, payment}
+
+      iex> X402.MCP.fetch_payment(%{"name" => "search"})
+      :error
+  """
+  @spec fetch_payment(map()) :: {:ok, map()} | :error
+  def fetch_payment(request) when is_map(request) do
+    with meta when is_map(meta) <- Utils.map_value(request, @meta_keys),
+         %{} = payment <- Map.get(meta, @payment_meta_key),
+         true <- payment_payload_structure?(payment) do
+      {:ok, payment}
+    else
+      _other -> :error
+    end
+  end
+
+  def fetch_payment(_request), do: :error
+
+  @doc since: "0.6.0"
+  @doc """
+  Attaches a `PaymentPayload` to a tool-call request's `_meta`.
+
+  Existing `_meta` entries are preserved; when the request uses an atom
+  `:_meta` key it is kept (avoiding a duplicate key on JSON encoding).
+
+  ## Examples
+
+      iex> request = %{"name" => "search", "arguments" => %{"q" => "x402"}}
+      iex> X402.MCP.put_payment(request, %{"x402Version" => 2, "payload" => %{}})
+      %{
+        "name" => "search",
+        "arguments" => %{"q" => "x402"},
+        "_meta" => %{"x402/payment" => %{"x402Version" => 2, "payload" => %{}}}
+      }
+  """
+  @spec put_payment(map(), map()) :: map()
+  def put_payment(request, payment_payload)
+      when is_map(request) and is_map(payment_payload) do
+    put_meta_entry(request, @payment_meta_key, payment_payload)
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Fetches the settlement receipt from a tool result's `_meta`.
+
+  The receipt must be a map containing `success` (the `SettlementResponse`
+  schema).
+
+  ## Examples
+
+      iex> receipt = %{"success" => true, "transaction" => "0xabc", "network" => "eip155:84532"}
+      iex> result = %{"content" => [], "_meta" => %{"x402/payment-response" => receipt}}
+      iex> X402.MCP.fetch_payment_response(result)
+      {:ok, receipt}
+
+      iex> X402.MCP.fetch_payment_response(%{"content" => []})
+      :error
+  """
+  @spec fetch_payment_response(map()) :: {:ok, map()} | :error
+  def fetch_payment_response(result) when is_map(result) do
+    with meta when is_map(meta) <- Utils.map_value(result, @meta_keys),
+         %{} = receipt <- Map.get(meta, @payment_response_meta_key),
+         true <- settle_response_structure?(receipt) do
+      {:ok, receipt}
+    else
+      _other -> :error
+    end
+  end
+
+  def fetch_payment_response(_result), do: :error
+
+  @doc since: "0.6.0"
+  @doc """
+  Attaches a settlement receipt to a tool result's `_meta`.
+
+  ## Examples
+
+      iex> result = %{"content" => [%{"type" => "text", "text" => "ok"}]}
+      iex> X402.MCP.put_payment_response(result, %{"success" => true})
+      %{
+        "content" => [%{"type" => "text", "text" => "ok"}],
+        "_meta" => %{"x402/payment-response" => %{"success" => true}}
+      }
+  """
+  @spec put_payment_response(map(), map()) :: map()
+  def put_payment_response(result, settle_response)
+      when is_map(result) and is_map(settle_response) do
+    put_meta_entry(result, @payment_response_meta_key, settle_response)
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Fetches the `PaymentRequired` object from a payment-required tool result.
+
+  Per the MCP transport spec, the result must have `isError: true`.
+  `structuredContent` is preferred; `content[0].text` is parsed as JSON when
+  structured content is absent. Returns `:error` for any other tool result.
+
+  ## Examples
+
+      iex> payment_required = %{"x402Version" => 2, "error" => "Payment required", "accepts" => []}
+      iex> result = %{"isError" => true, "structuredContent" => payment_required, "content" => []}
+      iex> X402.MCP.fetch_payment_required(result)
+      {:ok, payment_required}
+
+      iex> X402.MCP.fetch_payment_required(%{"content" => [%{"type" => "text", "text" => "hi"}]})
+      :error
+  """
+  @spec fetch_payment_required(map()) :: {:ok, map()} | :error
+  def fetch_payment_required(result) when is_map(result) do
+    with true <- Utils.map_value(result, {"isError", :isError}) == true,
+         {:ok, payment_required} <- extract_payment_required(result) do
+      {:ok, payment_required}
+    else
+      _other -> :error
+    end
+  end
+
+  def fetch_payment_required(_result), do: :error
+
+  @doc since: "0.6.0"
+  @doc """
+  Fetches the `PaymentRequired` object from a JSON-RPC error.
+
+  Some MCP stacks surface payment challenges as JSON-RPC errors instead of
+  tool results: code `402` (legacy x402) carries `PaymentRequired` directly in
+  `data`, and code `-32042` (SEP-1036 `UrlElicitationRequired`, which MCP
+  designates for payment/elicitation flows) carries it in `data` or namespaced
+  under `data.x402`.
+
+  ## Examples
+
+      iex> payment_required = %{"x402Version" => 2, "accepts" => []}
+      iex> error = %{"code" => 402, "message" => "Payment required", "data" => payment_required}
+      iex> X402.MCP.fetch_payment_required_from_error(error)
+      {:ok, payment_required}
+
+      iex> error = %{
+      ...>   "code" => -32042,
+      ...>   "message" => "Elicitation required",
+      ...>   "data" => %{"x402" => %{"x402Version" => 2, "accepts" => []}}
+      ...> }
+      iex> X402.MCP.fetch_payment_required_from_error(error)
+      {:ok, %{"x402Version" => 2, "accepts" => []}}
+
+      iex> X402.MCP.fetch_payment_required_from_error(%{"code" => -32600})
+      :error
+  """
+  @spec fetch_payment_required_from_error(term()) :: {:ok, map()} | :error
+  def fetch_payment_required_from_error(error) when is_map(error) do
+    payment_required_from_error(
+      Utils.map_value(error, {"code", :code}),
+      Utils.map_value(error, {"data", :data})
+    )
+  end
+
+  def fetch_payment_required_from_error(_error), do: :error
+
+  @spec payment_required_from_error(term(), term()) :: {:ok, map()} | :error
+  defp payment_required_from_error(@payment_required_code, data) do
+    fetch_payment_required_structure(data)
+  end
+
+  defp payment_required_from_error(@elicitation_required_code, data) do
+    case fetch_payment_required_structure(data) do
+      {:ok, payment_required} -> {:ok, payment_required}
+      :error -> fetch_payment_required_structure(namespaced_x402(data))
+    end
+  end
+
+  defp payment_required_from_error(_code, _data), do: :error
+
+  @spec fetch_payment_required_structure(term()) :: {:ok, map()} | :error
+  defp fetch_payment_required_structure(value) do
+    case payment_required_structure?(value) do
+      true -> {:ok, value}
+      false -> :error
+    end
+  end
+
+  @spec namespaced_x402(term()) :: term()
+  defp namespaced_x402(data) when is_map(data), do: Utils.map_value(data, {"x402", :x402})
+  defp namespaced_x402(_data), do: nil
+
+  @doc since: "0.6.0"
+  @doc """
+  Builds the payment-required tool result for a `PaymentRequired` object.
+
+  Per the MCP transport spec the object is provided in **both** formats:
+  `structuredContent` carries it directly and `content[0].text` carries the
+  same object JSON-encoded, with `isError: true`.
+
+  Returns `{:error, :invalid_payment_required}` when the map lacks the
+  `x402Version`/`accepts` structure or cannot be encoded as JSON.
+
+  ## Examples
+
+      iex> payment_required = %{"x402Version" => 2, "error" => "Payment required", "accepts" => []}
+      iex> {:ok, result} = X402.MCP.payment_required_result(payment_required)
+      iex> {result["isError"], result["structuredContent"] == payment_required}
+      {true, true}
+      iex> [%{"type" => "text", "text" => text}] = result["content"]
+      iex> Jason.decode!(text) == payment_required
+      true
+
+      iex> X402.MCP.payment_required_result(%{"accepts" => []})
+      {:error, :invalid_payment_required}
+  """
+  @spec payment_required_result(map()) :: {:ok, map()} | {:error, :invalid_payment_required}
+  def payment_required_result(payment_required) when is_map(payment_required) do
+    with true <- payment_required_structure?(payment_required),
+         {:ok, json} <- Jason.encode(payment_required) do
+      {:ok,
+       %{
+         "isError" => true,
+         "structuredContent" => payment_required,
+         "content" => [%{"type" => "text", "text" => json}]
+       }}
+    else
+      _other -> {:error, :invalid_payment_required}
+    end
+  end
+
+  def payment_required_result(_payment_required), do: {:error, :invalid_payment_required}
+
+  # -- Structure checks -------------------------------------------------------
+
+  @spec payment_payload_structure?(map()) :: boolean()
+  defp payment_payload_structure?(payment) do
+    not is_nil(Utils.map_value(payment, {"x402Version", :x402Version})) and
+      not is_nil(Utils.map_value(payment, {"payload", :payload}))
+  end
+
+  @spec settle_response_structure?(map()) :: boolean()
+  defp settle_response_structure?(receipt) do
+    has_key?(receipt, {"success", :success})
+  end
+
+  @spec payment_required_structure?(term()) :: boolean()
+  defp payment_required_structure?(value) when is_map(value) do
+    not is_nil(Utils.map_value(value, {"x402Version", :x402Version})) and
+      is_list(Utils.map_value(value, {"accepts", :accepts}))
+  end
+
+  defp payment_required_structure?(_value), do: false
+
+  @spec has_key?(map(), {String.t(), atom()}) :: boolean()
+  defp has_key?(map, {string_key, atom_key}) do
+    Map.has_key?(map, string_key) or Map.has_key?(map, atom_key)
+  end
+
+  # -- _meta plumbing ---------------------------------------------------------
+
+  @spec extract_payment_required(map()) :: {:ok, map()} | :error
+  defp extract_payment_required(result) do
+    structured = Utils.map_value(result, {"structuredContent", :structuredContent})
+
+    case payment_required_structure?(structured) do
+      true -> {:ok, structured}
+      false -> extract_payment_required_from_content(result)
+    end
+  end
+
+  @spec extract_payment_required_from_content(map()) :: {:ok, map()} | :error
+  defp extract_payment_required_from_content(result) do
+    with [first | _rest] <- Utils.map_value(result, {"content", :content}),
+         true <- is_map(first),
+         "text" <- Utils.map_value(first, {"type", :type}),
+         text when is_binary(text) <- Utils.map_value(first, {"text", :text}),
+         {:ok, decoded} <- Jason.decode(text),
+         true <- payment_required_structure?(decoded) do
+      {:ok, decoded}
+    else
+      _other -> :error
+    end
+  end
+
+  @spec put_meta_entry(map(), String.t(), map()) :: map()
+  defp put_meta_entry(map, key, value) do
+    meta =
+      case Utils.map_value(map, @meta_keys) do
+        existing when is_map(existing) -> existing
+        _other -> %{}
+      end
+
+    meta_key =
+      case Map.has_key?(map, :_meta) and not Map.has_key?(map, "_meta") do
+        true -> :_meta
+        false -> "_meta"
+      end
+
+    Map.put(map, meta_key, Map.put(meta, key, value))
+  end
+end

--- a/lib/x402/mcp/client.ex
+++ b/lib/x402/mcp/client.ex
@@ -1,0 +1,280 @@
+defmodule X402.MCP.Client do
+  @moduledoc """
+  Client half of the x402 MCP transport: pay for tool calls automatically.
+
+  `call/3` drives an arbitrary tool-call function (any MCP client library, or
+  a plain function in tests) through the x402 detect → sign → retry-once loop:
+
+  1. Perform the tool call. A result that is not payment-required is returned
+     as-is.
+  2. Extract the `PaymentRequired` object from the payment-required tool
+     result (or from a `402`/`-32042` JSON-RPC error).
+  3. Invoke the `:on_payment_required` hook, which may cancel.
+  4. Build and sign a payment via `X402.Client.build_payment/3` and retry the
+     tool call once with the payload in request `_meta["x402/payment"]`.
+  5. Return the retried result with the decoded settlement receipt from
+     result `_meta["x402/payment-response"]`, when present.
+
+  A tool call is **never paid twice**: at most one payment retry is made, a
+  second payment-required result is returned as-is, and requests that already
+  carry `_meta["x402/payment"]` are refused.
+
+  ## Example
+
+      {:ok, signer} = X402.Signer.LocalKey.new(System.fetch_env!("PAYER_KEY"))
+
+      request = %{"name" => "premium_search", "arguments" => %{"query" => "x402"}}
+
+      {:ok, %{result: result, payment_response: receipt, paid: true}} =
+        X402.MCP.Client.call(request, &MyMCP.call_tool/1,
+          signer: signer,
+          max_amount: "10000",
+          on_payment_required: fn payment_required ->
+            IO.inspect(payment_required["accepts"], label: "about to pay")
+            :ok
+          end
+        )
+
+  The tool-call function receives the (possibly payment-carrying) request map
+  and may return the tool result map directly, `{:ok, result}`, or
+  `{:error, reason}`.
+  """
+
+  alias X402.Client
+  alias X402.MCP
+  alias X402.Signer
+
+  @call_opts_schema [
+    signer: [
+      type: {:custom, __MODULE__, :validate_signer, []},
+      required: true,
+      doc: "A struct implementing `X402.Signer`, used to sign the payment."
+    ],
+    network: [
+      type: :string,
+      doc: "Payment selection filter — see `X402.Client.select_requirements/2`."
+    ],
+    scheme: [
+      type: :string,
+      doc: "Payment selection filter — see `X402.Client.select_requirements/2`."
+    ],
+    asset: [
+      type: :string,
+      doc: "Payment selection filter — see `X402.Client.select_requirements/2`."
+    ],
+    max_amount: [
+      type: {:or, [:string, :non_neg_integer]},
+      doc: """
+      Maximum `amount` (atomic units) this client will pay — the budget guard
+      for automated payers. Requirements above it are never selected.
+      """
+    ],
+    valid_after_buffer: [
+      type: :non_neg_integer,
+      default: 60,
+      doc: "Clock-skew buffer for the authorization's `validAfter`, in seconds."
+    ],
+    on_payment_required: [
+      type: {:or, [{:fun, 1}, nil]},
+      default: nil,
+      doc: """
+      Budget/consent hook invoked with the decoded `PaymentRequired` map
+      before any payment is signed. Return `:cancel` to abort with
+      `{:error, :payment_cancelled}`; any other return value continues.
+      """
+    ]
+  ]
+
+  @typedoc """
+  A completed tool call.
+
+  `:result` is the final tool result map; `:payment_response` holds the
+  decoded settlement receipt from `_meta["x402/payment-response"]` when the
+  server sent one, otherwise `nil`; `:paid` tells whether a payment was
+  signed and submitted.
+  """
+  @type response :: %{
+          result: map(),
+          payment_response: map() | nil,
+          paid: boolean()
+        }
+
+  @typedoc "A tool-call function driven by `call/3`."
+  @type call_fun :: (map() -> map() | {:ok, map()} | {:error, term()})
+
+  @type call_error ::
+          :payment_already_attempted
+          | :payment_cancelled
+          | :invalid_tool_result
+          | {:transport_error, term()}
+          | Client.build_error()
+
+  @doc since: "0.6.0"
+  @doc """
+  Performs a tool call, paying for the tool if it requires payment.
+
+  See the module documentation for the full flow. Returns `{:ok, response()}`
+  with the final tool result, or `{:error, reason}` when the payment was
+  cancelled, could not be built, or the tool-call function failed.
+
+  ## Options
+
+  #{NimbleOptions.docs(@call_opts_schema)}
+  """
+  @spec call(map(), call_fun(), keyword()) :: {:ok, response()} | {:error, call_error()}
+  def call(request, call_fun, opts)
+      when is_map(request) and is_function(call_fun, 1) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @call_opts_schema)
+
+    result = drive(request, call_fun, opts)
+    emit_call_telemetry(result)
+    result
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Builds the request `_meta` map paying for a payment-required response.
+
+  Accepts either a decoded `PaymentRequired` map or the payment-required tool
+  result that carries one, selects and signs a payment option via
+  `X402.Client.build_payment/3`, and returns the `_meta` entries to merge into
+  the retried tool-call request. Options are forwarded to
+  `X402.Client.build_payment/3`.
+
+  Use this instead of `call/3` when your MCP library exposes request `_meta`
+  but you want to drive the retry yourself.
+  """
+  @spec build_payment_meta(map(), Signer.t(), keyword()) ::
+          {:ok, %{String.t() => map()}} | {:error, Client.build_error()}
+  def build_payment_meta(payment_required_or_result, signer, opts \\ [])
+      when is_map(payment_required_or_result) and is_list(opts) do
+    payment_required =
+      case MCP.fetch_payment_required(payment_required_or_result) do
+        {:ok, payment_required} -> payment_required
+        :error -> payment_required_or_result
+      end
+
+    with {:ok, payload} <- Client.build_payment(payment_required, signer, opts) do
+      {:ok, %{MCP.payment_meta_key() => payload}}
+    end
+  end
+
+  @doc false
+  @spec validate_signer(term()) :: {:ok, struct()} | {:error, String.t()}
+  def validate_signer(%module{} = signer) do
+    case X402.Behaviour.implements?(module, address: 1, sign_eip712: 3) do
+      true -> {:ok, signer}
+      false -> {:error, "expected a struct implementing X402.Signer"}
+    end
+  end
+
+  def validate_signer(_signer), do: {:error, "expected a struct implementing X402.Signer"}
+
+  # -- Payment flow -----------------------------------------------------------
+
+  @spec drive(map(), call_fun(), keyword()) :: {:ok, response()} | {:error, call_error()}
+  defp drive(request, call_fun, opts) do
+    case attempt(call_fun, request) do
+      {:ok, tool_result} -> maybe_pay(request, call_fun, opts, tool_result)
+      {:error, :invalid_tool_result} = error -> error
+      {:error, reason} -> maybe_pay_from_error(request, call_fun, opts, reason)
+    end
+  end
+
+  @spec maybe_pay(map(), call_fun(), keyword(), map()) ::
+          {:ok, response()} | {:error, call_error()}
+  defp maybe_pay(request, call_fun, opts, tool_result) do
+    case MCP.fetch_payment_required(tool_result) do
+      {:ok, payment_required} -> pay_and_retry(request, call_fun, opts, payment_required)
+      :error -> {:ok, finalize(tool_result, false)}
+    end
+  end
+
+  @spec maybe_pay_from_error(map(), call_fun(), keyword(), term()) ::
+          {:ok, response()} | {:error, call_error()}
+  defp maybe_pay_from_error(request, call_fun, opts, reason) do
+    case MCP.fetch_payment_required_from_error(reason) do
+      {:ok, payment_required} -> pay_and_retry(request, call_fun, opts, payment_required)
+      :error -> {:error, {:transport_error, reason}}
+    end
+  end
+
+  @spec pay_and_retry(map(), call_fun(), keyword(), map()) ::
+          {:ok, response()} | {:error, call_error()}
+  defp pay_and_retry(request, call_fun, opts, payment_required) do
+    with :ok <- ensure_not_already_paid(request),
+         :ok <- consent(opts, payment_required),
+         {:ok, payload} <-
+           Client.build_payment(payment_required, opts[:signer], build_opts(opts)),
+         {:ok, retry_result} <- retry(call_fun, MCP.put_payment(request, payload)) do
+      # A second payment-required result is returned as-is — the payment is
+      # never re-signed or re-sent.
+      {:ok, finalize(retry_result, true)}
+    end
+  end
+
+  @spec ensure_not_already_paid(map()) :: :ok | {:error, :payment_already_attempted}
+  defp ensure_not_already_paid(request) do
+    case MCP.fetch_payment(request) do
+      :error -> :ok
+      {:ok, _payment} -> {:error, :payment_already_attempted}
+    end
+  end
+
+  @spec consent(keyword(), map()) :: :ok | {:error, :payment_cancelled}
+  defp consent(opts, payment_required) do
+    case Keyword.fetch!(opts, :on_payment_required) do
+      nil ->
+        :ok
+
+      hook when is_function(hook, 1) ->
+        case hook.(payment_required) do
+          :cancel -> {:error, :payment_cancelled}
+          _other -> :ok
+        end
+    end
+  end
+
+  @spec build_opts(keyword()) :: keyword()
+  defp build_opts(opts),
+    do: Keyword.take(opts, [:network, :scheme, :asset, :max_amount, :valid_after_buffer])
+
+  @spec attempt(call_fun(), map()) :: {:ok, map()} | {:error, term()}
+  defp attempt(call_fun, request) do
+    case call_fun.(request) do
+      {:ok, %{} = tool_result} -> {:ok, tool_result}
+      {:error, reason} -> {:error, reason}
+      %{} = tool_result -> {:ok, tool_result}
+      _other -> {:error, :invalid_tool_result}
+    end
+  end
+
+  @spec retry(call_fun(), map()) :: {:ok, map()} | {:error, call_error()}
+  defp retry(call_fun, request) do
+    case attempt(call_fun, request) do
+      {:ok, tool_result} -> {:ok, tool_result}
+      {:error, :invalid_tool_result} = error -> error
+      {:error, reason} -> {:error, {:transport_error, reason}}
+    end
+  end
+
+  @spec finalize(map(), boolean()) :: response()
+  defp finalize(tool_result, paid) do
+    payment_response =
+      case MCP.fetch_payment_response(tool_result) do
+        {:ok, receipt} -> receipt
+        :error -> nil
+      end
+
+    %{result: tool_result, payment_response: payment_response, paid: paid}
+  end
+
+  @spec emit_call_telemetry({:ok, response()} | {:error, term()}) :: :ok
+  defp emit_call_telemetry({:ok, response}) do
+    :telemetry.execute([:x402, :mcp, :call], %{count: 1}, %{status: :ok, paid: response.paid})
+  end
+
+  defp emit_call_telemetry({:error, reason}) do
+    :telemetry.execute([:x402, :mcp, :call], %{count: 1}, %{status: :error, reason: reason})
+  end
+end

--- a/lib/x402/mcp/client.ex
+++ b/lib/x402/mcp/client.ex
@@ -254,7 +254,21 @@ defmodule X402.MCP.Client do
     case attempt(call_fun, request) do
       {:ok, tool_result} -> {:ok, tool_result}
       {:error, :invalid_tool_result} = error -> error
-      {:error, reason} -> {:error, {:transport_error, reason}}
+      {:error, reason} -> classify_retry_error(reason)
+    end
+  end
+
+  # A rejected paid retry may come back as a JSON-RPC payment error instead of
+  # a payment-required tool result. Normalize it to the tool-result form so
+  # both shapes are returned as-is (the payment is never re-signed) rather
+  # than surfacing as a transport error.
+  @spec classify_retry_error(term()) :: {:ok, map()} | {:error, call_error()}
+  defp classify_retry_error(reason) do
+    with {:ok, payment_required} <- MCP.fetch_payment_required_from_error(reason),
+         {:ok, tool_result} <- MCP.payment_required_result(payment_required) do
+      {:ok, tool_result}
+    else
+      _other -> {:error, {:transport_error, reason}}
     end
   end
 

--- a/lib/x402/mcp/server.ex
+++ b/lib/x402/mcp/server.ex
@@ -1,0 +1,692 @@
+defmodule X402.MCP.Server do
+  @moduledoc """
+  Server half of the x402 MCP transport: gates a tool handler behind payment.
+
+  `call/3` inspects an MCP tool-call request for a payment in
+  `_meta["x402/payment"]` and drives the full verify → execute → settle flow
+  against an `X402.Facilitator`:
+
+  1. No payment → the payment-required tool result (`isError: true` with the
+     `PaymentRequired` object in `structuredContent` and `content[0].text`).
+  2. Invalid payment (wrong version, `accepted` not matching the advertised
+     requirements, extension echo mismatch, failed verification) → the same
+     payment-required result with the rejection reason.
+  3. Valid payment → the wrapped handler runs; on success the payment is
+     settled and the receipt is attached to result
+     `_meta["x402/payment-response"]`. When settlement fails after execution,
+     only the payment error is returned — never the tool's content.
+
+  The module is MCP-library agnostic: requests and results are plain maps in
+  the shapes MCP libraries already use, so the wrapper drops into any tool
+  dispatch function. See the [MCP guide](mcp.html) for integration snippets.
+
+  ## Example
+
+      config =
+        X402.MCP.Server.init(
+          tool: "premium_search",
+          accepts: [
+            %{
+              price: "10000",
+              network: "eip155:84532",
+              asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+              pay_to: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+              extra: %{"name" => "USDC", "version" => "2"}
+            }
+          ],
+          facilitator: MyApp.Facilitator
+        )
+
+      X402.MCP.Server.call(request, config, fn _request ->
+        %{"content" => [%{"type" => "text", "text" => "results..."}]}
+      end)
+
+  ## Replay protection
+
+  Pass `payment_identifier_cache:` (an
+  `X402.Extensions.PaymentIdentifier.ETSCache` server, the same option
+  `X402.Plug.PaymentGate` takes) to atomically claim each payment proof before
+  settlement, rejecting concurrent or repeated submissions of the same signed
+  payment. The claim is released when the handler fails or settlement fails,
+  so the client may retry with the same payment.
+  """
+
+  alias X402.Extensions.PaymentIdentifier.ETSCache
+  alias X402.Facilitator
+  alias X402.Facilitator.Error
+  alias X402.Hooks
+  alias X402.Hooks.Default
+  alias X402.MCP
+  alias X402.PaymentRequirements
+  alias X402.PaymentSignature
+  alias X402.Utils
+
+  require Logger
+
+  @schemes ["exact", "upto"]
+  @x402_version 2
+  @supported_payment_flow "authorization"
+  @default_max_timeout_seconds 60
+  @default_mime_type "application/json"
+
+  @accept_option_schema [
+    scheme: [
+      type: {:in, @schemes},
+      default: "exact",
+      doc: "Payment scheme (`exact` or `upto`)."
+    ],
+    price: [
+      type: {:custom, __MODULE__, :validate_atomic_amount, []},
+      required: true,
+      doc: "Payment amount in atomic token units (PaymentRequirements `amount`)."
+    ],
+    network: [
+      type: :string,
+      required: true,
+      doc: "Blockchain network in CAIP-2 format (for example `eip155:84532`)."
+    ],
+    asset: [
+      type: :string,
+      required: true,
+      doc: "Token contract address or asset identifier."
+    ],
+    pay_to: [
+      type: :string,
+      required: true,
+      doc: "Recipient wallet address (`payTo` in the PaymentRequirements schema)."
+    ],
+    max_timeout_seconds: [
+      type: :pos_integer,
+      default: @default_max_timeout_seconds,
+      doc: "Maximum time allowed for payment completion."
+    ],
+    extra: [
+      type: {:custom, __MODULE__, :validate_extra_map, []},
+      default: %{},
+      doc: "Scheme-specific extra fields (string or atom keys)."
+    ]
+  ]
+
+  @options_schema [
+    tool: [
+      type: :string,
+      required: true,
+      doc: "Tool name; used for the default `mcp://tool/{tool}` resource URL."
+    ],
+    accepts: [
+      type: {:list, {:map, @accept_option_schema}},
+      required: true,
+      doc: "Payment options advertised in `PaymentRequired.accepts` (at least one)."
+    ],
+    facilitator: [
+      type: :any,
+      default: Facilitator,
+      doc: "Facilitator server pid/name used for verification and settlement."
+    ],
+    hooks: [
+      type: {:custom, Hooks, :validate_module, []},
+      default: Default,
+      doc: "Lifecycle hook module implementing `X402.Hooks`."
+    ],
+    payment_identifier_cache: [
+      type: {:or, [:atom, :pid, :any]},
+      default: nil,
+      doc: """
+      Optional `ETSCache` server pid/name used for idempotency. When set, the
+      wrapper performs an atomic claim (via `put_new`) on the payment proof
+      hash before settling, preventing concurrent requests from double-settling
+      the same payment.
+      """
+    ],
+    resource_url: [
+      type: {:or, [:string, nil]},
+      default: nil,
+      doc: "Custom ResourceInfo.url (defaults to `mcp://tool/{tool}`)."
+    ],
+    description: [
+      type: {:or, [:string, nil]},
+      default: nil,
+      doc: "ResourceInfo.description (defaults to `Tool: {tool}`)."
+    ],
+    mime_type: [
+      type: :string,
+      default: @default_mime_type,
+      doc: "ResourceInfo.mimeType."
+    ],
+    service_name: [
+      type: {:or, [:string, nil]},
+      default: nil,
+      doc: "ResourceInfo.serviceName (printable ASCII, max 32 characters recommended)."
+    ],
+    tags: [
+      type: {:list, :string},
+      default: [],
+      doc: "ResourceInfo.tags (max 5 recommended)."
+    ],
+    icon_url: [
+      type: {:or, [:string, nil]},
+      default: nil,
+      doc: "ResourceInfo.iconUrl (absolute http(s) URL)."
+    ],
+    extensions: [
+      type: {:custom, __MODULE__, :validate_extra_map, []},
+      default: %{},
+      doc: "Protocol extensions advertised in PaymentRequired.extensions."
+    ]
+  ]
+
+  @typedoc "Configuration map produced by `init/1`."
+  @type options :: %{
+          tool: String.t(),
+          facilitator: Facilitator.server(),
+          hooks: module(),
+          payment_identifier_cache: ETSCache.server() | nil,
+          accepts: [map()],
+          resource: map(),
+          extensions: map()
+        }
+
+  @typedoc "An MCP tool-call handler: request params in, tool result map out."
+  @type handler :: (map() -> map())
+
+  # Reasons caused by facilitator infrastructure failures rather than by the
+  # client's payment; these produce an opaque internal error result instead of
+  # re-advertising the payment requirements.
+  defguardp is_infrastructure_reason(reason)
+            when is_struct(reason, Error) or
+                   (is_tuple(reason) and
+                      elem(reason, 0) in [
+                        :unexpected_facilitator_status,
+                        :malformed_facilitator_response
+                      ])
+
+  @doc false
+  @spec validate_extra_map(term()) :: {:ok, map()} | {:error, String.t()}
+  def validate_extra_map(value) when is_map(value), do: {:ok, value}
+  def validate_extra_map(_value), do: {:error, "expected a map"}
+
+  @doc false
+  @spec validate_atomic_amount(term()) :: {:ok, String.t()} | {:error, String.t()}
+  def validate_atomic_amount(value) when is_binary(value) do
+    case Regex.match?(~r/^\d+$/, value) do
+      true -> {:ok, value}
+      false -> {:error, "expected a digit-only atomic-unit amount"}
+    end
+  end
+
+  def validate_atomic_amount(_value), do: {:error, "expected a digit-only atomic-unit amount"}
+
+  @doc since: "0.6.0"
+  @doc """
+  Validates and compiles paid-tool options.
+
+  Raises `NimbleOptions.ValidationError` for invalid options and
+  `ArgumentError` when `:accepts` is empty, an accept's `extra.paymentFlow`
+  is not `"authorization"`, or the advertised data cannot be encoded as JSON.
+
+  ## Options
+
+  #{NimbleOptions.docs(@options_schema)}
+
+  ### Accept option fields (inside `:accepts`)
+
+  #{NimbleOptions.docs(@accept_option_schema)}
+  """
+  @spec init(keyword()) :: options()
+  def init(opts) when is_list(opts) do
+    validated = NimbleOptions.validate!(opts, @options_schema)
+
+    tool = Keyword.fetch!(validated, :tool)
+    accepts = compile_accepts(Keyword.fetch!(validated, :accepts))
+    resource = compile_resource(tool, validated)
+    extensions = stringify_keys(Keyword.fetch!(validated, :extensions))
+
+    ensure_json_encodable!(%{
+      "accepts" => accepts,
+      "resource" => resource,
+      "extensions" => extensions
+    })
+
+    %{
+      tool: tool,
+      facilitator: Keyword.fetch!(validated, :facilitator),
+      hooks: Keyword.fetch!(validated, :hooks),
+      payment_identifier_cache: Keyword.get(validated, :payment_identifier_cache),
+      accepts: accepts,
+      resource: resource,
+      extensions: extensions
+    }
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Gates an MCP tool-call request behind x402 payment verification.
+
+  `request` is the tool-call params map (typically with `"name"`,
+  `"arguments"`, and `"_meta"` keys). `handler` receives the request and must
+  return a tool result map (with a `"content"` list and optional
+  `"isError"`); it only runs after the payment has been verified.
+
+  Always returns a tool result map:
+
+  - the payment-required result when payment is missing, invalid, rejected
+    by the facilitator, or already settled (replay)
+  - the handler's result with the settlement receipt attached to
+    `_meta["x402/payment-response"]` on success
+  - the handler's error result unchanged (no settlement) when the handler
+    sets `"isError" => true`
+  - the settlement-failure result (payment-required format, without the
+    tool's content) when settlement fails after execution
+  - an opaque internal error result when the facilitator transport fails
+
+  If the handler raises, the replay claim is released and the exception is
+  re-raised for the MCP library to surface.
+  """
+  @spec call(map(), options(), handler()) :: map()
+  def call(request, config, handler)
+      when is_map(request) and is_map(config) and is_function(handler, 1) do
+    if is_nil(config.payment_identifier_cache), do: warn_no_idempotency_cache_once()
+
+    case MCP.fetch_payment(request) do
+      :error ->
+        emit(:payment_required, %{tool: config.tool})
+        payment_required_result(config, "Payment required to access this tool")
+
+      {:ok, payment_payload} ->
+        verify_and_execute(request, config, handler, payment_payload)
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Builds the payment-required tool result advertised by this configuration.
+
+  Useful for advertising the price of a paid tool outside `call/3` (for
+  example in a `tools/list` response or documentation).
+  """
+  @spec payment_required_result(options(), String.t()) :: map()
+  def payment_required_result(config, error_message \\ "Payment required to access this tool")
+      when is_map(config) and is_binary(error_message) do
+    payment_required = %{
+      "x402Version" => @x402_version,
+      "error" => error_message,
+      "resource" => config.resource,
+      "accepts" => config.accepts,
+      "extensions" => config.extensions
+    }
+
+    case MCP.payment_required_result(payment_required) do
+      {:ok, result} -> result
+      # init/1 guarantees encodability; this is a defensive fallback.
+      {:error, _reason} -> internal_error_result()
+    end
+  end
+
+  # -- Verification -----------------------------------------------------------
+
+  @spec verify_and_execute(map(), options(), handler(), map()) :: map()
+  defp verify_and_execute(request, config, handler, payment_payload) do
+    with {:ok, requirements} <- validate_payment(payment_payload, config),
+         {:ok, payment_id} <- payment_id(payment_payload),
+         {:ok, verify_response} <- facilitator_verify(config, payment_payload, requirements),
+         :ok <- ensure_verify_success(verify_response),
+         :ok <- claim_payment(config.payment_identifier_cache, payment_id) do
+      execute_and_settle(request, config, handler, payment_payload, requirements, payment_id)
+    else
+      {:error, reason} ->
+        emit(:payment_rejected, %{tool: config.tool, reason: reason})
+        rejection_result(config, reason)
+    end
+  end
+
+  @spec validate_payment(map(), options()) :: {:ok, map()} | {:error, term()}
+  defp validate_payment(payment_payload, config) do
+    with :ok <- ensure_v2_payload(payment_payload),
+         {:ok, payment_payload} <- PaymentSignature.validate(payment_payload),
+         {:ok, matched} <- find_matching_requirements(config.accepts, payment_payload),
+         :ok <- validate_extensions(payment_payload, config.extensions) do
+      {:ok, matched}
+    end
+  end
+
+  @spec ensure_v2_payload(map()) :: :ok | {:error, :invalid_x402_version}
+  defp ensure_v2_payload(payload) do
+    case Utils.map_value(payload, {"x402Version", :x402Version}) do
+      @x402_version -> :ok
+      _version -> {:error, :invalid_x402_version}
+    end
+  end
+
+  @spec find_matching_requirements([map()], map()) ::
+          {:ok, map()} | {:error, :no_matching_requirements}
+  defp find_matching_requirements(accepts, payment_payload) do
+    accepted = Utils.map_value(payment_payload, {"accepted", :accepted})
+
+    with true <- is_map(accepted),
+         %{} = matched <- Enum.find(accepts, &PaymentRequirements.match?(&1, accepted)) do
+      {:ok, matched}
+    else
+      _other -> {:error, :no_matching_requirements}
+    end
+  end
+
+  @spec validate_extensions(map(), map()) :: :ok | {:error, :extension_echo_mismatch}
+  defp validate_extensions(payload, advertised_extensions) do
+    client_extensions = Utils.map_value(payload, {"extensions", :extensions})
+
+    case PaymentRequirements.extensions_match?(advertised_extensions, client_extensions) do
+      true -> :ok
+      false -> {:error, :extension_echo_mismatch}
+    end
+  end
+
+  @spec payment_id(map()) :: {:ok, String.t()} | {:error, :invalid_payload}
+  defp payment_id(payment_payload) do
+    case Jason.encode(payment_payload) do
+      {:ok, json} ->
+        {:ok, :crypto.hash(:sha256, json) |> Base.encode16(case: :lower)}
+
+      {:error, _reason} ->
+        {:error, :invalid_payload}
+    end
+  end
+
+  # -- Execution and settlement -----------------------------------------------
+
+  @spec execute_and_settle(map(), options(), handler(), map(), map(), String.t()) :: map()
+  defp execute_and_settle(request, config, handler, payment_payload, requirements, payment_id) do
+    result = run_handler(config, handler, request, payment_id)
+
+    case error_result?(result) do
+      true ->
+        # The tool itself failed: return its error unchanged, do not settle,
+        # and release the claim so the client may retry with the same payment.
+        release_claim(config.payment_identifier_cache, payment_id)
+        result
+
+      false ->
+        settle_result(config, payment_payload, requirements, payment_id, result)
+    end
+  end
+
+  @spec run_handler(options(), handler(), map(), String.t()) :: map()
+  defp run_handler(config, handler, request, payment_id) do
+    result =
+      try do
+        handler.(request)
+      rescue
+        exception ->
+          release_claim(config.payment_identifier_cache, payment_id)
+          reraise exception, __STACKTRACE__
+      catch
+        kind, reason ->
+          release_claim(config.payment_identifier_cache, payment_id)
+          :erlang.raise(kind, reason, __STACKTRACE__)
+      end
+
+    case result do
+      %{} = result_map ->
+        result_map
+
+      other ->
+        release_claim(config.payment_identifier_cache, payment_id)
+
+        raise ArgumentError,
+              "expected the wrapped MCP tool handler to return a tool result map, " <>
+                "got: #{inspect(other)}"
+    end
+  end
+
+  @spec settle_result(options(), map(), map(), String.t(), map()) :: map()
+  defp settle_result(config, payment_payload, requirements, payment_id, result) do
+    with {:ok, settle_response} <- facilitator_settle(config, payment_payload, requirements),
+         :ok <- ensure_settle_success(settle_response) do
+      emit(:payment_verified, %{tool: config.tool})
+      MCP.put_payment_response(result, settle_response.body)
+    else
+      {:error, reason} ->
+        release_claim(config.payment_identifier_cache, payment_id)
+        emit(:payment_rejected, %{tool: config.tool, reason: reason})
+        settlement_failed_result(config, reason)
+    end
+  end
+
+  # Per the spec, settlement failure after execution follows the payment
+  # required format and must not include the tool's content.
+  @spec settlement_failed_result(options(), term()) :: map()
+  defp settlement_failed_result(_config, reason) when is_infrastructure_reason(reason) do
+    internal_error_result()
+  end
+
+  defp settlement_failed_result(config, reason) do
+    payment_required_result(config, "Payment settlement failed: #{rejection_message(reason)}")
+  end
+
+  @spec rejection_result(options(), term()) :: map()
+  defp rejection_result(_config, reason) when is_infrastructure_reason(reason) do
+    internal_error_result()
+  end
+
+  defp rejection_result(config, reason) do
+    payment_required_result(config, rejection_message(reason))
+  end
+
+  @spec internal_error_result() :: map()
+  defp internal_error_result do
+    %{
+      "isError" => true,
+      "content" => [%{"type" => "text", "text" => "Internal server error"}]
+    }
+  end
+
+  @spec rejection_message(term()) :: String.t()
+  defp rejection_message(:invalid_x402_version), do: "invalid_x402_version"
+  defp rejection_message(:invalid_payload), do: "invalid_payload"
+  defp rejection_message(:no_matching_requirements), do: "No matching payment requirements"
+  defp rejection_message(:extension_echo_mismatch), do: "invalid_payload"
+  defp rejection_message(:already_exists), do: "payment already processed"
+  defp rejection_message({:missing_fields, _fields}), do: "invalid_payload"
+  defp rejection_message({:invalid_fields, _fields}), do: "invalid_payload"
+  defp rejection_message({:invalid_format, _fields}), do: "invalid_payload"
+  defp rejection_message({:invalid_upto_payment, _reason}), do: "invalid_payload"
+  defp rejection_message(:invalid_payment_requirements), do: "invalid_payload"
+
+  defp rejection_message({:verification_failed, reason}) when is_binary(reason), do: reason
+
+  defp rejection_message({:verification_failed, _reason}),
+    do: "facilitator rejected payment"
+
+  defp rejection_message({:settlement_failed, reason}) when is_binary(reason), do: reason
+  defp rejection_message({:settlement_failed, _reason}), do: "facilitator rejected payment"
+  defp rejection_message(_reason), do: "payment processing failed"
+
+  @spec error_result?(map()) :: boolean()
+  defp error_result?(result), do: Utils.map_value(result, {"isError", :isError}) == true
+
+  # -- Facilitator ------------------------------------------------------------
+
+  @spec facilitator_verify(options(), map(), map()) :: Facilitator.response()
+  defp facilitator_verify(%{hooks: Default} = config, payment_payload, requirements) do
+    Facilitator.verify(config.facilitator, payment_payload, requirements)
+  end
+
+  defp facilitator_verify(config, payment_payload, requirements) do
+    Facilitator.verify(config.facilitator, payment_payload, requirements, config.hooks)
+  end
+
+  @spec facilitator_settle(options(), map(), map()) :: Facilitator.response()
+  defp facilitator_settle(%{hooks: Default} = config, payment_payload, requirements) do
+    Facilitator.settle(config.facilitator, payment_payload, requirements)
+  end
+
+  defp facilitator_settle(config, payment_payload, requirements) do
+    Facilitator.settle(config.facilitator, payment_payload, requirements, config.hooks)
+  end
+
+  @spec ensure_verify_success(map()) :: :ok | {:error, term()}
+  defp ensure_verify_success(%{status: status, body: body})
+       when status in 200..299 and is_map(body) do
+    case Utils.map_value(body, {"isValid", :isValid}) do
+      true ->
+        :ok
+
+      false ->
+        {:error, {:verification_failed, Utils.map_value(body, {"invalidReason", :invalidReason})}}
+
+      _missing_or_invalid ->
+        {:error, {:malformed_facilitator_response, :verify}}
+    end
+  end
+
+  defp ensure_verify_success(%{status: status}) when status in 200..299,
+    do: {:error, {:malformed_facilitator_response, :verify}}
+
+  defp ensure_verify_success(%{status: status}) when is_integer(status),
+    do: {:error, {:unexpected_facilitator_status, status}}
+
+  defp ensure_verify_success(%{}),
+    do: {:error, {:malformed_facilitator_response, :verify}}
+
+  @spec ensure_settle_success(map()) :: :ok | {:error, term()}
+  defp ensure_settle_success(%{status: status, body: body})
+       when status in 200..299 and is_map(body) do
+    case Utils.map_value(body, {"success", :success}) do
+      true ->
+        validate_settle_response_fields(body)
+
+      false ->
+        with :ok <- validate_settle_response_fields(body) do
+          {:error, {:settlement_failed, Utils.map_value(body, {"errorReason", :errorReason})}}
+        end
+
+      _missing_or_invalid ->
+        {:error, {:malformed_facilitator_response, :settle}}
+    end
+  end
+
+  defp ensure_settle_success(%{status: status}) when status in 200..299,
+    do: {:error, {:malformed_facilitator_response, :settle}}
+
+  defp ensure_settle_success(%{status: status}) when is_integer(status),
+    do: {:error, {:unexpected_facilitator_status, status}}
+
+  defp ensure_settle_success(%{}),
+    do: {:error, {:malformed_facilitator_response, :settle}}
+
+  @spec validate_settle_response_fields(map()) ::
+          :ok | {:error, {:malformed_facilitator_response, :settle}}
+  defp validate_settle_response_fields(body) do
+    transaction = Utils.map_value(body, {"transaction", :transaction})
+    network = Utils.map_value(body, {"network", :network})
+
+    case is_binary(transaction) and is_binary(network) and network != "" do
+      true -> :ok
+      false -> {:error, {:malformed_facilitator_response, :settle}}
+    end
+  end
+
+  # -- Replay claims ----------------------------------------------------------
+
+  @spec claim_payment(ETSCache.server() | nil, String.t()) :: :ok | {:error, :already_exists}
+  defp claim_payment(nil, _payment_id), do: :ok
+  defp claim_payment(cache, payment_id), do: ETSCache.put_new(cache, payment_id, :verified)
+
+  @spec release_claim(ETSCache.server() | nil, String.t()) :: :ok | {:error, term()}
+  defp release_claim(nil, _payment_id), do: :ok
+  defp release_claim(cache, payment_id), do: ETSCache.delete(cache, payment_id)
+
+  defp warn_no_idempotency_cache_once do
+    key = {__MODULE__, :no_idempotency_cache_warned}
+
+    unless :persistent_term.get(key, false) do
+      :persistent_term.put(key, true)
+
+      Logger.warning(
+        "[X402.MCP.Server] payment_identifier_cache is not configured. " <>
+          "Duplicate payment proofs will NOT be detected — your deployment is " <>
+          "vulnerable to double-settlement of concurrent identical requests. " <>
+          "Pass `payment_identifier_cache: pid_or_name` to enable idempotency."
+      )
+    end
+  end
+
+  # -- Config compilation -----------------------------------------------------
+
+  @spec compile_accepts([map()]) :: [map()]
+  defp compile_accepts([]) do
+    raise ArgumentError, ":accepts must contain at least one payment option"
+  end
+
+  defp compile_accepts(accepts) do
+    Enum.map(accepts, fn accept ->
+      extra = stringify_keys(Map.get(accept, :extra, %{}))
+      ensure_supported_payment_flow!(extra)
+
+      %{
+        "scheme" => Map.get(accept, :scheme, "exact"),
+        "network" => Map.fetch!(accept, :network),
+        "amount" => Map.fetch!(accept, :price),
+        "asset" => Map.fetch!(accept, :asset),
+        "payTo" => Map.fetch!(accept, :pay_to),
+        "maxTimeoutSeconds" =>
+          Map.get(accept, :max_timeout_seconds, @default_max_timeout_seconds),
+        "extra" => extra
+      }
+    end)
+  end
+
+  @spec ensure_supported_payment_flow!(map()) :: :ok
+  defp ensure_supported_payment_flow!(extra) do
+    case Utils.map_value(extra, {"paymentFlow", :paymentFlow}) do
+      nil -> :ok
+      @supported_payment_flow -> :ok
+      flow -> raise ArgumentError, "unsupported payment flow: #{inspect(flow)}"
+    end
+  end
+
+  @spec compile_resource(String.t(), keyword()) :: map()
+  defp compile_resource(tool, validated) do
+    %{
+      "url" => Keyword.get(validated, :resource_url) || "mcp://tool/#{tool}",
+      "description" => Keyword.get(validated, :description) || "Tool: #{tool}",
+      "mimeType" => Keyword.fetch!(validated, :mime_type)
+    }
+    |> maybe_put("serviceName", Keyword.get(validated, :service_name))
+    |> maybe_put_tags(Keyword.fetch!(validated, :tags))
+    |> maybe_put("iconUrl", Keyword.get(validated, :icon_url))
+  end
+
+  @spec ensure_json_encodable!(map()) :: :ok
+  defp ensure_json_encodable!(advertised) do
+    case Jason.encode(advertised) do
+      {:ok, _json} ->
+        :ok
+
+      {:error, reason} ->
+        raise ArgumentError,
+              "accepts/resource/extensions must be JSON-encodable, got: #{inspect(reason)}"
+    end
+  end
+
+  @spec maybe_put(map(), String.t(), term()) :: map()
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, _key, ""), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  @spec maybe_put_tags(map(), [String.t()]) :: map()
+  defp maybe_put_tags(map, tags) when tags != [], do: Map.put(map, "tags", tags)
+  defp maybe_put_tags(map, _tags), do: map
+
+  @spec stringify_keys(map()) :: map()
+  defp stringify_keys(map) do
+    Map.new(map, fn
+      {key, value} when is_atom(key) -> {Atom.to_string(key), value}
+      {key, value} -> {key, value}
+    end)
+  end
+
+  @spec emit(:payment_required | :payment_verified | :payment_rejected, map()) :: :ok
+  defp emit(event, metadata) do
+    :telemetry.execute([:x402, :mcp, event], %{count: 1}, metadata)
+  end
+end

--- a/lib/x402/mcp/server.ex
+++ b/lib/x402/mcp/server.ex
@@ -51,6 +51,7 @@ defmodule X402.MCP.Server do
   so the client may retry with the same payment.
   """
 
+  alias X402.Extensions.PaymentIdentifier.Cache
   alias X402.Extensions.PaymentIdentifier.ETSCache
   alias X402.Facilitator
   alias X402.Facilitator.Error
@@ -129,13 +130,15 @@ defmodule X402.MCP.Server do
       doc: "Lifecycle hook module implementing `X402.Hooks`."
     ],
     payment_identifier_cache: [
-      type: {:or, [:atom, :pid, :any]},
+      type: {:custom, __MODULE__, :validate_payment_identifier_cache, []},
       default: nil,
       doc: """
-      Optional `ETSCache` server pid/name used for idempotency. When set, the
-      wrapper performs an atomic claim (via `put_new`) on the payment proof
-      hash before settling, preventing concurrent requests from double-settling
-      the same payment.
+      Optional idempotency cache: an `ETSCache` server pid/name (the default
+      adapter), or a `{module, cache}` adapter tuple implementing
+      `X402.Extensions.PaymentIdentifier.Cache`. When set, the wrapper
+      performs an atomic claim (via `put_new`) on a hash of the signed scheme
+      payload before settling, preventing concurrent requests from
+      double-settling the same payment.
       """
     ],
     resource_url: [
@@ -194,10 +197,12 @@ defmodule X402.MCP.Server do
   # re-advertising the payment requirements.
   defguardp is_infrastructure_reason(reason)
             when is_struct(reason, Error) or
+                   reason == :cache_full or
                    (is_tuple(reason) and
                       elem(reason, 0) in [
                         :unexpected_facilitator_status,
-                        :malformed_facilitator_response
+                        :malformed_facilitator_response,
+                        :claim_failed
                       ])
 
   @doc false
@@ -330,7 +335,7 @@ defmodule X402.MCP.Server do
          {:ok, payment_id} <- payment_id(payment_payload),
          {:ok, verify_response} <- facilitator_verify(config, payment_payload, requirements),
          :ok <- ensure_verify_success(verify_response),
-         :ok <- claim_payment(config.payment_identifier_cache, payment_id) do
+         :ok <- claim_or_fail(config.payment_identifier_cache, payment_id) do
       execute_and_settle(request, config, handler, payment_payload, requirements, payment_id)
     else
       {:error, reason} ->
@@ -380,13 +385,21 @@ defmodule X402.MCP.Server do
     end
   end
 
+  # The claim key must be derived from the SIGNED material only, encoded
+  # deterministically: hashing a plain Jason encoding of the whole envelope
+  # lets extra envelope fields or a different key order mint a fresh id for
+  # the same signed authorization, so a mutated replay would claim a new slot
+  # and run the paid handler again. The scheme payload (signature +
+  # authorization) cannot be altered without failing facilitator
+  # verification, which precedes the claim.
   @spec payment_id(map()) :: {:ok, String.t()} | {:error, :invalid_payload}
   defp payment_id(payment_payload) do
-    case Jason.encode(payment_payload) do
-      {:ok, json} ->
-        {:ok, :crypto.hash(:sha256, json) |> Base.encode16(case: :lower)}
+    case Utils.map_value(payment_payload, {"payload", :payload}) do
+      scheme_payload when is_map(scheme_payload) ->
+        canonical = :erlang.term_to_binary(scheme_payload, [:deterministic])
+        {:ok, :crypto.hash(:sha256, canonical) |> Base.encode16(case: :lower)}
 
-      {:error, _reason} ->
+      _other ->
         {:error, :invalid_payload}
     end
   end
@@ -587,13 +600,56 @@ defmodule X402.MCP.Server do
 
   # -- Replay claims ----------------------------------------------------------
 
-  @spec claim_payment(ETSCache.server() | nil, String.t()) :: :ok | {:error, :already_exists}
+  @spec claim_payment(Cache.adapter() | nil, String.t()) :: Cache.put_new_result()
   defp claim_payment(nil, _payment_id), do: :ok
-  defp claim_payment(cache, payment_id), do: ETSCache.put_new(cache, payment_id, :verified)
+  defp claim_payment(adapter, payment_id), do: Cache.put_new(adapter, payment_id, :verified)
 
-  @spec release_claim(ETSCache.server() | nil, String.t()) :: :ok | {:error, term()}
+  # Duplicates are payment rejections; any other claim failure is cache
+  # infrastructure trouble and must fail closed as an internal error rather
+  # than re-advertise PaymentRequired after a successful verify (mirrors the
+  # Plug gate's 500 mapping).
+  @spec claim_or_fail(Cache.adapter() | nil, String.t()) ::
+          :ok | {:error, :already_exists | {:claim_failed, term()}}
+  defp claim_or_fail(cache, payment_id) do
+    case claim_payment(cache, payment_id) do
+      :ok -> :ok
+      {:error, :already_exists} = duplicate -> duplicate
+      {:error, reason} -> {:error, {:claim_failed, reason}}
+    end
+  end
+
+  @spec release_claim(Cache.adapter() | nil, String.t()) :: Cache.write_result()
   defp release_claim(nil, _payment_id), do: :ok
-  defp release_claim(cache, payment_id), do: ETSCache.delete(cache, payment_id)
+  defp release_claim(adapter, payment_id), do: Cache.delete(adapter, payment_id)
+
+  @doc false
+  @spec validate_payment_identifier_cache(term()) ::
+          {:ok, Cache.adapter() | nil} | {:error, String.t()}
+  def validate_payment_identifier_cache(nil), do: {:ok, nil}
+
+  # {:global, name} and {:via, registry, term} are unambiguous GenServer
+  # names, never adapter tuples — route them to the default ETSCache adapter.
+  def validate_payment_identifier_cache({:global, _name} = server),
+    do: {:ok, {ETSCache, server}}
+
+  def validate_payment_identifier_cache({:via, registry, _term} = server)
+      when is_atom(registry),
+      do: {:ok, {ETSCache, server}}
+
+  def validate_payment_identifier_cache({module, _cache} = adapter) when is_atom(module) do
+    case Cache.validate_adapter(adapter) do
+      :ok ->
+        {:ok, adapter}
+
+      {:error, message} ->
+        {:error,
+         message <>
+           "; to address a remote ETSCache as {name, node}, wrap it explicitly: " <>
+           "{X402.Extensions.PaymentIdentifier.ETSCache, {name, node}}"}
+    end
+  end
+
+  def validate_payment_identifier_cache(server), do: {:ok, {ETSCache, server}}
 
   defp warn_no_idempotency_cache_once do
     key = {__MODULE__, :no_idempotency_cache_warned}

--- a/mix.exs
+++ b/mix.exs
@@ -118,6 +118,7 @@ defmodule X402.MixProject do
         "guides/getting-started.md": [title: "Getting Started"],
         "guides/client.md": [title: "Paying for Resources"],
         "guides/plug-integration.md": [title: "Plug/Phoenix Integration"],
+        "guides/mcp.md": [title: "Paid MCP Tools"],
         "guides/live-smoke-tests.md": [title: "Live Smoke Tests"]
       ],
       groups_for_extras: [
@@ -150,6 +151,11 @@ defmodule X402.MixProject do
         ],
         "Plug Integration": [
           X402.Plug.PaymentGate
+        ],
+        "MCP Transport": [
+          X402.MCP,
+          X402.MCP.Server,
+          X402.MCP.Client
         ],
         Utilities: [
           X402.Wallet

--- a/test/x402/mcp/client_test.exs
+++ b/test/x402/mcp/client_test.exs
@@ -115,6 +115,18 @@ defmodule X402.MCP.ClientTest do
       assert Client.call(@request, call_fun, signer: signer()) ==
                {:error, :invalid_tool_result}
     end
+
+    test "rejects signers that do not implement X402.Signer" do
+      call_fun = tracking_fun([@ok_result])
+
+      assert_raise NimbleOptions.ValidationError, ~r/X402.Signer/, fn ->
+        Client.call(@request, call_fun, signer: "not a signer")
+      end
+
+      assert_raise NimbleOptions.ValidationError, ~r/X402.Signer/, fn ->
+        Client.call(@request, call_fun, signer: %URI{})
+      end
+    end
   end
 
   describe "call/3 payment flow" do
@@ -241,6 +253,13 @@ defmodule X402.MCP.ClientTest do
 
       assert Client.call(@request, call_fun, signer: signer()) ==
                {:error, {:transport_error, :closed}}
+    end
+
+    test "rejects invalid tool results on the retry" do
+      call_fun = tracking_fun([payment_required_result(), "nope"])
+
+      assert Client.call(@request, call_fun, signer: signer()) ==
+               {:error, :invalid_tool_result}
     end
   end
 

--- a/test/x402/mcp/client_test.exs
+++ b/test/x402/mcp/client_test.exs
@@ -1,0 +1,414 @@
+defmodule X402.MCP.ClientTest do
+  use ExUnit.Case, async: true
+
+  doctest X402.MCP.Client
+
+  alias X402.EIP3009
+  alias X402.Extensions.PaymentIdentifier.ETSCache
+  alias X402.MCP
+  alias X402.MCP.Client
+  alias X402.MCP.Server
+  alias X402.Signer.LocalKey
+
+  defmodule MockFacilitator do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) when is_list(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl true
+    def init(opts) do
+      {:ok,
+       %{
+         owner: Keyword.fetch!(opts, :owner),
+         verify: Keyword.fetch!(opts, :verify),
+         settle: Keyword.fetch!(opts, :settle)
+       }}
+    end
+
+    @impl true
+    def handle_call({:verify, payment_payload, requirements}, _from, state) do
+      send(state.owner, {:verify_called, payment_payload, requirements})
+      {:reply, state.verify, state}
+    end
+
+    def handle_call({:settle, payment_payload, requirements}, _from, state) do
+      send(state.owner, {:settle_called, payment_payload, requirements})
+      {:reply, state.settle, state}
+    end
+  end
+
+  @asset "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+  @receiver "0x2222222222222222222222222222222222222222"
+  @network "eip155:84532"
+
+  @requirements %{
+    "scheme" => "exact",
+    "network" => @network,
+    "amount" => "10000",
+    "asset" => @asset,
+    "payTo" => @receiver,
+    "maxTimeoutSeconds" => 300,
+    "extra" => %{"name" => "USDC", "version" => "2"}
+  }
+
+  @payment_required %{
+    "x402Version" => 2,
+    "error" => "Payment required to access this tool",
+    "resource" => %{"url" => "mcp://tool/premium_search", "mimeType" => "application/json"},
+    "accepts" => [@requirements],
+    "extensions" => %{}
+  }
+
+  @request %{"name" => "premium_search", "arguments" => %{"query" => "x402"}}
+
+  @ok_result %{"content" => [%{"type" => "text", "text" => "results"}]}
+
+  defp signer do
+    {:ok, signer} = LocalKey.new(:crypto.strong_rand_bytes(32))
+    signer
+  end
+
+  defp payment_required_result do
+    {:ok, result} = MCP.payment_required_result(@payment_required)
+    result
+  end
+
+  defp tracking_fun(responses) do
+    parent = self()
+    {:ok, agent} = Agent.start_link(fn -> responses end)
+
+    fn request ->
+      send(parent, {:tool_called, request})
+      Agent.get_and_update(agent, fn [head | rest] -> {head, rest} end)
+    end
+  end
+
+  describe "call/3 without payment required" do
+    test "returns the result as-is when the tool is free" do
+      call_fun = tracking_fun([@ok_result])
+
+      assert {:ok, %{result: @ok_result, payment_response: nil, paid: false}} =
+               Client.call(@request, call_fun, signer: signer())
+
+      assert_received {:tool_called, @request}
+      refute_received {:tool_called, _request}
+    end
+
+    test "accepts {:ok, result} returns from the tool-call function" do
+      call_fun = tracking_fun([{:ok, @ok_result}])
+
+      assert {:ok, %{result: @ok_result, paid: false}} =
+               Client.call(@request, call_fun, signer: signer())
+    end
+
+    test "propagates transport errors" do
+      call_fun = tracking_fun([{:error, :timeout}])
+
+      assert Client.call(@request, call_fun, signer: signer()) ==
+               {:error, {:transport_error, :timeout}}
+    end
+
+    test "rejects invalid tool results" do
+      call_fun = tracking_fun(["nope"])
+
+      assert Client.call(@request, call_fun, signer: signer()) ==
+               {:error, :invalid_tool_result}
+    end
+  end
+
+  describe "call/3 payment flow" do
+    test "signs and retries once with the payment in _meta" do
+      paid_result =
+        MCP.put_payment_response(@ok_result, %{"success" => true, "network" => @network})
+
+      call_fun = tracking_fun([payment_required_result(), paid_result])
+      signer = signer()
+
+      assert {:ok, %{result: result, payment_response: receipt, paid: true}} =
+               Client.call(@request, call_fun, signer: signer)
+
+      assert result == paid_result
+      assert receipt == %{"success" => true, "network" => @network}
+
+      assert_received {:tool_called, @request}
+      assert_received {:tool_called, retried}
+      assert retried["name"] == "premium_search"
+      assert retried["arguments"] == %{"query" => "x402"}
+
+      assert {:ok, payload} = MCP.fetch_payment(retried)
+      assert payload["x402Version"] == 2
+      assert payload["accepted"] == @requirements
+      assert payload["resource"] == @payment_required["resource"]
+
+      authorization = payload["payload"]["authorization"]
+      assert authorization["from"] == signer.address
+      assert authorization["to"] == @receiver
+      assert authorization["value"] == "10000"
+
+      assert {:ok, domain} = EIP3009.domain(@requirements)
+      assert {:ok, digest} = EIP3009.eip712_digest(domain, authorization)
+
+      assert EIP3009.recover_signer(digest, payload["payload"]["signature"]) ==
+               {:ok, signer.address}
+    end
+
+    test "detects payment-required results carried only in content text" do
+      text_only = %{
+        "isError" => true,
+        "content" => [%{"type" => "text", "text" => Jason.encode!(@payment_required)}]
+      }
+
+      call_fun = tracking_fun([text_only, @ok_result])
+
+      assert {:ok, %{result: @ok_result, paid: true}} =
+               Client.call(@request, call_fun, signer: signer())
+    end
+
+    test "detects payment-required JSON-RPC errors (402 and -32042)" do
+      error_402 = {:error, %{"code" => 402, "message" => "pay", "data" => @payment_required}}
+
+      assert {:ok, %{paid: true}} =
+               Client.call(@request, tracking_fun([error_402, @ok_result]), signer: signer())
+
+      elicitation =
+        {:error,
+         %{"code" => -32_042, "message" => "pay", "data" => %{"x402" => @payment_required}}}
+
+      assert {:ok, %{paid: true}} =
+               Client.call(@request, tracking_fun([elicitation, @ok_result]), signer: signer())
+    end
+
+    test "never pays twice: a second payment-required result is returned as-is" do
+      call_fun = tracking_fun([payment_required_result(), payment_required_result()])
+
+      assert {:ok, %{result: second, payment_response: nil, paid: true}} =
+               Client.call(@request, call_fun, signer: signer())
+
+      assert second["isError"] == true
+      assert_received {:tool_called, _first}
+      assert_received {:tool_called, _second}
+      refute_received {:tool_called, _third}
+    end
+
+    test "refuses to pay for requests that already carry a payment" do
+      request = MCP.put_payment(@request, %{"x402Version" => 2, "payload" => %{}})
+      call_fun = tracking_fun([payment_required_result()])
+
+      assert Client.call(request, call_fun, signer: signer()) ==
+               {:error, :payment_already_attempted}
+
+      assert_received {:tool_called, _first}
+      refute_received {:tool_called, _second}
+    end
+
+    test "the on_payment_required hook can cancel the payment" do
+      parent = self()
+      call_fun = tracking_fun([payment_required_result()])
+
+      hook = fn payment_required ->
+        send(parent, {:hook_called, payment_required})
+        :cancel
+      end
+
+      assert Client.call(@request, call_fun, signer: signer(), on_payment_required: hook) ==
+               {:error, :payment_cancelled}
+
+      assert_received {:hook_called, @payment_required}
+      assert_received {:tool_called, _first}
+      refute_received {:tool_called, _second}
+    end
+
+    test "any other hook return value continues the payment" do
+      call_fun = tracking_fun([payment_required_result(), @ok_result])
+
+      assert {:ok, %{paid: true}} =
+               Client.call(@request, call_fun,
+                 signer: signer(),
+                 on_payment_required: fn _payment_required -> :ok end
+               )
+    end
+
+    test "selection filters apply to the advertised requirements" do
+      call_fun = tracking_fun([payment_required_result()])
+
+      assert Client.call(@request, call_fun, signer: signer(), max_amount: "50") ==
+               {:error, :no_acceptable_requirements}
+    end
+
+    test "propagates transport errors on the retry" do
+      call_fun = tracking_fun([payment_required_result(), {:error, :closed}])
+
+      assert Client.call(@request, call_fun, signer: signer()) ==
+               {:error, {:transport_error, :closed}}
+    end
+  end
+
+  describe "build_payment_meta/3" do
+    test "builds the _meta entries from a PaymentRequired map" do
+      signer = signer()
+
+      assert {:ok, meta} = Client.build_payment_meta(@payment_required, signer)
+      assert %{"x402/payment" => payload} = meta
+      assert payload["accepted"] == @requirements
+    end
+
+    test "builds the _meta entries from a payment-required tool result" do
+      assert {:ok, %{"x402/payment" => payload}} =
+               Client.build_payment_meta(payment_required_result(), signer())
+
+      assert payload["accepted"] == @requirements
+    end
+
+    test "propagates selection errors" do
+      assert Client.build_payment_meta(@payment_required, signer(), max_amount: "1") ==
+               {:error, :no_acceptable_requirements}
+    end
+  end
+
+  describe "call/3 telemetry" do
+    test "emits [:x402, :mcp, :call]" do
+      handler_id = "mcp-client-test-#{System.unique_integer([:positive])}"
+      parent = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:x402, :mcp, :call],
+        fn event, measurements, metadata, _config ->
+          send(parent, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      Client.call(@request, tracking_fun([@ok_result]), signer: signer())
+
+      assert_received {:telemetry, [:x402, :mcp, :call], %{count: 1}, %{status: :ok, paid: false}}
+
+      Client.call(@request, tracking_fun([{:error, :timeout}]), signer: signer())
+
+      assert_received {:telemetry, [:x402, :mcp, :call], %{count: 1},
+                       %{status: :error, reason: {:transport_error, :timeout}}}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Full client ⇄ server loop
+  # ---------------------------------------------------------------------------
+
+  describe "client-server loop" do
+    setup do
+      facilitator =
+        start_supervised!(
+          {MockFacilitator,
+           owner: self(),
+           verify: {:ok, %{status: 200, body: %{"isValid" => true}}},
+           settle:
+             {:ok,
+              %{
+                status: 200,
+                body: %{
+                  "success" => true,
+                  "transaction" => "0x" <> String.duplicate("ab", 32),
+                  "network" => @network,
+                  "payer" => "0x3333333333333333333333333333333333333333"
+                }
+              }}}
+        )
+
+      cache =
+        start_supervised!({ETSCache, name: :"mcp_loop_#{System.unique_integer([:positive])}"})
+
+      config =
+        Server.init(
+          tool: "premium_search",
+          accepts: [
+            %{
+              price: "10000",
+              network: @network,
+              asset: @asset,
+              pay_to: @receiver,
+              max_timeout_seconds: 300,
+              extra: %{"name" => "USDC", "version" => "2"}
+            }
+          ],
+          facilitator: facilitator,
+          payment_identifier_cache: cache
+        )
+
+      %{config: config}
+    end
+
+    test "the client pays for a wrapped tool end to end", %{config: config} do
+      parent = self()
+      signer = signer()
+
+      handler = fn request ->
+        send(parent, {:handler_called, request})
+        @ok_result
+      end
+
+      call_fun = fn request ->
+        send(parent, {:tool_called, request})
+        Server.call(request, config, handler)
+      end
+
+      assert {:ok, %{result: result, payment_response: receipt, paid: true}} =
+               Client.call(@request, call_fun, signer: signer, max_amount: "10000")
+
+      assert result["content"] == [%{"type" => "text", "text" => "results"}]
+      assert receipt["success"] == true
+      assert receipt["transaction"] == "0x" <> String.duplicate("ab", 32)
+
+      # Exactly two tool calls: the unpaid probe and the paid retry.
+      assert_received {:tool_called, _first}
+      assert_received {:tool_called, _second}
+      refute_received {:tool_called, _third}
+
+      # The handler ran exactly once, for the paid call.
+      assert_received {:handler_called, _request}
+      refute_received {:handler_called, _request}
+
+      # The facilitator verified and settled the signed payment once.
+      assert_received {:verify_called, payload, requirements}
+      assert payload["payload"]["authorization"]["from"] == signer.address
+      assert requirements["payTo"] == @receiver
+      assert_received {:settle_called, _payload, _requirements}
+      refute_received {:verify_called, _payload, _requirements}
+    end
+
+    test "a rejected payment is surfaced without paying twice", %{config: config} do
+      facilitator =
+        start_supervised!(
+          {MockFacilitator,
+           owner: self(),
+           verify: {:ok, %{status: 200, body: %{"isValid" => false, "invalidReason" => "bad"}}},
+           settle: {:ok, %{status: 200, body: %{}}}},
+          id: :rejecting_facilitator
+        )
+
+      config = %{config | facilitator: facilitator}
+      parent = self()
+
+      call_fun = fn request ->
+        send(parent, {:tool_called, request})
+        Server.call(request, config, fn _request -> @ok_result end)
+      end
+
+      assert {:ok, %{result: result, payment_response: nil, paid: true}} =
+               Client.call(@request, call_fun, signer: signer())
+
+      # The retry's payment was rejected: the server re-advertises payment
+      # required and the client returns it as-is instead of signing again.
+      assert result["isError"] == true
+      assert result["structuredContent"]["error"] == "bad"
+
+      assert_received {:tool_called, _first}
+      assert_received {:tool_called, _second}
+      refute_received {:tool_called, _third}
+      assert_received {:verify_called, _payload, _requirements}
+      refute_received {:settle_called, _payload, _requirements}
+    end
+  end
+end

--- a/test/x402/mcp/client_test.exs
+++ b/test/x402/mcp/client_test.exs
@@ -10,32 +10,41 @@ defmodule X402.MCP.ClientTest do
   alias X402.MCP.Server
   alias X402.Signer.LocalKey
 
-  defmodule MockFacilitator do
-    @moduledoc false
-    use GenServer
+  # A real caller-side X402.Facilitator over a Bypass HTTP stub (the
+  # facilitator client executes verify/settle in the calling process).
+  defp start_bypass_facilitator(opts) do
+    owner = Keyword.fetch!(opts, :owner)
+    {:ok, %{status: v_status, body: v_body}} = Keyword.fetch!(opts, :verify)
+    {:ok, %{status: s_status, body: s_body}} = Keyword.fetch!(opts, :settle)
 
-    def start_link(opts) when is_list(opts), do: GenServer.start_link(__MODULE__, opts)
+    bypass = Bypass.open()
 
-    @impl true
-    def init(opts) do
-      {:ok,
-       %{
-         owner: Keyword.fetch!(opts, :owner),
-         verify: Keyword.fetch!(opts, :verify),
-         settle: Keyword.fetch!(opts, :settle)
-       }}
+    stub = fn path, tag, status, body ->
+      Bypass.stub(bypass, "POST", path, fn conn ->
+        {:ok, request_body, conn} = Plug.Conn.read_body(conn)
+        decoded = Jason.decode!(request_body)
+        send(owner, {tag, decoded["paymentPayload"], decoded["paymentRequirements"]})
+        Plug.Conn.resp(conn, status, Jason.encode!(body))
+      end)
     end
 
-    @impl true
-    def handle_call({:verify, payment_payload, requirements}, _from, state) do
-      send(state.owner, {:verify_called, payment_payload, requirements})
-      {:reply, state.verify, state}
-    end
+    stub.("/verify", :verify_called, v_status, v_body)
+    stub.("/settle", :settle_called, s_status, s_body)
 
-    def handle_call({:settle, payment_payload, requirements}, _from, state) do
-      send(state.owner, {:settle_called, payment_payload, requirements})
-      {:reply, state.settle, state}
-    end
+    suffix = System.unique_integer([:positive, :monotonic])
+    finch = String.to_atom("mcp_client_finch_#{suffix}")
+    name = String.to_atom("mcp_client_facilitator_#{suffix}")
+
+    start_supervised!(Supervisor.child_spec({Finch, name: finch}, id: finch))
+
+    start_supervised!(
+      {X402.Facilitator,
+       name: name,
+       finch: finch,
+       url: "http://localhost:#{bypass.port}",
+       max_retries: 0,
+       receive_timeout_ms: 2_000}
+    )
   end
 
   @asset "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
@@ -319,21 +328,20 @@ defmodule X402.MCP.ClientTest do
   describe "client-server loop" do
     setup do
       facilitator =
-        start_supervised!(
-          {MockFacilitator,
-           owner: self(),
-           verify: {:ok, %{status: 200, body: %{"isValid" => true}}},
-           settle:
-             {:ok,
-              %{
-                status: 200,
-                body: %{
-                  "success" => true,
-                  "transaction" => "0x" <> String.duplicate("ab", 32),
-                  "network" => @network,
-                  "payer" => "0x3333333333333333333333333333333333333333"
-                }
-              }}}
+        start_bypass_facilitator(
+          owner: self(),
+          verify: {:ok, %{status: 200, body: %{"isValid" => true}}},
+          settle:
+            {:ok,
+             %{
+               status: 200,
+               body: %{
+                 "success" => true,
+                 "transaction" => "0x" <> String.duplicate("ab", 32),
+                 "network" => @network,
+                 "payer" => "0x3333333333333333333333333333333333333333"
+               }
+             }}
         )
 
       cache =
@@ -399,12 +407,10 @@ defmodule X402.MCP.ClientTest do
 
     test "a rejected payment is surfaced without paying twice", %{config: config} do
       facilitator =
-        start_supervised!(
-          {MockFacilitator,
-           owner: self(),
-           verify: {:ok, %{status: 200, body: %{"isValid" => false, "invalidReason" => "bad"}}},
-           settle: {:ok, %{status: 200, body: %{}}}},
-          id: :rejecting_facilitator
+        start_bypass_facilitator(
+          owner: self(),
+          verify: {:ok, %{status: 200, body: %{"isValid" => false, "invalidReason" => "bad"}}},
+          settle: {:ok, %{status: 200, body: %{}}}
         )
 
       config = %{config | facilitator: facilitator}

--- a/test/x402/mcp/server_test.exs
+++ b/test/x402/mcp/server_test.exs
@@ -345,14 +345,27 @@ defmodule X402.MCP.ServerTest do
       assert result["structuredContent"]["error"] == "No matching payment requirements"
     end
 
-    test "rejects payments that cannot be encoded for the replay claim" do
-      config = config(start_facilitator())
-      unencodable = payment(%{"payload" => %{"bad" => {:not, :json}}})
+    test "keys the replay claim on the signed payload, not the envelope" do
+      # A mutated envelope (extra fields, reordered keys) around the SAME
+      # signed scheme payload must hash to the same claim key — otherwise a
+      # replay with a tweaked envelope claims a fresh slot and runs the paid
+      # handler again.
+      cache =
+        start_supervised!(
+          {ETSCache, name: :"mcp_canonical_#{System.unique_integer([:positive])}"}
+        )
 
-      result = Server.call(request(unencodable), config, refute_handler())
+      config = config(start_facilitator(), payment_identifier_cache: cache)
+      original = payment()
 
-      assert result["structuredContent"]["error"] == "invalid_payload"
-      refute_received {:verify_called, _payload, _requirements, _hooks}
+      first = Server.call(request(original), config, ok_handler())
+      refute first["isError"]
+
+      mutated = Map.put(original, "note", "attacker-added envelope field")
+      replay = Server.call(request(mutated), config, ok_handler())
+
+      assert replay["isError"] == true
+      assert replay["structuredContent"]["error"] == "payment already processed"
     end
 
     test "rejects extension echoes that drop advertised values" do

--- a/test/x402/mcp/server_test.exs
+++ b/test/x402/mcp/server_test.exs
@@ -100,7 +100,7 @@ defmodule X402.MCP.ServerTest do
   }
 
   defp start_facilitator(opts \\ []) do
-    start_supervised!({MockFacilitator, [owner: self()] ++ opts})
+    start_supervised!({MockFacilitator, [owner: self()] ++ opts}, id: make_ref())
   end
 
   defp config(facilitator, overrides \\ []) do
@@ -215,6 +215,26 @@ defmodule X402.MCP.ServerTest do
         Server.init(tool: "premium_search", accepts: [accept])
       end
     end
+
+    test "accepts an explicit authorization payment flow" do
+      accept = %{@accept | extra: %{"paymentFlow" => "authorization"}}
+      config = Server.init(tool: "premium_search", accepts: [accept])
+
+      assert hd(config.accepts)["extra"]["paymentFlow"] == "authorization"
+    end
+
+    test "omits empty optional resource fields" do
+      config = Server.init(tool: "premium_search", accepts: [@accept], service_name: "")
+
+      refute Map.has_key?(config.resource, "serviceName")
+    end
+
+    test "option validators reject invalid raw values" do
+      assert Server.validate_extra_map("nope") == {:error, "expected a map"}
+
+      assert Server.validate_atomic_amount(100) ==
+               {:error, "expected a digit-only atomic-unit amount"}
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -252,6 +272,23 @@ defmodule X402.MCP.ServerTest do
       assert result["isError"] == true
       assert result["structuredContent"]["error"] == "Pay up"
       assert result["structuredContent"]["accepts"] == [@requirements]
+    end
+
+    test "payment_required_result/1 uses the default message" do
+      config = config(start_facilitator())
+
+      result = Server.payment_required_result(config)
+
+      assert result["structuredContent"]["error"] == "Payment required to access this tool"
+    end
+
+    test "payment_required_result/2 falls back to an internal error for corrupt configs" do
+      config = %{config(start_facilitator()) | extensions: %{"bad" => {:not, :json}}}
+
+      assert Server.payment_required_result(config) == %{
+               "isError" => true,
+               "content" => [%{"type" => "text", "text" => "Internal server error"}]
+             }
     end
   end
 
@@ -300,6 +337,16 @@ defmodule X402.MCP.ServerTest do
       result = Server.call(request(dropped), config, refute_handler())
 
       assert result["structuredContent"]["error"] == "No matching payment requirements"
+    end
+
+    test "rejects payments that cannot be encoded for the replay claim" do
+      config = config(start_facilitator())
+      unencodable = payment(%{"payload" => %{"bad" => {:not, :json}}})
+
+      result = Server.call(request(unencodable), config, refute_handler())
+
+      assert result["structuredContent"]["error"] == "invalid_payload"
+      refute_received {:verify_called, _payload, _requirements, _hooks}
     end
 
     test "rejects extension echoes that drop advertised values" do
@@ -413,6 +460,33 @@ defmodule X402.MCP.ServerTest do
                "content" => [%{"type" => "text", "text" => "Internal server error"}]
              }
     end
+
+    test "treats malformed verify responses as internal errors" do
+      internal_error = %{
+        "isError" => true,
+        "content" => [%{"type" => "text", "text" => "Internal server error"}]
+      }
+
+      for verify <- [
+            {:ok, %{status: 200, body: %{"payer" => "0xpayer"}}},
+            {:ok, %{status: 200, body: "not a map"}},
+            {:ok, %{}}
+          ] do
+        facilitator = start_facilitator(verify: verify)
+        config = config(facilitator)
+
+        assert Server.call(request(payment()), config, refute_handler()) == internal_error
+      end
+    end
+
+    test "reports a generic reason when verification fails without invalidReason" do
+      facilitator = start_facilitator(verify: {:ok, %{status: 200, body: %{"isValid" => false}}})
+      config = config(facilitator)
+
+      result = Server.call(request(payment()), config, refute_handler())
+
+      assert result["structuredContent"]["error"] == "facilitator rejected payment"
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -451,12 +525,36 @@ defmodule X402.MCP.ServerTest do
     end
 
     test "returns an opaque internal error on malformed settle responses" do
-      facilitator = start_facilitator(settle: {:ok, %{status: 200, body: %{"success" => true}}})
+      for settle <- [
+            {:ok, %{status: 200, body: %{"success" => true}}},
+            {:ok, %{status: 200, body: %{"transaction" => "0xabc"}}},
+            {:ok, %{status: 200, body: "not a map"}},
+            {:ok, %{status: 500, body: %{}}},
+            {:ok, %{}}
+          ] do
+        facilitator = start_facilitator(settle: settle)
+        config = config(facilitator)
+
+        result = Server.call(request(payment()), config, ok_handler())
+
+        assert result["content"] == [%{"type" => "text", "text" => "Internal server error"}]
+      end
+    end
+
+    test "reports a generic reason when settlement fails without errorReason" do
+      facilitator =
+        start_facilitator(
+          settle:
+            {:ok,
+             %{status: 200, body: %{"success" => false, "transaction" => "", "network" => "n"}}}
+        )
+
       config = config(facilitator)
 
       result = Server.call(request(payment()), config, ok_handler())
 
-      assert result["content"] == [%{"type" => "text", "text" => "Internal server error"}]
+      assert result["structuredContent"]["error"] ==
+               "Payment settlement failed: facilitator rejected payment"
     end
   end
 
@@ -494,6 +592,20 @@ defmodule X402.MCP.ServerTest do
       assert_raise RuntimeError, "boom", fn ->
         Server.call(request(payment()), config, fn _request -> raise "boom" end)
       end
+    end
+
+    test "re-throws handler throws after releasing the claim" do
+      cache =
+        start_supervised!({ETSCache, name: :"mcp_throw_#{System.unique_integer([:positive])}"})
+
+      config = config(start_facilitator(), payment_identifier_cache: cache)
+      request = request(payment())
+
+      assert catch_throw(Server.call(request, config, fn _request -> throw(:tool_bail) end)) ==
+               :tool_bail
+
+      retry = Server.call(request, config, ok_handler())
+      assert retry["_meta"]["x402/payment-response"]["success"] == true
     end
   end
 

--- a/test/x402/mcp/server_test.exs
+++ b/test/x402/mcp/server_test.exs
@@ -21,60 +21,14 @@ defmodule X402.MCP.ServerTest do
   alias X402.Extensions.PaymentIdentifier.ETSCache
   alias X402.MCP.Server
 
-  defmodule MockFacilitator do
-    @moduledoc false
-    use GenServer
+  @default_settle_body %{
+    "success" => true,
+    "transaction" => "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    "network" => "eip155:84532",
+    "payer" => "0x1111111111111111111111111111111111111111"
+  }
 
-    @default_verify {:ok, %{status: 200, body: %{"isValid" => true, "payer" => "0xpayer"}}}
-
-    @default_settle {
-      :ok,
-      %{
-        status: 200,
-        body: %{
-          "success" => true,
-          "transaction" => "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-          "network" => "eip155:84532",
-          "payer" => "0x1111111111111111111111111111111111111111"
-        }
-      }
-    }
-
-    def start_link(opts) when is_list(opts), do: GenServer.start_link(__MODULE__, opts)
-
-    def default_settle_body, do: elem(@default_settle, 1).body
-
-    @impl true
-    def init(opts) do
-      {:ok,
-       %{
-         owner: Keyword.fetch!(opts, :owner),
-         verify: Keyword.get(opts, :verify, @default_verify),
-         settle: Keyword.get(opts, :settle, @default_settle)
-       }}
-    end
-
-    @impl true
-    def handle_call({:verify, payment_payload, requirements}, _from, state) do
-      send(state.owner, {:verify_called, payment_payload, requirements, nil})
-      {:reply, state.verify, state}
-    end
-
-    def handle_call({:verify, payment_payload, requirements, hooks_module}, _from, state) do
-      send(state.owner, {:verify_called, payment_payload, requirements, hooks_module})
-      {:reply, state.verify, state}
-    end
-
-    def handle_call({:settle, payment_payload, requirements}, _from, state) do
-      send(state.owner, {:settle_called, payment_payload, requirements, nil})
-      {:reply, state.settle, state}
-    end
-
-    def handle_call({:settle, payment_payload, requirements, hooks_module}, _from, state) do
-      send(state.owner, {:settle_called, payment_payload, requirements, hooks_module})
-      {:reply, state.settle, state}
-    end
-  end
+  defp default_settle_body, do: @default_settle_body
 
   @asset "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
   @receiver "0x1111111111111111111111111111111111111111"
@@ -99,8 +53,60 @@ defmodule X402.MCP.ServerTest do
     "extra" => %{"name" => "USDC", "version" => "2"}
   }
 
+  # A real caller-side X402.Facilitator over a Bypass HTTP stub — the
+  # facilitator client executes verify/settle in the calling process, so a
+  # GenServer speaking the old internal call protocol can no longer stand in.
   defp start_facilitator(opts \\ []) do
-    start_supervised!({MockFacilitator, [owner: self()] ++ opts}, id: make_ref())
+    owner = self()
+
+    verify =
+      Keyword.get(
+        opts,
+        :verify,
+        {:ok, %{status: 200, body: %{"isValid" => true, "payer" => "0xpayer"}}}
+      )
+
+    settle = Keyword.get(opts, :settle, {:ok, %{status: 200, body: @default_settle_body}})
+
+    bypass = Bypass.open()
+    stub_endpoint(bypass, owner, "/verify", :verify_called, verify)
+    stub_endpoint(bypass, owner, "/settle", :settle_called, settle)
+
+    suffix = System.unique_integer([:positive, :monotonic])
+    finch = String.to_atom("mcp_server_finch_#{suffix}")
+    name = String.to_atom("mcp_server_facilitator_#{suffix}")
+
+    start_supervised!(Supervisor.child_spec({Finch, name: finch}, id: finch))
+
+    start_supervised!(
+      {X402.Facilitator,
+       name: name,
+       finch: finch,
+       url: "http://localhost:#{bypass.port}",
+       max_retries: 0,
+       receive_timeout_ms: 2_000}
+    )
+  end
+
+  defp stub_endpoint(bypass, owner, path, tag, {:ok, %{status: status, body: body}}) do
+    Bypass.stub(bypass, "POST", path, fn conn ->
+      {:ok, request_body, conn} = Plug.Conn.read_body(conn)
+      decoded = Jason.decode!(request_body)
+      send(owner, {tag, decoded["paymentPayload"], decoded["paymentRequirements"], nil})
+      Plug.Conn.resp(conn, status, Jason.encode!(body))
+    end)
+  end
+
+  # Transport-level garbage cannot be expressed as {status, body} over real
+  # HTTP — answer with a non-JSON body so the facilitator client surfaces a
+  # malformed-response error, preserving the invariant under test.
+  defp stub_endpoint(bypass, owner, path, tag, _malformed) do
+    Bypass.stub(bypass, "POST", path, fn conn ->
+      {:ok, request_body, conn} = Plug.Conn.read_body(conn)
+      decoded = Jason.decode!(request_body)
+      send(owner, {tag, decoded["paymentPayload"], decoded["paymentRequirements"], nil})
+      Plug.Conn.resp(conn, 200, "not-json")
+    end)
   end
 
   defp config(facilitator, overrides \\ []) do
@@ -389,7 +395,7 @@ defmodule X402.MCP.ServerTest do
 
       assert result["content"] == [%{"type" => "text", "text" => "results"}]
       refute result["isError"]
-      assert result["_meta"]["x402/payment-response"] == MockFacilitator.default_settle_body()
+      assert result["_meta"]["x402/payment-response"] == default_settle_body()
 
       assert_received {:handler_called, %{"arguments" => %{"query" => "x402"}}}
       assert_received {:verify_called, ^payment, @requirements, nil}
@@ -416,10 +422,19 @@ defmodule X402.MCP.ServerTest do
 
         alias X402.Hooks.Context
 
-        def before_verify(%Context{} = context, _metadata), do: {:cont, context}
+        def before_verify(%Context{} = context, _metadata) do
+          send(self(), {:hook_called, :before_verify})
+          {:cont, context}
+        end
+
         def after_verify(%Context{} = context, _metadata), do: {:cont, context}
         def on_verify_failure(%Context{} = context, _metadata), do: {:cont, context}
-        def before_settle(%Context{} = context, _metadata), do: {:cont, context}
+
+        def before_settle(%Context{} = context, _metadata) do
+          send(self(), {:hook_called, :before_settle})
+          {:cont, context}
+        end
+
         def after_settle(%Context{} = context, _metadata), do: {:cont, context}
         def on_settle_failure(%Context{} = context, _metadata), do: {:cont, context}
       end
@@ -428,8 +443,11 @@ defmodule X402.MCP.ServerTest do
 
       Server.call(request(payment()), config, ok_handler())
 
-      assert_received {:verify_called, _payload, _requirements, PassthroughHooks}
-      assert_received {:settle_called, _payload, _requirements, PassthroughHooks}
+      # Hooks execute in the calling process with the caller-side facilitator.
+      assert_received {:hook_called, :before_verify}
+      assert_received {:hook_called, :before_settle}
+      assert_received {:verify_called, _payload, _requirements, _}
+      assert_received {:settle_called, _payload, _requirements, _}
     end
 
     test "returns the payment-required result with the facilitator's reason on failed verification" do

--- a/test/x402/mcp/server_test.exs
+++ b/test/x402/mcp/server_test.exs
@@ -1,0 +1,622 @@
+defmodule X402.MCP.ServerTest do
+  @moduledoc """
+  Spec-conformance tests for `X402.MCP.Server` against the x402 MCP transport.
+
+  https://github.com/x402-foundation/x402/blob/main/specs/transports-v2/mcp.md
+
+  Sections map to protocol concerns:
+
+  * PaymentRequired signaling (isError result with structuredContent +
+    content[0].text)
+  * PaymentPayload validation (version, accepted matching, extension echo)
+  * Facilitator verify/settle + `_meta["x402/payment-response"]`
+  * Settlement failure (payment error without tool content)
+  * Replay protection and handler failures
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest X402.MCP.Server
+
+  alias X402.Extensions.PaymentIdentifier.ETSCache
+  alias X402.MCP.Server
+
+  defmodule MockFacilitator do
+    @moduledoc false
+    use GenServer
+
+    @default_verify {:ok, %{status: 200, body: %{"isValid" => true, "payer" => "0xpayer"}}}
+
+    @default_settle {
+      :ok,
+      %{
+        status: 200,
+        body: %{
+          "success" => true,
+          "transaction" => "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          "network" => "eip155:84532",
+          "payer" => "0x1111111111111111111111111111111111111111"
+        }
+      }
+    }
+
+    def start_link(opts) when is_list(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    def default_settle_body, do: elem(@default_settle, 1).body
+
+    @impl true
+    def init(opts) do
+      {:ok,
+       %{
+         owner: Keyword.fetch!(opts, :owner),
+         verify: Keyword.get(opts, :verify, @default_verify),
+         settle: Keyword.get(opts, :settle, @default_settle)
+       }}
+    end
+
+    @impl true
+    def handle_call({:verify, payment_payload, requirements}, _from, state) do
+      send(state.owner, {:verify_called, payment_payload, requirements, nil})
+      {:reply, state.verify, state}
+    end
+
+    def handle_call({:verify, payment_payload, requirements, hooks_module}, _from, state) do
+      send(state.owner, {:verify_called, payment_payload, requirements, hooks_module})
+      {:reply, state.verify, state}
+    end
+
+    def handle_call({:settle, payment_payload, requirements}, _from, state) do
+      send(state.owner, {:settle_called, payment_payload, requirements, nil})
+      {:reply, state.settle, state}
+    end
+
+    def handle_call({:settle, payment_payload, requirements, hooks_module}, _from, state) do
+      send(state.owner, {:settle_called, payment_payload, requirements, hooks_module})
+      {:reply, state.settle, state}
+    end
+  end
+
+  @asset "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+  @receiver "0x1111111111111111111111111111111111111111"
+  @network "eip155:84532"
+  @amount "10000"
+
+  @accept %{
+    price: @amount,
+    network: @network,
+    asset: @asset,
+    pay_to: @receiver,
+    extra: %{"name" => "USDC", "version" => "2"}
+  }
+
+  @requirements %{
+    "scheme" => "exact",
+    "network" => @network,
+    "amount" => @amount,
+    "asset" => @asset,
+    "payTo" => @receiver,
+    "maxTimeoutSeconds" => 60,
+    "extra" => %{"name" => "USDC", "version" => "2"}
+  }
+
+  defp start_facilitator(opts \\ []) do
+    start_supervised!({MockFacilitator, [owner: self()] ++ opts})
+  end
+
+  defp config(facilitator, overrides \\ []) do
+    Server.init(
+      Keyword.merge(
+        [tool: "premium_search", accepts: [@accept], facilitator: facilitator],
+        overrides
+      )
+    )
+  end
+
+  defp payment(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "x402Version" => 2,
+        "accepted" => @requirements,
+        "payload" => %{"signature" => "0xsignature", "authorization" => %{"value" => @amount}}
+      },
+      overrides
+    )
+  end
+
+  defp request(payment_payload) do
+    %{
+      "name" => "premium_search",
+      "arguments" => %{"query" => "x402"},
+      "_meta" => %{"x402/payment" => payment_payload}
+    }
+  end
+
+  defp ok_handler do
+    parent = self()
+
+    fn request ->
+      send(parent, {:handler_called, request})
+      %{"content" => [%{"type" => "text", "text" => "results"}]}
+    end
+  end
+
+  defp refute_handler do
+    parent = self()
+    fn _request -> send(parent, :handler_called) end
+  end
+
+  # ---------------------------------------------------------------------------
+  # init/1
+  # ---------------------------------------------------------------------------
+
+  describe "init/1" do
+    test "compiles accepts, resource, and extensions" do
+      config =
+        Server.init(
+          tool: "premium_search",
+          accepts: [@accept],
+          service_name: "Example",
+          tags: ["search"],
+          icon_url: "https://example.com/icon.png",
+          extensions: %{example: %{"info" => %{"required" => true}}}
+        )
+
+      assert config.accepts == [@requirements]
+
+      assert config.resource == %{
+               "url" => "mcp://tool/premium_search",
+               "description" => "Tool: premium_search",
+               "mimeType" => "application/json",
+               "serviceName" => "Example",
+               "tags" => ["search"],
+               "iconUrl" => "https://example.com/icon.png"
+             }
+
+      assert config.extensions == %{"example" => %{"info" => %{"required" => true}}}
+    end
+
+    test "honors resource_url and description overrides" do
+      config =
+        Server.init(
+          tool: "premium_search",
+          accepts: [@accept],
+          resource_url: "mcp://tool/custom",
+          description: "Premium search"
+        )
+
+      assert config.resource["url"] == "mcp://tool/custom"
+      assert config.resource["description"] == "Premium search"
+    end
+
+    test "rejects empty accepts" do
+      assert_raise ArgumentError, ~r/at least one payment option/, fn ->
+        Server.init(tool: "premium_search", accepts: [])
+      end
+    end
+
+    test "rejects non-atomic prices" do
+      assert_raise NimbleOptions.ValidationError, fn ->
+        Server.init(tool: "premium_search", accepts: [%{@accept | price: "$0.10"}])
+      end
+    end
+
+    test "rejects unsupported payment flows" do
+      accept = %{@accept | extra: %{"paymentFlow" => "pre-settlement"}}
+
+      assert_raise ArgumentError, ~r/unsupported payment flow/, fn ->
+        Server.init(tool: "premium_search", accepts: [accept])
+      end
+    end
+
+    test "rejects non-JSON-encodable advertised data" do
+      accept = %{@accept | extra: %{"nope" => {:not, :json}}}
+
+      assert_raise ArgumentError, ~r/JSON-encodable/, fn ->
+        Server.init(tool: "premium_search", accepts: [accept])
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PaymentRequired signaling
+  # ---------------------------------------------------------------------------
+
+  describe "payment required signaling" do
+    test "returns the spec result when no payment is provided" do
+      config = config(start_facilitator())
+      request = %{"name" => "premium_search", "arguments" => %{}}
+
+      result = Server.call(request, config, refute_handler())
+
+      assert result["isError"] == true
+
+      assert result["structuredContent"] == %{
+               "x402Version" => 2,
+               "error" => "Payment required to access this tool",
+               "resource" => config.resource,
+               "accepts" => [@requirements],
+               "extensions" => %{}
+             }
+
+      assert [%{"type" => "text", "text" => text}] = result["content"]
+      assert Jason.decode!(text) == result["structuredContent"]
+      refute_received :handler_called
+      refute_received {:verify_called, _payload, _requirements, _hooks}
+    end
+
+    test "payment_required_result/2 exposes the advertised result" do
+      config = config(start_facilitator())
+
+      result = Server.payment_required_result(config, "Pay up")
+
+      assert result["isError"] == true
+      assert result["structuredContent"]["error"] == "Pay up"
+      assert result["structuredContent"]["accepts"] == [@requirements]
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PaymentPayload validation
+  # ---------------------------------------------------------------------------
+
+  describe "payment validation" do
+    test "rejects non-v2 payloads without contacting the facilitator" do
+      config = config(start_facilitator())
+
+      result = Server.call(request(payment(%{"x402Version" => 1})), config, refute_handler())
+
+      assert result["isError"] == true
+      assert result["structuredContent"]["error"] == "invalid_x402_version"
+      refute_received {:verify_called, _payload, _requirements, _hooks}
+      refute_received :handler_called
+    end
+
+    test "rejects structurally invalid payloads" do
+      config = config(start_facilitator())
+      invalid = payment(%{"accepted" => %{"scheme" => "exact"}})
+
+      result = Server.call(request(invalid), config, refute_handler())
+
+      assert result["isError"] == true
+      assert result["structuredContent"]["error"] == "invalid_payload"
+      refute_received {:verify_called, _payload, _requirements, _hooks}
+    end
+
+    test "rejects accepted values that do not match the advertised requirements" do
+      config = config(start_facilitator())
+      mismatched = payment(%{"accepted" => %{@requirements | "amount" => "1"}})
+
+      result = Server.call(request(mismatched), config, refute_handler())
+
+      assert result["isError"] == true
+      assert result["structuredContent"]["error"] == "No matching payment requirements"
+      refute_received {:verify_called, _payload, _requirements, _hooks}
+    end
+
+    test "rejects accepted values that drop advertised extra entries" do
+      config = config(start_facilitator())
+      dropped = payment(%{"accepted" => %{@requirements | "extra" => %{"name" => "USDC"}}})
+
+      result = Server.call(request(dropped), config, refute_handler())
+
+      assert result["structuredContent"]["error"] == "No matching payment requirements"
+    end
+
+    test "rejects extension echoes that drop advertised values" do
+      extensions = %{"example" => %{"info" => %{"required" => true}}}
+      config = config(start_facilitator(), extensions: extensions)
+      echo = payment(%{"extensions" => %{"example" => %{"info" => %{}}}})
+
+      result = Server.call(request(echo), config, refute_handler())
+
+      assert result["structuredContent"]["error"] == "invalid_payload"
+      refute_received {:verify_called, _payload, _requirements, _hooks}
+    end
+
+    test "accepts extension echoes that preserve advertised values" do
+      extensions = %{"example" => %{"info" => %{"required" => true}}}
+      config = config(start_facilitator(), extensions: extensions)
+
+      echo =
+        payment(%{
+          "extensions" => %{"example" => %{"info" => %{"required" => true, "client" => "x"}}}
+        })
+
+      result = Server.call(request(echo), config, ok_handler())
+
+      refute result["isError"]
+      assert_received {:verify_called, _payload, _requirements, _hooks}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Verify / settle flow
+  # ---------------------------------------------------------------------------
+
+  describe "verify and settle" do
+    test "verifies, executes, settles, and attaches the receipt to _meta" do
+      config = config(start_facilitator())
+      payment = payment()
+
+      result = Server.call(request(payment), config, ok_handler())
+
+      assert result["content"] == [%{"type" => "text", "text" => "results"}]
+      refute result["isError"]
+      assert result["_meta"]["x402/payment-response"] == MockFacilitator.default_settle_body()
+
+      assert_received {:handler_called, %{"arguments" => %{"query" => "x402"}}}
+      assert_received {:verify_called, ^payment, @requirements, nil}
+      assert_received {:settle_called, ^payment, @requirements, nil}
+    end
+
+    test "preserves existing result _meta entries" do
+      config = config(start_facilitator())
+
+      handler = fn _request ->
+        %{"content" => [], "_meta" => %{"traceId" => "abc"}}
+      end
+
+      result = Server.call(request(payment()), config, handler)
+
+      assert result["_meta"]["traceId"] == "abc"
+      assert result["_meta"]["x402/payment-response"]["success"] == true
+    end
+
+    test "passes a custom hooks module through to the facilitator" do
+      defmodule PassthroughHooks do
+        @moduledoc false
+        @behaviour X402.Hooks
+
+        alias X402.Hooks.Context
+
+        def before_verify(%Context{} = context, _metadata), do: {:cont, context}
+        def after_verify(%Context{} = context, _metadata), do: {:cont, context}
+        def on_verify_failure(%Context{} = context, _metadata), do: {:cont, context}
+        def before_settle(%Context{} = context, _metadata), do: {:cont, context}
+        def after_settle(%Context{} = context, _metadata), do: {:cont, context}
+        def on_settle_failure(%Context{} = context, _metadata), do: {:cont, context}
+      end
+
+      config = config(start_facilitator(), hooks: PassthroughHooks)
+
+      Server.call(request(payment()), config, ok_handler())
+
+      assert_received {:verify_called, _payload, _requirements, PassthroughHooks}
+      assert_received {:settle_called, _payload, _requirements, PassthroughHooks}
+    end
+
+    test "returns the payment-required result with the facilitator's reason on failed verification" do
+      facilitator =
+        start_facilitator(
+          verify: {:ok, %{status: 200, body: %{"isValid" => false, "invalidReason" => "expired"}}}
+        )
+
+      config = config(facilitator)
+
+      result = Server.call(request(payment()), config, refute_handler())
+
+      assert result["isError"] == true
+      assert result["structuredContent"]["error"] == "expired"
+      assert result["structuredContent"]["accepts"] == [@requirements]
+      refute_received :handler_called
+      refute_received {:settle_called, _payload, _requirements, _hooks}
+    end
+
+    test "returns an opaque internal error on facilitator transport failures" do
+      facilitator = start_facilitator(verify: {:ok, %{status: 503, body: %{}}})
+      config = config(facilitator)
+
+      result = Server.call(request(payment()), config, refute_handler())
+
+      assert result == %{
+               "isError" => true,
+               "content" => [%{"type" => "text", "text" => "Internal server error"}]
+             }
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Settlement failure
+  # ---------------------------------------------------------------------------
+
+  describe "settlement failure" do
+    test "returns the payment error without the tool's content" do
+      facilitator =
+        start_facilitator(
+          settle:
+            {:ok,
+             %{
+               status: 200,
+               body: %{
+                 "success" => false,
+                 "errorReason" => "insufficient_funds",
+                 "transaction" => "",
+                 "network" => @network
+               }
+             }}
+        )
+
+      config = config(facilitator)
+
+      result = Server.call(request(payment()), config, ok_handler())
+
+      assert_received {:handler_called, _request}
+      assert result["isError"] == true
+
+      assert result["structuredContent"]["error"] ==
+               "Payment settlement failed: insufficient_funds"
+
+      assert [%{"type" => "text", "text" => text}] = result["content"]
+      refute text =~ "results"
+    end
+
+    test "returns an opaque internal error on malformed settle responses" do
+      facilitator = start_facilitator(settle: {:ok, %{status: 200, body: %{"success" => true}}})
+      config = config(facilitator)
+
+      result = Server.call(request(payment()), config, ok_handler())
+
+      assert result["content"] == [%{"type" => "text", "text" => "Internal server error"}]
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Handler behavior
+  # ---------------------------------------------------------------------------
+
+  describe "handler behavior" do
+    test "returns handler error results unchanged without settling" do
+      config = config(start_facilitator())
+
+      error_result = %{
+        "isError" => true,
+        "content" => [%{"type" => "text", "text" => "tool blew up"}]
+      }
+
+      result = Server.call(request(payment()), config, fn _request -> error_result end)
+
+      assert result == error_result
+      assert_received {:verify_called, _payload, _requirements, _hooks}
+      refute_received {:settle_called, _payload, _requirements, _hooks}
+    end
+
+    test "raises when the handler returns a non-map" do
+      config = config(start_facilitator())
+
+      assert_raise ArgumentError, ~r/tool result map/, fn ->
+        Server.call(request(payment()), config, fn _request -> :ok end)
+      end
+    end
+
+    test "re-raises handler exceptions" do
+      config = config(start_facilitator())
+
+      assert_raise RuntimeError, "boom", fn ->
+        Server.call(request(payment()), config, fn _request -> raise "boom" end)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Replay protection
+  # ---------------------------------------------------------------------------
+
+  describe "replay protection" do
+    setup do
+      cache =
+        start_supervised!({ETSCache, name: :"mcp_replay_#{System.unique_integer([:positive])}"})
+
+      %{cache: cache}
+    end
+
+    test "rejects a second settlement of the same payment", %{cache: cache} do
+      config = config(start_facilitator(), payment_identifier_cache: cache)
+      request = request(payment())
+
+      first = Server.call(request, config, ok_handler())
+      second = Server.call(request, config, refute_handler())
+
+      assert first["_meta"]["x402/payment-response"]["success"] == true
+      assert second["isError"] == true
+      assert second["structuredContent"]["error"] == "payment already processed"
+
+      assert_received {:settle_called, _payload, _requirements, _hooks}
+      refute_received {:settle_called, _payload, _requirements, _hooks}
+    end
+
+    test "releases the claim when the handler fails", %{cache: cache} do
+      config = config(start_facilitator(), payment_identifier_cache: cache)
+      request = request(payment())
+
+      error_result = %{"isError" => true, "content" => []}
+      first = Server.call(request, config, fn _request -> error_result end)
+      second = Server.call(request, config, ok_handler())
+
+      assert first == error_result
+      assert second["_meta"]["x402/payment-response"]["success"] == true
+    end
+
+    test "releases the claim when the handler raises", %{cache: cache} do
+      config = config(start_facilitator(), payment_identifier_cache: cache)
+      request = request(payment())
+
+      assert_raise RuntimeError, fn ->
+        Server.call(request, config, fn _request -> raise "boom" end)
+      end
+
+      retry = Server.call(request, config, ok_handler())
+      assert retry["_meta"]["x402/payment-response"]["success"] == true
+    end
+
+    test "releases the claim when settlement fails", %{cache: cache} do
+      facilitator =
+        start_facilitator(
+          settle:
+            {:ok,
+             %{
+               status: 200,
+               body: %{
+                 "success" => false,
+                 "errorReason" => "nope",
+                 "transaction" => "",
+                 "network" => @network
+               }
+             }}
+        )
+
+      config = config(facilitator, payment_identifier_cache: cache)
+      request = request(payment())
+
+      Server.call(request, config, ok_handler())
+      second = Server.call(request, config, ok_handler())
+
+      # The claim was released, so the second call reaches settlement again.
+      assert_received {:settle_called, _payload, _requirements, _hooks}
+      assert_received {:settle_called, _payload, _requirements, _hooks}
+      assert second["structuredContent"]["error"] =~ "settlement failed"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Telemetry
+  # ---------------------------------------------------------------------------
+
+  describe "telemetry" do
+    test "emits payment lifecycle events" do
+      handler_id = "mcp-server-test-#{System.unique_integer([:positive])}"
+      parent = self()
+
+      :telemetry.attach_many(
+        handler_id,
+        [
+          [:x402, :mcp, :payment_required],
+          [:x402, :mcp, :payment_verified],
+          [:x402, :mcp, :payment_rejected]
+        ],
+        fn event, measurements, metadata, _config ->
+          send(parent, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      config = config(start_facilitator())
+
+      Server.call(%{"name" => "premium_search"}, config, refute_handler())
+
+      assert_received {:telemetry, [:x402, :mcp, :payment_required], %{count: 1},
+                       %{tool: "premium_search"}}
+
+      Server.call(request(payment()), config, ok_handler())
+
+      assert_received {:telemetry, [:x402, :mcp, :payment_verified], %{count: 1},
+                       %{tool: "premium_search"}}
+
+      Server.call(request(payment(%{"x402Version" => 1})), config, refute_handler())
+
+      assert_received {:telemetry, [:x402, :mcp, :payment_rejected], %{count: 1},
+                       %{tool: "premium_search", reason: :invalid_x402_version}}
+    end
+  end
+end

--- a/test/x402/mcp_test.exs
+++ b/test/x402/mcp_test.exs
@@ -36,6 +36,11 @@ defmodule X402.MCPTest do
       assert MCP.fetch_payment(%{"_meta" => %{"x402/payment" => "paid"}}) == :error
       assert MCP.fetch_payment(%{"_meta" => "nope"}) == :error
     end
+
+    test "rejects non-map requests" do
+      assert MCP.fetch_payment(nil) == :error
+      assert MCP.fetch_payment("request") == :error
+    end
   end
 
   describe "put_payment/2" do
@@ -74,6 +79,10 @@ defmodule X402.MCPTest do
       result = %{"_meta" => %{"x402/payment-response" => %{"transaction" => "0xabc"}}}
 
       assert MCP.fetch_payment_response(result) == :error
+    end
+
+    test "rejects non-map results" do
+      assert MCP.fetch_payment_response(nil) == :error
     end
   end
 
@@ -123,6 +132,10 @@ defmodule X402.MCPTest do
 
       assert MCP.fetch_payment_required(result) == :error
     end
+
+    test "rejects non-map results" do
+      assert MCP.fetch_payment_required(nil) == :error
+    end
   end
 
   describe "fetch_payment_required_from_error/1" do
@@ -141,6 +154,10 @@ defmodule X402.MCPTest do
     test "rejects 402 errors without PaymentRequired data" do
       assert MCP.fetch_payment_required_from_error(%{"code" => 402, "data" => %{}}) == :error
       assert MCP.fetch_payment_required_from_error(%{"code" => 402}) == :error
+    end
+
+    test "rejects -32042 errors with non-map data" do
+      assert MCP.fetch_payment_required_from_error(%{"code" => -32_042, "data" => "x"}) == :error
     end
 
     test "rejects other error codes and non-map errors" do

--- a/test/x402/mcp_test.exs
+++ b/test/x402/mcp_test.exs
@@ -1,0 +1,173 @@
+defmodule X402.MCPTest do
+  use ExUnit.Case, async: true
+
+  doctest X402.MCP
+
+  alias X402.MCP
+
+  @payment %{"x402Version" => 2, "accepted" => %{"scheme" => "exact"}, "payload" => %{}}
+  @payment_required %{
+    "x402Version" => 2,
+    "error" => "Payment required",
+    "accepts" => [%{"scheme" => "exact"}]
+  }
+
+  describe "payment meta keys" do
+    test "match the MCP transport spec" do
+      assert MCP.payment_meta_key() == "x402/payment"
+      assert MCP.payment_response_meta_key() == "x402/payment-response"
+    end
+  end
+
+  describe "fetch_payment/1" do
+    test "reads the payment from an atom-keyed _meta" do
+      request = %{name: "search", _meta: %{"x402/payment" => @payment}}
+
+      assert MCP.fetch_payment(request) == {:ok, @payment}
+    end
+
+    test "rejects payments without the payload structure" do
+      request = %{"_meta" => %{"x402/payment" => %{"x402Version" => 2}}}
+
+      assert MCP.fetch_payment(request) == :error
+    end
+
+    test "rejects non-map payments and non-map _meta" do
+      assert MCP.fetch_payment(%{"_meta" => %{"x402/payment" => "paid"}}) == :error
+      assert MCP.fetch_payment(%{"_meta" => "nope"}) == :error
+    end
+  end
+
+  describe "put_payment/2" do
+    test "preserves existing _meta entries" do
+      request = %{"name" => "search", "_meta" => %{"traceId" => "abc"}}
+
+      assert MCP.put_payment(request, @payment) == %{
+               "name" => "search",
+               "_meta" => %{"traceId" => "abc", "x402/payment" => @payment}
+             }
+    end
+
+    test "keeps an atom :_meta key to avoid duplicate keys on encoding" do
+      request = %{name: "search", _meta: %{"traceId" => "abc"}}
+      updated = MCP.put_payment(request, @payment)
+
+      assert updated[:_meta] == %{"traceId" => "abc", "x402/payment" => @payment}
+      refute Map.has_key?(updated, "_meta")
+    end
+  end
+
+  describe "put_payment_response/2" do
+    test "preserves existing _meta entries" do
+      result = %{"content" => [], "_meta" => %{"traceId" => "abc"}}
+      receipt = %{"success" => true}
+
+      assert MCP.put_payment_response(result, receipt) == %{
+               "content" => [],
+               "_meta" => %{"traceId" => "abc", "x402/payment-response" => receipt}
+             }
+    end
+  end
+
+  describe "fetch_payment_response/1" do
+    test "rejects receipts without the success field" do
+      result = %{"_meta" => %{"x402/payment-response" => %{"transaction" => "0xabc"}}}
+
+      assert MCP.fetch_payment_response(result) == :error
+    end
+  end
+
+  describe "fetch_payment_required/1" do
+    test "requires isError to be true" do
+      result = %{"structuredContent" => @payment_required, "content" => []}
+
+      assert MCP.fetch_payment_required(result) == :error
+    end
+
+    test "falls back to parsing content[0].text as JSON" do
+      result = %{
+        "isError" => true,
+        "content" => [%{"type" => "text", "text" => Jason.encode!(@payment_required)}]
+      }
+
+      assert MCP.fetch_payment_required(result) == {:ok, @payment_required}
+    end
+
+    test "prefers structuredContent over content text" do
+      other = Map.put(@payment_required, "error", "from content")
+
+      result = %{
+        "isError" => true,
+        "structuredContent" => @payment_required,
+        "content" => [%{"type" => "text", "text" => Jason.encode!(other)}]
+      }
+
+      assert MCP.fetch_payment_required(result) == {:ok, @payment_required}
+    end
+
+    test "rejects non-JSON and non-PaymentRequired content" do
+      not_json = %{"isError" => true, "content" => [%{"type" => "text", "text" => "boom"}]}
+      wrong = %{"isError" => true, "content" => [%{"type" => "text", "text" => ~s({"a":1})}]}
+      not_text = %{"isError" => true, "content" => [%{"type" => "image", "data" => "..."}]}
+      empty = %{"isError" => true, "content" => []}
+
+      assert MCP.fetch_payment_required(not_json) == :error
+      assert MCP.fetch_payment_required(wrong) == :error
+      assert MCP.fetch_payment_required(not_text) == :error
+      assert MCP.fetch_payment_required(empty) == :error
+    end
+
+    test "requires accepts to be a list" do
+      invalid = %{"x402Version" => 2, "accepts" => %{}}
+      result = %{"isError" => true, "structuredContent" => invalid, "content" => []}
+
+      assert MCP.fetch_payment_required(result) == :error
+    end
+  end
+
+  describe "fetch_payment_required_from_error/1" do
+    test "reads PaymentRequired directly from -32042 error data" do
+      error = %{"code" => -32_042, "message" => "Elicitation", "data" => @payment_required}
+
+      assert MCP.fetch_payment_required_from_error(error) == {:ok, @payment_required}
+    end
+
+    test "supports atom keys" do
+      error = %{code: 402, message: "Payment required", data: @payment_required}
+
+      assert MCP.fetch_payment_required_from_error(error) == {:ok, @payment_required}
+    end
+
+    test "rejects 402 errors without PaymentRequired data" do
+      assert MCP.fetch_payment_required_from_error(%{"code" => 402, "data" => %{}}) == :error
+      assert MCP.fetch_payment_required_from_error(%{"code" => 402}) == :error
+    end
+
+    test "rejects other error codes and non-map errors" do
+      error = %{"code" => -32_600, "data" => @payment_required}
+
+      assert MCP.fetch_payment_required_from_error(error) == :error
+      assert MCP.fetch_payment_required_from_error(:timeout) == :error
+    end
+  end
+
+  describe "payment_required_result/1" do
+    test "content text and structuredContent carry identical data" do
+      assert {:ok, result} = MCP.payment_required_result(@payment_required)
+      assert result["isError"] == true
+      assert result["structuredContent"] == @payment_required
+      assert [%{"type" => "text", "text" => text}] = result["content"]
+      assert Jason.decode!(text) == @payment_required
+    end
+
+    test "rejects maps that cannot be encoded as JSON" do
+      invalid = Map.put(@payment_required, "extra", {:not, :json})
+
+      assert MCP.payment_required_result(invalid) == {:error, :invalid_payment_required}
+    end
+
+    test "rejects non-PaymentRequired input" do
+      assert MCP.payment_required_result("nope") == {:error, :invalid_payment_required}
+    end
+  end
+end


### PR DESCRIPTION
## What

Implements the x402 MCP transport ([docs/ecosystem-comparison.md](https://github.com/cardotrejos/x402/blob/main/docs/ecosystem-comparison.md) §8 P1.6 — the roadmap's biggest blind spot: all three official SDKs ship MCP; agentic payments increasingly happen there). Five commits:

- **`X402.MCP`** — spec primitives over plain tool-call maps: payment in request `_meta["x402/payment"]`, receipt in result `_meta["x402/payment-response"]`, PaymentRequired signaled via `isError` results (`structuredContent` + `content[0].text` per the normative spec — note: TS/Python agree the requirements do NOT ride in `_meta`) and JSON-RPC error variants (402 / SEP-1036 `-32042`).
- **`X402.MCP.Server`** — wraps any tool handler: validates as strictly as the Plug gate (v2 version, `PaymentSignature.validate`, accepted-matching, extension echo), verifies/settles via `X402.Facilitator` with hooks, replay protection via the same `payment_identifier_cache` claim/release semantics, settlement failure returns the payment error without tool content (spec R5).
- **`X402.MCP.Client`** — detect → sign → retry-once driver over any user-supplied call function, using `X402.Client.build_payment`; same `on_payment_required` veto hook and budget filters as `X402.Client.Finch`; never pays twice.

## Design: zero new dependencies

Surveyed the Elixir MCP landscape (anubis_mcp 2.0 dominates as hermes_mcp's successor; field otherwise fragmented). Anubis' component callbacks don't expose per-tool-call `_meta`, so a library adapter would need internals — instead the layer is pure functions over maps, and `guides/mcp.md` documents wiring (with an honest note on the Anubis limitation).

## Testing

112 doctests + 512 tests, 0 failures; new modules 96–100% coverage. Includes a full client⇄server loop (LocalKey signer → wrapped tool → verify → settle → receipt, signature recovered to the signer address; exactly 2 tool calls, 1 verify, 1 settle), never-pay-twice, veto, replay rejection. All gates: format, credo --strict, dialyzer 0 errors, --no-optional-deps compile.

## Notes

Telemetry `[:x402, :mcp, *]` consistent with existing conventions. `upto` accepted in server config for parity but settles the advertised amount (no conn-style metering in MCP; documented).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New payment verification, settlement, and idempotency paths mirror the Plug gate but are security-sensitive; misconfiguration (e.g. missing `payment_identifier_cache`) can allow double settlement, though the server logs a one-time warning.
> 
> **Overview**
> Adds **x402 v2 MCP transport** support so agents can pay for Model Context Protocol tool calls using plain request/result maps—no new MCP library dependency.
> 
> **`X402.MCP`** implements spec wiring: `_meta["x402/payment"]` on requests, `_meta["x402/payment-response"]` on results, payment-required tool results (`isError` + `structuredContent` / `content[0].text`), and `402` / `-32042` JSON-RPC error parsing.
> 
> **`X402.MCP.Server`** wraps tool handlers with verify → execute → settle via `X402.Facilitator`, with validation aligned to `X402.Plug.PaymentGate` (v2, accepted matching, extension echo) and optional `payment_identifier_cache` replay protection.
> 
> **`X402.MCP.Client`** runs detect → sign → retry-once over any tool-call function (same budget/`on_payment_required` guards as `X402.Client.Finch`), plus `build_payment_meta/3` for manual retries.
> 
> Also adds **`guides/mcp.md`**, changelog and ExDoc entries, and **`[:x402, :mcp, *]`** telemetry, with broad unit/integration tests including a full client⇄server loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8abe25ecf0cc73f11f2c5d9e882cd979ee809d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->