### PR TITLE
feat: EIP-2612 and ERC-20 approval gas-sponsoring extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   budget/consent hook and enforces `https://` for non-loopback resources
 - `[:x402, :client, :select | :sign | :build | :request]` telemetry events
 - `guides/client.md` — "Paying for x402 Resources from Elixir"
+- `X402.EIP712` — shared EIP-712 hashing primitives (requirements-derived
+  domain, domain separator, `hash_struct/2`, `digest/2`, and the ABI word
+  encoders), extracted from `X402.EIP3009` which now delegates to it
 
 ## [0.5.0] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   validation, plus client-side assembly of the extension data around a
   pre-signed `approve(Permit2, amount)` transaction (`build_info/1`,
   `put_info/2`, and `enricher/1` for `X402.Client.build_payment/3`)
+- `X402.Client.build_payment/3` and `X402.Client.Finch.request/3`
+  `:extensions` option — client extension enrichers applied to the
+  assembled payload (how gas-sponsoring data is attached opt-in)
 
 ## [0.5.0] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `validate_info/1`), plus client-side EIP-2612 `Permit` signing
   (`sign_permit/3`, `put_info/2`, and `enricher/2` for
   `X402.Client.build_payment/3`)
+- `X402.Extensions.ERC20ApprovalGasSponsoring` — the
+  `erc20ApprovalGasSponsoring` gas-sponsoring extension (report §8 P2.4)
+  for tokens without EIP-2612: server-side declaration and echo
+  validation, plus client-side assembly of the extension data around a
+  pre-signed `approve(Permit2, amount)` transaction (`build_info/1`,
+  `put_info/2`, and `enricher/1` for `X402.Client.build_payment/3`)
 
 ## [0.5.0] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `X402.EIP712` — shared EIP-712 hashing primitives (requirements-derived
   domain, domain separator, `hash_struct/2`, `digest/2`, and the ABI word
   encoders), extracted from `X402.EIP3009` which now delegates to it
+- `X402.Extensions.EIP2612GasSponsoring` — the `eip2612GasSponsoring`
+  gas-sponsoring extension (report §8 P2.4): server-side declaration
+  (`build_extension/0`) and echo validation (`extract_info/1` /
+  `validate_info/1`), plus client-side EIP-2612 `Permit` signing
+  (`sign_permit/3`, `put_info/2`, and `enricher/2` for
+  `X402.Client.build_payment/3`)
 
 ## [0.5.0] - 2026-08-26
 

--- a/guides/client.md
+++ b/guides/client.md
@@ -107,6 +107,59 @@ alias X402.{Client, PaymentRequired}
 `Client.select_requirements/2` is also public if you want to inspect or
 choose the payment option yourself before signing.
 
+## Gas-sponsoring extensions
+
+Permit2-based payments need a one-time on-chain `approve(Permit2, ...)`
+from the payer's wallet — which costs gas the wallet may not have. Two x402
+extensions let the facilitator sponsor that approval; when a server
+advertises them in its `PAYMENT-REQUIRED` extensions, the client can attach
+the corresponding data through `build_payment/3`'s `:extensions` option
+(also accepted by `X402.Client.Finch.request/3`).
+
+**EIP-2612 tokens** (`X402.Extensions.EIP2612GasSponsoring`): the client
+signs an off-chain EIP-2612 `Permit` authorizing the canonical Permit2
+contract, and the facilitator submits it on-chain, paying the gas. The SDK
+signs the permit itself — you only supply the owner's current EIP-2612
+nonce (read from the token contract's `nonces(owner)`; the SDK has no
+chain access):
+
+```elixir
+alias X402.Extensions.EIP2612GasSponsoring
+
+{:ok, payload} =
+  X402.Client.build_payment(payment_required, signer,
+    extensions: [EIP2612GasSponsoring.enricher(signer, nonce: "0")]
+  )
+```
+
+**Plain ERC-20 tokens** (`X402.Extensions.ERC20ApprovalGasSponsoring`):
+tokens without EIP-2612 have no gasless approval, so the client signs — but
+does not broadcast — a normal `approve(Permit2, amount)` transaction, and
+the facilitator funds the wallet's gas if needed, broadcasts it, and
+settles atomically. Signing that transaction needs the wallet's live
+on-chain nonce and network fees, so it happens outside the SDK; the
+enricher wraps the pre-signed transaction in the extension data:
+
+```elixir
+alias X402.Extensions.ERC20ApprovalGasSponsoring
+
+{:ok, payload} =
+  X402.Client.build_payment(payment_required, signer,
+    extensions: [
+      ERC20ApprovalGasSponsoring.enricher(
+        from: wallet_address,
+        signed_transaction: signed_approve_tx_hex
+      )
+    ]
+  )
+```
+
+Both enrichers are no-ops when the server did not advertise the extension,
+and both preserve the server's echoed declaration — client data is only
+added alongside it, per the spec's append-only rule. Resource servers
+declare support with `build_extension/0` and validate a client's echoed
+data with `extract_info/1` and `validate_info/1` on either module.
+
 ## Custom signers
 
 `X402.Signer.LocalKey` holds a raw private key in memory — fine for testing

--- a/lib/x402/client.ex
+++ b/lib/x402/client.ex
@@ -64,6 +64,19 @@ defmodule X402.Client do
                            Seconds subtracted from the current time for the EVM
                            authorization's `validAfter` (clock-skew tolerance).
                            """
+                         ],
+                         extensions: [
+                           type: {:list, {:fun, 2}},
+                           default: [],
+                           doc: """
+                           Client extension enrichers applied, in order, to the
+                           assembled payload. Each function receives the payload
+                           and the original `PaymentRequired` map (`nil` when
+                           building from a bare requirements map) and returns
+                           `{:ok, payload}` or `{:error, reason}` — see
+                           `X402.Extensions.EIP2612GasSponsoring.enricher/2` and
+                           `X402.Extensions.ERC20ApprovalGasSponsoring.enricher/1`.
+                           """
                          ]
                        ]
 
@@ -158,7 +171,10 @@ defmodule X402.Client do
   The chosen requirements are echoed in full (including `extra`) as
   `accepted`, and server-advertised `extensions` are echoed unchanged,
   following the spec's append-only rule: the client must preserve every
-  advertised value and may only add to them.
+  advertised value and may only add to them. `:extensions` enrichers run
+  after assembly and may add extension data on top of the echo — for
+  example `X402.Extensions.EIP2612GasSponsoring.enricher/2` for
+  gas-sponsored Permit2 approvals.
 
   Signing dispatches on the scheme and network of the chosen requirements;
   this release supports `exact` on `eip155:*` networks (EIP-3009). Other
@@ -177,7 +193,9 @@ defmodule X402.Client do
       with {:ok, requirements, envelope} <-
              resolve_requirements(payment_required_or_requirements, opts),
            {:ok, scheme_payload} <- sign_for_kind(requirements, signer, opts) do
-        {:ok, assemble_payload(requirements, scheme_payload, envelope)}
+        requirements
+        |> assemble_payload(scheme_payload, envelope)
+        |> apply_extensions(envelope.payment_required, Keyword.fetch!(opts, :extensions))
       end
 
     case result do
@@ -295,7 +313,8 @@ defmodule X402.Client do
   # -- Payload assembly -------------------------------------------------------
 
   @spec resolve_requirements(term(), keyword()) ::
-          {:ok, map(), %{resource: term(), extensions: term()}} | {:error, select_error()}
+          {:ok, map(), %{resource: term(), extensions: term(), payment_required: map() | nil}}
+          | {:error, select_error()}
   defp resolve_requirements(%{} = payment_required_or_requirements, opts) do
     if payment_required?(payment_required_or_requirements) do
       with {:ok, requirements} <-
@@ -304,11 +323,13 @@ defmodule X402.Client do
          %{
            resource: Utils.map_value(payment_required_or_requirements, {"resource", :resource}),
            extensions:
-             Utils.map_value(payment_required_or_requirements, {"extensions", :extensions})
+             Utils.map_value(payment_required_or_requirements, {"extensions", :extensions}),
+           payment_required: payment_required_or_requirements
          }}
       end
     else
-      {:ok, payment_required_or_requirements, %{resource: nil, extensions: nil}}
+      {:ok, payment_required_or_requirements,
+       %{resource: nil, extensions: nil, payment_required: nil}}
     end
   end
 
@@ -351,7 +372,11 @@ defmodule X402.Client do
     end
   end
 
-  @spec assemble_payload(map(), map(), %{resource: term(), extensions: term()}) :: map()
+  @spec assemble_payload(map(), map(), %{
+          resource: term(),
+          extensions: term(),
+          payment_required: map() | nil
+        }) :: map()
   defp assemble_payload(requirements, scheme_payload, envelope) do
     %{
       "x402Version" => 2,
@@ -360,6 +385,23 @@ defmodule X402.Client do
     }
     |> maybe_put("resource", envelope.resource)
     |> maybe_put("extensions", envelope.extensions)
+  end
+
+  @spec apply_extensions(map(), map() | nil, [(map(), map() | nil -> term())]) ::
+          {:ok, map()} | {:error, term()}
+  defp apply_extensions(payload, _payment_required, []), do: {:ok, payload}
+
+  defp apply_extensions(payload, payment_required, [enricher | enrichers]) do
+    case enricher.(payload, payment_required) do
+      {:ok, enriched} when is_map(enriched) ->
+        apply_extensions(enriched, payment_required, enrichers)
+
+      {:error, reason} ->
+        {:error, reason}
+
+      other ->
+        {:error, {:invalid_extension_result, other}}
+    end
   end
 
   @spec maybe_put(map(), String.t(), term()) :: map()

--- a/lib/x402/client/finch.ex
+++ b/lib/x402/client/finch.ex
@@ -92,6 +92,14 @@ defmodule X402.Client.Finch do
       default: 60,
       doc: "Clock-skew buffer for the authorization's `validAfter`, in seconds."
     ],
+    extensions: [
+      type: {:list, {:fun, 2}},
+      default: [],
+      doc: """
+      Client extension enrichers forwarded to
+      `X402.Client.build_payment/3` — see its `:extensions` option.
+      """
+    ],
     on_payment_required: [
       type: {:or, [{:fun, 1}, nil]},
       default: nil,
@@ -287,7 +295,15 @@ defmodule X402.Client.Finch do
 
   @spec build_opts(keyword()) :: keyword()
   defp build_opts(opts),
-    do: Keyword.take(opts, [:network, :scheme, :asset, :max_amount, :valid_after_buffer])
+    do:
+      Keyword.take(opts, [
+        :network,
+        :scheme,
+        :asset,
+        :max_amount,
+        :valid_after_buffer,
+        :extensions
+      ])
 
   @spec finalize(map()) :: response()
   defp finalize(response) do

--- a/lib/x402/eip3009.ex
+++ b/lib/x402/eip3009.ex
@@ -21,11 +21,10 @@ defmodule X402.EIP3009 do
   they are unavailable; the library itself compiles without them.
   """
 
+  alias X402.EIP712
   alias X402.Signer
   alias X402.Utils
-  alias X402.Wallet
 
-  @eip712_domain_type "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
   @transfer_with_authorization_type "TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
 
   @typed_data_types %{
@@ -58,18 +57,9 @@ defmodule X402.EIP3009 do
   ]
 
   @typedoc """
-  An EIP-712 domain map with `:name`, `:version`, `:chain_id`, and
-  `:verifying_contract` keys.
-
-  Functions accepting a domain also take the wire-style keys
-  (`"name"`, `"version"`, `"chainId"`, `"verifyingContract"`).
+  An EIP-712 domain map — see `t:X402.EIP712.domain/0`.
   """
-  @type domain :: %{
-          name: String.t(),
-          version: String.t(),
-          chain_id: non_neg_integer(),
-          verifying_contract: String.t()
-        }
+  @type domain :: EIP712.domain()
 
   @typedoc """
   A `TransferWithAuthorization` authorization in wire shape: string keys
@@ -80,18 +70,9 @@ defmodule X402.EIP3009 do
   @typedoc "The scheme `payload` map for a signed EIP-3009 payment."
   @type payload :: %{optional(String.t()) => String.t() | authorization()}
 
-  @type domain_error ::
-          :invalid_requirements
-          | {:missing_extra, String.t()}
-          | {:unsupported_transfer_method, term()}
-          | :unsupported_network
+  @type domain_error :: EIP712.domain_error() | {:unsupported_transfer_method, term()}
 
-  @type encode_error ::
-          :missing_dependency
-          | :invalid_address
-          | :invalid_amount
-          | :invalid_bytes32
-          | {:missing_field, String.t()}
+  @type encode_error :: EIP712.encode_error()
 
   @doc since: "0.6.0"
   @doc """
@@ -167,16 +148,10 @@ defmodule X402.EIP3009 do
   @spec domain(map()) :: {:ok, domain()} | {:error, domain_error()}
   def domain(requirements) when is_map(requirements) do
     extra = Utils.map_value(requirements, {"extra", :extra}) || %{}
-    network = Utils.map_value(requirements, {"network", :network})
-    asset = Utils.map_value(requirements, {"asset", :asset})
 
     with :ok <- ensure_map(extra),
-         :ok <- ensure_transfer_method(extra),
-         {:ok, name} <- fetch_extra(extra, {"name", :name}),
-         {:ok, version} <- fetch_extra(extra, {"version", :version}),
-         {:ok, chain_id} <- chain_id_from_caip2(network),
-         :ok <- ensure_binary(asset) do
-      {:ok, %{name: name, version: version, chain_id: chain_id, verifying_contract: asset}}
+         :ok <- ensure_transfer_method(extra) do
+      EIP712.domain(requirements)
     end
   end
 
@@ -248,10 +223,8 @@ defmodule X402.EIP3009 do
   """
   @spec eip712_digest(map(), map()) :: {:ok, <<_::256>>} | {:error, encode_error()}
   def eip712_digest(domain, authorization) when is_map(domain) and is_map(authorization) do
-    with {:ok, keccak_module} <- keccak_module(),
-         {:ok, domain_separator} <- domain_separator(domain, keccak_module),
-         {:ok, struct_hash} <- struct_hash(authorization, keccak_module) do
-      {:ok, keccak_module.hash_256(<<0x19, 0x01>> <> domain_separator <> struct_hash)}
+    with {:ok, struct_hash} <- struct_hash(authorization) do
+      EIP712.digest(domain, struct_hash)
     end
   end
 
@@ -322,6 +295,8 @@ defmodule X402.EIP3009 do
   @doc """
   Extracts the chain id from an `eip155:<chainId>` CAIP-2 network identifier.
 
+  See `X402.EIP712.chain_id_from_caip2/1`.
+
   ## Examples
 
       iex> X402.EIP3009.chain_id_from_caip2("eip155:84532")
@@ -331,18 +306,13 @@ defmodule X402.EIP3009 do
       {:error, :unsupported_network}
   """
   @spec chain_id_from_caip2(term()) :: {:ok, non_neg_integer()} | {:error, :unsupported_network}
-  def chain_id_from_caip2("eip155:" <> chain_id) do
-    case Integer.parse(chain_id) do
-      {parsed, ""} when parsed >= 0 -> {:ok, parsed}
-      _parsed -> {:error, :unsupported_network}
-    end
-  end
-
-  def chain_id_from_caip2(_network), do: {:error, :unsupported_network}
+  defdelegate chain_id_from_caip2(network), to: EIP712
 
   @doc since: "0.6.0"
   @doc """
   ABI-encodes a `0x`-prefixed EVM address into a 32-byte word.
+
+  See `X402.EIP712.encode_address/1`.
 
   ## Examples
 
@@ -354,23 +324,13 @@ defmodule X402.EIP3009 do
       {:error, :invalid_address}
   """
   @spec encode_address(term()) :: {:ok, <<_::256>>} | {:error, :invalid_address}
-  def encode_address(address) when is_binary(address) do
-    case Wallet.valid_evm?(address) do
-      true ->
-        "0x" <> hex = address
-        {:ok, bytes} = Base.decode16(hex, case: :mixed)
-        {:ok, <<0::unsigned-big-integer-size(96), bytes::binary>>}
-
-      false ->
-        {:error, :invalid_address}
-    end
-  end
-
-  def encode_address(_address), do: {:error, :invalid_address}
+  defdelegate encode_address(address), to: EIP712
 
   @doc since: "0.6.0"
   @doc """
   ABI-encodes a non-negative integer (or decimal string) into a 32-byte word.
+
+  See `X402.EIP712.encode_uint256/1`.
 
   ## Examples
 
@@ -381,21 +341,13 @@ defmodule X402.EIP3009 do
       {:error, :invalid_amount}
   """
   @spec encode_uint256(term()) :: {:ok, <<_::256>>} | {:error, :invalid_amount}
-  def encode_uint256(integer) when is_integer(integer) and integer >= 0,
-    do: {:ok, <<integer::unsigned-big-integer-size(256)>>}
-
-  def encode_uint256(string) when is_binary(string) do
-    case Integer.parse(string) do
-      {integer, ""} when integer >= 0 -> encode_uint256(integer)
-      _parsed -> {:error, :invalid_amount}
-    end
-  end
-
-  def encode_uint256(_value), do: {:error, :invalid_amount}
+  defdelegate encode_uint256(value), to: EIP712
 
   @doc since: "0.6.0"
   @doc """
   Decodes a `0x`-prefixed hex string into a 32-byte binary.
+
+  See `X402.EIP712.encode_bytes32/1`.
 
   ## Examples
 
@@ -407,60 +359,32 @@ defmodule X402.EIP3009 do
       {:error, :invalid_bytes32}
   """
   @spec encode_bytes32(term()) :: {:ok, <<_::256>>} | {:error, :invalid_bytes32}
-  def encode_bytes32("0x" <> hex) do
-    case Base.decode16(hex, case: :mixed) do
-      {:ok, bytes} when byte_size(bytes) == 32 -> {:ok, bytes}
-      _decoded -> {:error, :invalid_bytes32}
-    end
-  end
+  defdelegate encode_bytes32(value), to: EIP712
 
-  def encode_bytes32(_value), do: {:error, :invalid_bytes32}
+  # -- Struct hashing ---------------------------------------------------------
 
-  # -- Domain / struct hashing ------------------------------------------------
-
-  @spec domain_separator(map(), module()) :: {:ok, binary()} | {:error, encode_error()}
-  defp domain_separator(domain, keccak_module) do
-    with {:ok, name} <- fetch_field(domain, {"name", :name}),
-         {:ok, version} <- fetch_field(domain, {"version", :version}),
-         {:ok, chain_id} <- fetch_chain_id(domain),
-         {:ok, contract} <- fetch_field(domain, {"verifyingContract", :verifying_contract}),
-         {:ok, chain_id_word} <- encode_uint256(chain_id),
-         {:ok, contract_word} <- encode_address(contract) do
-      {:ok,
-       keccak_module.hash_256(
-         keccak_module.hash_256(@eip712_domain_type) <>
-           keccak_module.hash_256(name) <>
-           keccak_module.hash_256(version) <>
-           chain_id_word <>
-           contract_word
-       )}
-    end
-  end
-
-  @spec struct_hash(map(), module()) :: {:ok, binary()} | {:error, encode_error()}
-  defp struct_hash(authorization, keccak_module) do
+  @spec struct_hash(map()) :: {:ok, binary()} | {:error, encode_error()}
+  defp struct_hash(authorization) do
     with {:ok, from} <- fetch_field(authorization, {"from", :from}),
          {:ok, to} <- fetch_field(authorization, {"to", :to}),
          {:ok, value} <- fetch_field(authorization, {"value", :value}),
          {:ok, valid_after} <- fetch_field(authorization, {"validAfter", :valid_after}),
          {:ok, valid_before} <- fetch_field(authorization, {"validBefore", :valid_before}),
          {:ok, nonce} <- fetch_field(authorization, {"nonce", :nonce}),
-         {:ok, from_word} <- encode_address(from),
-         {:ok, to_word} <- encode_address(to),
-         {:ok, value_word} <- encode_uint256(value),
-         {:ok, valid_after_word} <- encode_uint256(valid_after),
-         {:ok, valid_before_word} <- encode_uint256(valid_before),
-         {:ok, nonce_word} <- encode_bytes32(nonce) do
-      {:ok,
-       keccak_module.hash_256(
-         keccak_module.hash_256(@transfer_with_authorization_type) <>
-           from_word <>
-           to_word <>
-           value_word <>
-           valid_after_word <>
-           valid_before_word <>
-           nonce_word
-       )}
+         {:ok, from_word} <- EIP712.encode_address(from),
+         {:ok, to_word} <- EIP712.encode_address(to),
+         {:ok, value_word} <- EIP712.encode_uint256(value),
+         {:ok, valid_after_word} <- EIP712.encode_uint256(valid_after),
+         {:ok, valid_before_word} <- EIP712.encode_uint256(valid_before),
+         {:ok, nonce_word} <- EIP712.encode_bytes32(nonce) do
+      EIP712.hash_struct(@transfer_with_authorization_type, [
+        from_word,
+        to_word,
+        value_word,
+        valid_after_word,
+        valid_before_word,
+        nonce_word
+      ])
     end
   end
 
@@ -497,30 +421,9 @@ defmodule X402.EIP3009 do
     end
   end
 
-  @spec fetch_chain_id(map()) :: {:ok, term()} | {:error, {:missing_field, String.t()}}
-  defp fetch_chain_id(domain) do
-    case Utils.map_value(domain, {"chainId", :chain_id}) do
-      nil -> {:error, {:missing_field, "chainId"}}
-      value -> {:ok, value}
-    end
-  end
-
-  @spec fetch_extra(map(), {String.t(), atom()}) ::
-          {:ok, String.t()} | {:error, {:missing_extra, String.t()}}
-  defp fetch_extra(extra, {string_key, _atom_key} = key) do
-    case Utils.map_value(extra, key) do
-      value when is_binary(value) and value != "" -> {:ok, value}
-      _value -> {:error, {:missing_extra, string_key}}
-    end
-  end
-
   @spec ensure_map(term()) :: :ok | {:error, :invalid_requirements}
   defp ensure_map(value) when is_map(value), do: :ok
   defp ensure_map(_value), do: {:error, :invalid_requirements}
-
-  @spec ensure_binary(term()) :: :ok | {:error, :invalid_requirements}
-  defp ensure_binary(value) when is_binary(value) and value != "", do: :ok
-  defp ensure_binary(_value), do: {:error, :invalid_requirements}
 
   @spec ensure_transfer_method(map()) :: :ok | {:error, {:unsupported_transfer_method, term()}}
   defp ensure_transfer_method(extra) do
@@ -592,7 +495,7 @@ defmodule X402.EIP3009 do
   defp crypto_modules do
     secp256k1_module = Module.concat(["ExSecp256k1"])
 
-    with {:ok, keccak_module} <- keccak_module(),
+    with {:ok, keccak_module} <- EIP712.keccak_module(),
          true <-
            Code.ensure_loaded?(secp256k1_module) and
              function_exported?(secp256k1_module, :create_public_key, 1) and
@@ -600,16 +503,6 @@ defmodule X402.EIP3009 do
       {:ok, secp256k1_module, keccak_module}
     else
       _unavailable -> {:error, :missing_dependency}
-    end
-  end
-
-  @spec keccak_module() :: {:ok, module()} | {:error, :missing_dependency}
-  defp keccak_module do
-    keccak_module = Module.concat(["ExKeccak"])
-
-    case Code.ensure_loaded?(keccak_module) and function_exported?(keccak_module, :hash_256, 1) do
-      true -> {:ok, keccak_module}
-      false -> {:error, :missing_dependency}
     end
   end
 end

--- a/lib/x402/eip712.ex
+++ b/lib/x402/eip712.ex
@@ -1,0 +1,308 @@
+defmodule X402.EIP712 do
+  @moduledoc """
+  Generic [EIP-712](https://eips.ethereum.org/EIPS/eip-712) hashing primitives.
+
+  Shared by the x402 signing modules: `X402.EIP3009` hashes
+  `TransferWithAuthorization` structs with these primitives, and
+  `X402.Extensions.EIP2612GasSponsoring` hashes EIP-2612 `Permit` structs.
+  The module covers the common x402 domain shape
+  (`name`/`version`/`chainId`/`verifyingContract`) and the generic
+  `hash_struct/2` / `digest/2` combination
+
+      digest = keccak256(0x19 0x01 || domainSeparator || structHash)
+
+  together with the ABI word encoders the struct hashes are built from.
+
+  Cryptographic hashing requires the optional `ex_keccak` dependency and
+  returns `{:error, :missing_dependency}` when it is unavailable; the library
+  itself compiles without it.
+  """
+
+  alias X402.Utils
+  alias X402.Wallet
+
+  @domain_type "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+
+  @typedoc """
+  An EIP-712 domain map with `:name`, `:version`, `:chain_id`, and
+  `:verifying_contract` keys.
+
+  Functions accepting a domain also take the wire-style keys
+  (`"name"`, `"version"`, `"chainId"`, `"verifyingContract"`).
+  """
+  @type domain :: %{
+          name: String.t(),
+          version: String.t(),
+          chain_id: non_neg_integer(),
+          verifying_contract: String.t()
+        }
+
+  @type domain_error ::
+          :invalid_requirements
+          | {:missing_extra, String.t()}
+          | :unsupported_network
+
+  @type encode_error ::
+          :missing_dependency
+          | :invalid_address
+          | :invalid_amount
+          | :invalid_bytes32
+          | :invalid_word
+          | {:missing_field, String.t()}
+
+  @doc since: "0.6.0"
+  @doc """
+  Derives the EIP-712 domain from v2 payment requirements.
+
+  Per the exact-EVM scheme specification, `extra.name` and `extra.version`
+  are required, the chain id comes from the CAIP-2 `network`, and the
+  verifying contract is the `asset` address. Unlike `X402.EIP3009.domain/1`,
+  the `extra.assetTransferMethod` is not restricted, so the same derivation
+  serves EIP-3009, Permit2, and extension signing.
+
+  ## Examples
+
+      iex> X402.EIP712.domain(%{
+      ...>   "network" => "eip155:84532",
+      ...>   "asset" => "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      ...>   "extra" => %{"name" => "USDC", "version" => "2"}
+      ...> })
+      {:ok,
+       %{
+         name: "USDC",
+         version: "2",
+         chain_id: 84532,
+         verifying_contract: "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+       }}
+
+      iex> X402.EIP712.domain(%{"network" => "eip155:84532", "asset" => "0xasset", "extra" => %{}})
+      {:error, {:missing_extra, "name"}}
+  """
+  @spec domain(map()) :: {:ok, domain()} | {:error, domain_error()}
+  def domain(requirements) when is_map(requirements) do
+    extra = Utils.map_value(requirements, {"extra", :extra}) || %{}
+    network = Utils.map_value(requirements, {"network", :network})
+    asset = Utils.map_value(requirements, {"asset", :asset})
+
+    with :ok <- ensure_map(extra),
+         {:ok, name} <- fetch_extra(extra, {"name", :name}),
+         {:ok, version} <- fetch_extra(extra, {"version", :version}),
+         {:ok, chain_id} <- chain_id_from_caip2(network),
+         :ok <- ensure_binary(asset) do
+      {:ok, %{name: name, version: version, chain_id: chain_id, verifying_contract: asset}}
+    end
+  end
+
+  def domain(_requirements), do: {:error, :invalid_requirements}
+
+  @doc since: "0.6.0"
+  @doc """
+  Computes the EIP-712 domain separator for a domain map.
+
+  Returns `keccak256(typeHash || keccak256(name) || keccak256(version) ||
+  chainId || verifyingContract)` as a 32-byte binary.
+  """
+  @spec domain_separator(map()) :: {:ok, <<_::256>>} | {:error, encode_error()}
+  def domain_separator(domain) when is_map(domain) do
+    with {:ok, keccak_module} <- keccak_module(),
+         {:ok, name} <- fetch_field(domain, {"name", :name}),
+         {:ok, version} <- fetch_field(domain, {"version", :version}),
+         {:ok, chain_id} <- fetch_field(domain, {"chainId", :chain_id}),
+         {:ok, contract} <- fetch_field(domain, {"verifyingContract", :verifying_contract}),
+         {:ok, chain_id_word} <- encode_uint256(chain_id),
+         {:ok, contract_word} <- encode_address(contract) do
+      {:ok,
+       keccak_module.hash_256(
+         keccak_module.hash_256(@domain_type) <>
+           keccak_module.hash_256(name) <>
+           keccak_module.hash_256(version) <>
+           chain_id_word <>
+           contract_word
+       )}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Computes an EIP-712 struct hash from a type string and encoded words.
+
+  `type` is the full encoded type (for example
+  `"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"`)
+  and `words` the ABI-encoded 32-byte field values, in declaration order —
+  see `encode_address/1`, `encode_uint256/1`, and `encode_bytes32/1`.
+  """
+  @spec hash_struct(String.t(), [<<_::256>>]) ::
+          {:ok, <<_::256>>} | {:error, :missing_dependency | :invalid_word}
+  def hash_struct(type, words) when is_binary(type) and is_list(words) do
+    with {:ok, keccak_module} <- keccak_module(),
+         :ok <- ensure_words(words) do
+      {:ok, keccak_module.hash_256(IO.iodata_to_binary([keccak_module.hash_256(type) | words]))}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Computes the final EIP-712 digest for a domain and a struct hash.
+
+  Returns `keccak256(0x19 0x01 || domainSeparator || structHash)` as a
+  32-byte binary — the value a signer signs.
+  """
+  @spec digest(map(), <<_::256>>) :: {:ok, <<_::256>>} | {:error, encode_error()}
+  def digest(domain, struct_hash)
+      when is_map(domain) and is_binary(struct_hash) and byte_size(struct_hash) == 32 do
+    with {:ok, keccak_module} <- keccak_module(),
+         {:ok, domain_separator} <- domain_separator(domain) do
+      {:ok, keccak_module.hash_256(<<0x19, 0x01>> <> domain_separator <> struct_hash)}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Extracts the chain id from an `eip155:<chainId>` CAIP-2 network identifier.
+
+  ## Examples
+
+      iex> X402.EIP712.chain_id_from_caip2("eip155:84532")
+      {:ok, 84532}
+
+      iex> X402.EIP712.chain_id_from_caip2("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp")
+      {:error, :unsupported_network}
+  """
+  @spec chain_id_from_caip2(term()) :: {:ok, non_neg_integer()} | {:error, :unsupported_network}
+  def chain_id_from_caip2("eip155:" <> chain_id) do
+    case Integer.parse(chain_id) do
+      {parsed, ""} when parsed >= 0 -> {:ok, parsed}
+      _parsed -> {:error, :unsupported_network}
+    end
+  end
+
+  def chain_id_from_caip2(_network), do: {:error, :unsupported_network}
+
+  @doc since: "0.6.0"
+  @doc """
+  ABI-encodes a `0x`-prefixed EVM address into a 32-byte word.
+
+  ## Examples
+
+      iex> {:ok, word} = X402.EIP712.encode_address("0x1111111111111111111111111111111111111111")
+      iex> byte_size(word)
+      32
+
+      iex> X402.EIP712.encode_address("0x123")
+      {:error, :invalid_address}
+  """
+  @spec encode_address(term()) :: {:ok, <<_::256>>} | {:error, :invalid_address}
+  def encode_address(address) when is_binary(address) do
+    case Wallet.valid_evm?(address) do
+      true ->
+        "0x" <> hex = address
+        {:ok, bytes} = Base.decode16(hex, case: :mixed)
+        {:ok, <<0::unsigned-big-integer-size(96), bytes::binary>>}
+
+      false ->
+        {:error, :invalid_address}
+    end
+  end
+
+  def encode_address(_address), do: {:error, :invalid_address}
+
+  @doc since: "0.6.0"
+  @doc """
+  ABI-encodes a non-negative integer (or decimal string) into a 32-byte word.
+
+  ## Examples
+
+      iex> X402.EIP712.encode_uint256(1)
+      {:ok, <<1::unsigned-big-integer-size(256)>>}
+
+      iex> X402.EIP712.encode_uint256("not a number")
+      {:error, :invalid_amount}
+  """
+  @spec encode_uint256(term()) :: {:ok, <<_::256>>} | {:error, :invalid_amount}
+  def encode_uint256(integer) when is_integer(integer) and integer >= 0,
+    do: {:ok, <<integer::unsigned-big-integer-size(256)>>}
+
+  def encode_uint256(string) when is_binary(string) do
+    case Integer.parse(string) do
+      {integer, ""} when integer >= 0 -> encode_uint256(integer)
+      _parsed -> {:error, :invalid_amount}
+    end
+  end
+
+  def encode_uint256(_value), do: {:error, :invalid_amount}
+
+  @doc since: "0.6.0"
+  @doc """
+  Decodes a `0x`-prefixed hex string into a 32-byte binary.
+
+  ## Examples
+
+      iex> {:ok, bytes} = X402.EIP712.encode_bytes32("0x" <> String.duplicate("ab", 32))
+      iex> byte_size(bytes)
+      32
+
+      iex> X402.EIP712.encode_bytes32("0xdead")
+      {:error, :invalid_bytes32}
+  """
+  @spec encode_bytes32(term()) :: {:ok, <<_::256>>} | {:error, :invalid_bytes32}
+  def encode_bytes32("0x" <> hex) do
+    case Base.decode16(hex, case: :mixed) do
+      {:ok, bytes} when byte_size(bytes) == 32 -> {:ok, bytes}
+      _decoded -> {:error, :invalid_bytes32}
+    end
+  end
+
+  def encode_bytes32(_value), do: {:error, :invalid_bytes32}
+
+  # -- Optional dependency resolution ----------------------------------------
+  #
+  # The module is resolved at runtime via Module.concat so the library
+  # compiles without ex_keccak (same pattern as X402.Facilitator.HTTP).
+
+  @doc false
+  @spec keccak_module() :: {:ok, module()} | {:error, :missing_dependency}
+  def keccak_module do
+    keccak_module = Module.concat(["ExKeccak"])
+
+    case Code.ensure_loaded?(keccak_module) and function_exported?(keccak_module, :hash_256, 1) do
+      true -> {:ok, keccak_module}
+      false -> {:error, :missing_dependency}
+    end
+  end
+
+  # -- Field access -----------------------------------------------------------
+
+  @spec fetch_field(map(), {String.t(), atom()}) ::
+          {:ok, term()} | {:error, {:missing_field, String.t()}}
+  defp fetch_field(map, {string_key, _atom_key} = key) do
+    case Utils.map_value(map, key) do
+      nil -> {:error, {:missing_field, string_key}}
+      value -> {:ok, value}
+    end
+  end
+
+  @spec fetch_extra(map(), {String.t(), atom()}) ::
+          {:ok, String.t()} | {:error, {:missing_extra, String.t()}}
+  defp fetch_extra(extra, {string_key, _atom_key} = key) do
+    case Utils.map_value(extra, key) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _value -> {:error, {:missing_extra, string_key}}
+    end
+  end
+
+  @spec ensure_words([term()]) :: :ok | {:error, :invalid_word}
+  defp ensure_words(words) do
+    case Enum.all?(words, &(is_binary(&1) and byte_size(&1) == 32)) do
+      true -> :ok
+      false -> {:error, :invalid_word}
+    end
+  end
+
+  @spec ensure_map(term()) :: :ok | {:error, :invalid_requirements}
+  defp ensure_map(value) when is_map(value), do: :ok
+  defp ensure_map(_value), do: {:error, :invalid_requirements}
+
+  @spec ensure_binary(term()) :: :ok | {:error, :invalid_requirements}
+  defp ensure_binary(value) when is_binary(value) and value != "", do: :ok
+  defp ensure_binary(_value), do: {:error, :invalid_requirements}
+end

--- a/lib/x402/extensions/eip2612_gas_sponsoring.ex
+++ b/lib/x402/extensions/eip2612_gas_sponsoring.ex
@@ -1,0 +1,594 @@
+defmodule X402.Extensions.EIP2612GasSponsoring do
+  @moduledoc """
+  Builds, signs, and validates the `eip2612GasSponsoring` extension.
+
+  The extension enables a gasless approval flow for tokens that implement
+  [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612): instead of paying gas
+  for an `approve` transaction, the client signs an off-chain EIP-2612
+  `Permit` authorizing the canonical
+  [Permit2](https://github.com/Uniswap/permit2) contract as spender, and the
+  facilitator submits it on-chain (paying the gas) via
+  `x402Permit2Proxy.settleWithPermit`.
+
+  Server side, `build_extension/0` declares support under
+  `extensions.eip2612GasSponsoring` in a `PAYMENT-REQUIRED` response, and
+  `extract_info/1` / `validate_info/1` check the client-populated data echoed
+  back in a `PaymentPayload`.
+
+  Client side, `sign_permit/3` signs the `Permit` typed data for a selected
+  payment requirements entry through the `X402.Signer` behaviour, and
+  `put_info/2` attaches the resulting info to a payload's extensions.
+  `enricher/2` packages both for `X402.Client.build_payment/3`:
+
+      {:ok, payload} =
+        X402.Client.build_payment(payment_required, signer,
+          extensions: [
+            X402.Extensions.EIP2612GasSponsoring.enricher(signer, nonce: "0")
+          ]
+        )
+
+  The library has no chain access, so the owner's current EIP-2612 `:nonce`
+  (read from the token contract's `nonces(owner)`) must be supplied by the
+  caller.
+
+  See the
+  [eip2612GasSponsoring extension spec](https://github.com/x402-foundation/x402/blob/main/specs/extensions/eip2612_gas_sponsoring.md).
+  """
+
+  alias X402.EIP712
+  alias X402.Signer
+  alias X402.Utils
+  alias X402.Wallet
+
+  @extension_key "eip2612GasSponsoring"
+  @permit2_address "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+  @info_version "1"
+  @schema_uri "https://json-schema.org/draft/2020-12/schema"
+
+  @permit_type "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+
+  @typed_data_types %{
+    "EIP712Domain" => [
+      %{"name" => "name", "type" => "string"},
+      %{"name" => "version", "type" => "string"},
+      %{"name" => "chainId", "type" => "uint256"},
+      %{"name" => "verifyingContract", "type" => "address"}
+    ],
+    "Permit" => [
+      %{"name" => "owner", "type" => "address"},
+      %{"name" => "spender", "type" => "address"},
+      %{"name" => "value", "type" => "uint256"},
+      %{"name" => "nonce", "type" => "uint256"},
+      %{"name" => "deadline", "type" => "uint256"}
+    ]
+  }
+
+  @required_fields ~w(from asset spender amount nonce deadline signature version)
+
+  @sign_opts_schema [
+    nonce: [
+      type: {:or, [:non_neg_integer, :string]},
+      required: true,
+      doc: """
+      The owner's current EIP-2612 nonce on the token contract (the value of
+      `nonces(owner)`), as an integer or decimal string. The library has no
+      chain access, so the caller must read it.
+      """
+    ],
+    deadline: [
+      type: {:or, [:non_neg_integer, :string]},
+      doc: """
+      Unix timestamp at which the permit signature expires. Defaults to the
+      current time plus the requirements' `maxTimeoutSeconds`.
+      """
+    ],
+    amount: [
+      type: {:or, [:non_neg_integer, :string]},
+      doc: """
+      Approval amount in atomic units. Defaults to the requirements'
+      `amount` — `x402Permit2Proxy.settleWithPermit` enforces that the
+      permit value matches the Permit2 permitted amount exactly.
+      """
+    ],
+    spender: [
+      type: :string,
+      doc: "The approved spender. Defaults to the canonical Permit2 contract."
+    ]
+  ]
+
+  @typedoc "A built `extensions.eip2612GasSponsoring` declaration (`info` + `schema`)."
+  @type t :: %{binary() => map()}
+
+  @typedoc """
+  Client-populated extension info in wire shape: string keys `"from"`,
+  `"asset"`, `"spender"`, `"amount"`, `"nonce"`, `"deadline"`,
+  `"signature"`, and `"version"`.
+  """
+  @type info :: %{optional(binary()) => binary()}
+
+  @type info_error ::
+          :extension_missing
+          | {:missing_info_field, String.t()}
+          | {:invalid_info_field, String.t()}
+
+  @type sign_error ::
+          :invalid_nonce
+          | :invalid_deadline
+          | :invalid_amount
+          | :invalid_requirements
+          | EIP712.domain_error()
+          | EIP712.encode_error()
+          | term()
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the extension key, `"eip2612GasSponsoring"`.
+
+  ## Examples
+
+      iex> X402.Extensions.EIP2612GasSponsoring.key()
+      "eip2612GasSponsoring"
+  """
+  @spec key() :: String.t()
+  def key, do: @extension_key
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the canonical Permit2 contract address — the default spender.
+
+  ## Examples
+
+      iex> X402.Extensions.EIP2612GasSponsoring.permit2_address()
+      "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+  """
+  @spec permit2_address() :: String.t()
+  def permit2_address, do: @permit2_address
+
+  @doc since: "0.6.0"
+  @doc """
+  Builds the server-side extension declaration (`info` + `schema`).
+
+  Resource servers advertise support by placing the declaration under
+  `extensions.eip2612GasSponsoring` in a `PAYMENT-REQUIRED` response; the
+  client populates the actual permit data.
+
+  ## Examples
+
+      iex> ext = X402.Extensions.EIP2612GasSponsoring.build_extension()
+      iex> ext["info"]["version"]
+      "1"
+      iex> ext["schema"]["required"]
+      ["from", "asset", "spender", "amount", "nonce", "deadline", "signature", "version"]
+  """
+  @spec build_extension() :: t()
+  def build_extension do
+    %{
+      "info" => %{
+        "description" =>
+          "The facilitator accepts EIP-2612 gasless Permit to `Permit2` canonical contract.",
+        "version" => @info_version
+      },
+      "schema" => schema()
+    }
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the JSON Schema (Draft 2020-12) for the client-populated info.
+  """
+  @spec schema() :: map()
+  def schema do
+    %{
+      "$schema" => @schema_uri,
+      "type" => "object",
+      "properties" => %{
+        "from" => %{
+          "type" => "string",
+          "pattern" => "^0x[a-fA-F0-9]{40}$",
+          "description" => "The address of the sender."
+        },
+        "asset" => %{
+          "type" => "string",
+          "pattern" => "^0x[a-fA-F0-9]{40}$",
+          "description" => "The address of the ERC-20 token contract."
+        },
+        "spender" => %{
+          "type" => "string",
+          "pattern" => "^0x[a-fA-F0-9]{40}$",
+          "description" => "The address of the spender (Canonical Permit2)."
+        },
+        "amount" => %{
+          "type" => "string",
+          "pattern" => "^[0-9]+$",
+          "description" => "The amount to approve (uint256). Typically MaxUint."
+        },
+        "nonce" => %{
+          "type" => "string",
+          "pattern" => "^[0-9]+$",
+          "description" => "The current nonce of the sender."
+        },
+        "deadline" => %{
+          "type" => "string",
+          "pattern" => "^[0-9]+$",
+          "description" => "The timestamp at which the signature expires."
+        },
+        "signature" => %{
+          "type" => "string",
+          "pattern" => "^0x[a-fA-F0-9]+$",
+          "description" => "The 65-byte concatenated signature (r, s, v) as a hex string."
+        },
+        "version" => %{
+          "type" => "string",
+          "pattern" => "^[0-9]+(\\.[0-9]+)*$",
+          "description" => "Schema version identifier."
+        }
+      },
+      "required" => @required_fields
+    }
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Signs an EIP-2612 `Permit` for a payment requirements entry.
+
+  The EIP-712 domain is the token's: `extra.name` / `extra.version`, the
+  chain id from the CAIP-2 `network`, and the `asset` contract as verifying
+  contract. The permit authorizes `:spender` (canonical Permit2 by default)
+  to spend `:amount` (the requirements' `amount` by default) of the owner's
+  tokens until `:deadline`.
+
+  Returns the client-populated extension info in wire shape, ready for
+  `put_info/2`.
+
+  ## Options
+
+  #{NimbleOptions.docs(@sign_opts_schema)}
+
+  ## Examples
+
+      {:ok, signer} = X402.Signer.LocalKey.new(private_key)
+
+      {:ok, %{"signature" => _, "spender" => _} = info} =
+        X402.Extensions.EIP2612GasSponsoring.sign_permit(
+          %{
+            "scheme" => "exact",
+            "network" => "eip155:84532",
+            "amount" => "10000",
+            "asset" => "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+            "payTo" => "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+            "maxTimeoutSeconds" => 60,
+            "extra" => %{"assetTransferMethod" => "permit2", "name" => "USDC", "version" => "2"}
+          },
+          signer,
+          nonce: "0"
+        )
+  """
+  @spec sign_permit(map(), Signer.t(), keyword()) :: {:ok, info()} | {:error, sign_error()}
+  def sign_permit(requirements, signer, opts) when is_map(requirements) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @sign_opts_schema)
+
+    with {:ok, domain} <- EIP712.domain(requirements),
+         {:ok, owner} <- Signer.address(signer),
+         {:ok, nonce} <- normalize_uint(Keyword.fetch!(opts, :nonce), :invalid_nonce),
+         {:ok, deadline} <- resolve_deadline(requirements, opts),
+         {:ok, amount} <- resolve_amount(requirements, opts) do
+      spender = Keyword.get(opts, :spender, @permit2_address)
+
+      permit = %{
+        "owner" => owner,
+        "spender" => spender,
+        "value" => amount,
+        "nonce" => nonce,
+        "deadline" => deadline
+      }
+
+      with {:ok, digest} <- permit_digest(domain, permit),
+           {:ok, signature} <- Signer.sign_eip712(signer, digest, typed_data(domain, permit)) do
+        {:ok,
+         %{
+           "from" => owner,
+           "asset" => domain.verifying_contract,
+           "spender" => spender,
+           "amount" => amount,
+           "nonce" => nonce,
+           "deadline" => deadline,
+           "signature" => "0x" <> Base.encode16(signature, case: :lower),
+           "version" => @info_version
+         }}
+      end
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Computes the EIP-712 digest of an EIP-2612 `Permit` message.
+
+  `domain` is the token's EIP-712 domain (see `X402.EIP712.domain/1`) and
+  `permit` a map with `"owner"`, `"spender"`, `"value"`, `"nonce"`, and
+  `"deadline"` keys (snake-case atom keys are also accepted). Useful for
+  verifying a signed permit with `X402.EIP3009.recover_signer/2`.
+  """
+  @spec permit_digest(map(), map()) :: {:ok, <<_::256>>} | {:error, EIP712.encode_error()}
+  def permit_digest(domain, permit) when is_map(domain) and is_map(permit) do
+    with {:ok, owner} <- fetch_field(permit, {"owner", :owner}),
+         {:ok, spender} <- fetch_field(permit, {"spender", :spender}),
+         {:ok, value} <- fetch_field(permit, {"value", :value}),
+         {:ok, nonce} <- fetch_field(permit, {"nonce", :nonce}),
+         {:ok, deadline} <- fetch_field(permit, {"deadline", :deadline}),
+         {:ok, owner_word} <- EIP712.encode_address(owner),
+         {:ok, spender_word} <- EIP712.encode_address(spender),
+         {:ok, value_word} <- EIP712.encode_uint256(value),
+         {:ok, nonce_word} <- EIP712.encode_uint256(nonce),
+         {:ok, deadline_word} <- EIP712.encode_uint256(deadline),
+         {:ok, struct_hash} <-
+           EIP712.hash_struct(@permit_type, [
+             owner_word,
+             spender_word,
+             value_word,
+             nonce_word,
+             deadline_word
+           ]) do
+      EIP712.digest(domain, struct_hash)
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Attaches client-populated info to a payload's extensions.
+
+  Places the info under `extensions.eip2612GasSponsoring.info`, following
+  the append-only rule: when the payload already echoes the server's
+  declaration, server-declared info fields are preserved (they win over
+  client values) and the declared `schema` is kept; the client's fields are
+  added alongside them.
+
+  ## Examples
+
+      iex> info = %{"from" => "0x1111111111111111111111111111111111111111"}
+      iex> payload = X402.Extensions.EIP2612GasSponsoring.put_info(%{"payload" => %{}}, info)
+      iex> payload["extensions"]["eip2612GasSponsoring"]["info"]["from"]
+      "0x1111111111111111111111111111111111111111"
+  """
+  @spec put_info(map(), info()) :: map()
+  def put_info(payload, info) when is_map(payload) and is_map(info) do
+    extensions = ensure_extensions(Utils.map_value(payload, {"extensions", :extensions}))
+    declaration = ensure_declaration(Map.get(extensions, @extension_key))
+    server_info = ensure_declaration(Map.get(declaration, "info"))
+    merged = Map.put(declaration, "info", Map.merge(info, server_info))
+    Map.put(payload, "extensions", Map.put(extensions, @extension_key, merged))
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Extracts the client-populated info from a `PaymentPayload` map.
+
+  Returns the info when the extension is present and every required field
+  is populated. Field formats are not checked here — see `validate_info/1`.
+
+  ## Examples
+
+      iex> X402.Extensions.EIP2612GasSponsoring.extract_info(%{"payload" => %{}})
+      {:error, :extension_missing}
+  """
+  @spec extract_info(map()) :: {:ok, info()} | {:error, info_error()}
+  def extract_info(payload) when is_map(payload) do
+    extensions = Utils.map_value(payload, {"extensions", :extensions})
+
+    with {:ok, info} <- fetch_info(extensions),
+         :ok <- ensure_fields_present(info) do
+      {:ok, info}
+    end
+  end
+
+  def extract_info(_payload), do: {:error, :extension_missing}
+
+  @doc since: "0.6.0"
+  @doc """
+  Validates the format of client-populated info.
+
+  Checks that addresses match `^0x[a-fA-F0-9]{40}$`, that `amount`,
+  `nonce`, and `deadline` are decimal strings, that `signature` is a
+  `0x`-prefixed hex string, and that `version` is a dotted numeric version.
+
+  ## Examples
+
+      iex> X402.Extensions.EIP2612GasSponsoring.validate_info(%{
+      ...>   "from" => "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+      ...>   "asset" => "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      ...>   "spender" => "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+      ...>   "amount" => "10000",
+      ...>   "nonce" => "0",
+      ...>   "deadline" => "1740672154",
+      ...>   "signature" => "0xabcdef",
+      ...>   "version" => "1"
+      ...> })
+      :ok
+
+      iex> X402.Extensions.EIP2612GasSponsoring.validate_info(%{"from" => "0x123"})
+      {:error, {:invalid_info_field, "from"}}
+  """
+  @spec validate_info(term()) :: :ok | {:error, info_error()}
+  def validate_info(info) when is_map(info) do
+    Enum.reduce_while(@required_fields, :ok, fn field, :ok ->
+      case Map.get(info, field) do
+        nil -> {:halt, {:error, {:missing_info_field, field}}}
+        value -> validate_field(field, value)
+      end
+    end)
+  end
+
+  def validate_info(_info), do: {:error, :extension_missing}
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns an enricher for `X402.Client.build_payment/3`'s `:extensions`.
+
+  The enricher signs an EIP-2612 permit for the payload's accepted
+  requirements and attaches it via `put_info/2` — but only when the server
+  advertised `eip2612GasSponsoring` in the `PaymentRequired` extensions;
+  otherwise the payload passes through unchanged.
+
+  Takes the same options as `sign_permit/3` (`:nonce` is required).
+  """
+  @spec enricher(Signer.t(), keyword()) ::
+          (map(), map() | nil -> {:ok, map()} | {:error, sign_error()})
+  def enricher(signer, opts) when is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @sign_opts_schema)
+    fn payload, payment_required -> enrich(payload, payment_required, signer, opts) end
+  end
+
+  # -- Enrichment -------------------------------------------------------------
+
+  @spec enrich(map(), map() | nil, Signer.t(), keyword()) ::
+          {:ok, map()} | {:error, sign_error()}
+  defp enrich(payload, payment_required, signer, opts) do
+    if advertised?(payment_required) do
+      requirements = Utils.map_value(payload, {"accepted", :accepted}) || %{}
+
+      with {:ok, info} <- sign_permit(requirements, signer, opts) do
+        {:ok, put_info(payload, info)}
+      end
+    else
+      {:ok, payload}
+    end
+  end
+
+  @spec advertised?(term()) :: boolean()
+  defp advertised?(payment_required) when is_map(payment_required) do
+    case Utils.map_value(payment_required, {"extensions", :extensions}) do
+      extensions when is_map(extensions) -> Map.has_key?(extensions, @extension_key)
+      _extensions -> false
+    end
+  end
+
+  defp advertised?(_payment_required), do: false
+
+  # -- Signing helpers --------------------------------------------------------
+
+  @spec typed_data(map(), map()) :: Signer.typed_data()
+  defp typed_data(domain, permit) do
+    %{
+      "types" => @typed_data_types,
+      "primaryType" => "Permit",
+      "domain" => %{
+        "name" => Utils.map_value(domain, {"name", :name}),
+        "version" => Utils.map_value(domain, {"version", :version}),
+        "chainId" => Utils.map_value(domain, {"chainId", :chain_id}),
+        "verifyingContract" => Utils.map_value(domain, {"verifyingContract", :verifying_contract})
+      },
+      "message" => permit
+    }
+  end
+
+  @spec resolve_deadline(map(), keyword()) ::
+          {:ok, String.t()} | {:error, :invalid_deadline | :invalid_requirements}
+  defp resolve_deadline(requirements, opts) do
+    case Keyword.fetch(opts, :deadline) do
+      {:ok, deadline} ->
+        normalize_uint(deadline, :invalid_deadline)
+
+      :error ->
+        case Utils.map_value(requirements, {"maxTimeoutSeconds", :maxTimeoutSeconds}) do
+          timeout when is_integer(timeout) and timeout > 0 ->
+            {:ok, Integer.to_string(System.os_time(:second) + timeout)}
+
+          _timeout ->
+            {:error, :invalid_requirements}
+        end
+    end
+  end
+
+  @spec resolve_amount(map(), keyword()) ::
+          {:ok, String.t()} | {:error, :invalid_amount | :invalid_requirements}
+  defp resolve_amount(requirements, opts) do
+    case Keyword.fetch(opts, :amount) do
+      {:ok, amount} ->
+        normalize_uint(amount, :invalid_amount)
+
+      :error ->
+        case Utils.map_value(requirements, {"amount", :amount}) do
+          nil -> {:error, :invalid_requirements}
+          amount -> normalize_uint(amount, :invalid_amount)
+        end
+    end
+  end
+
+  @spec normalize_uint(term(), atom()) :: {:ok, String.t()} | {:error, atom()}
+  defp normalize_uint(value, _error) when is_integer(value) and value >= 0,
+    do: {:ok, Integer.to_string(value)}
+
+  defp normalize_uint(value, error) when is_binary(value) do
+    case Integer.parse(value) do
+      {integer, ""} when integer >= 0 -> {:ok, Integer.to_string(integer)}
+      _parsed -> {:error, error}
+    end
+  end
+
+  defp normalize_uint(_value, error), do: {:error, error}
+
+  @spec fetch_field(map(), {String.t(), atom()}) ::
+          {:ok, term()} | {:error, {:missing_field, String.t()}}
+  defp fetch_field(map, {string_key, _atom_key} = key) do
+    case Utils.map_value(map, key) do
+      nil -> {:error, {:missing_field, string_key}}
+      value -> {:ok, value}
+    end
+  end
+
+  # -- Info validation --------------------------------------------------------
+
+  @spec fetch_info(term()) :: {:ok, map()} | {:error, :extension_missing}
+  defp fetch_info(extensions) when is_map(extensions) do
+    with %{} = extension <- Map.get(extensions, @extension_key),
+         %{} = info <- Map.get(extension, "info") do
+      {:ok, info}
+    else
+      _missing -> {:error, :extension_missing}
+    end
+  end
+
+  defp fetch_info(_extensions), do: {:error, :extension_missing}
+
+  @spec ensure_fields_present(map()) :: :ok | {:error, {:missing_info_field, String.t()}}
+  defp ensure_fields_present(info) do
+    Enum.reduce_while(@required_fields, :ok, fn field, :ok ->
+      case Map.get(info, field) do
+        nil -> {:halt, {:error, {:missing_info_field, field}}}
+        "" -> {:halt, {:error, {:missing_info_field, field}}}
+        _value -> {:cont, :ok}
+      end
+    end)
+  end
+
+  @spec validate_field(String.t(), term()) ::
+          {:cont, :ok} | {:halt, {:error, {:invalid_info_field, String.t()}}}
+  defp validate_field(field, value) do
+    case valid_field?(field, value) do
+      true -> {:cont, :ok}
+      false -> {:halt, {:error, {:invalid_info_field, field}}}
+    end
+  end
+
+  @spec valid_field?(String.t(), term()) :: boolean()
+  defp valid_field?(field, value) when field in ~w(from asset spender),
+    do: Wallet.valid_evm?(value)
+
+  defp valid_field?(field, value) when field in ~w(amount nonce deadline),
+    do: is_binary(value) and value =~ ~r/^[0-9]+$/
+
+  defp valid_field?("signature", value),
+    do: is_binary(value) and value =~ ~r/^0x[a-fA-F0-9]+$/
+
+  defp valid_field?("version", value),
+    do: is_binary(value) and value =~ ~r/^[0-9]+(\.[0-9]+)*$/
+
+  # -- Payload helpers --------------------------------------------------------
+
+  @spec ensure_extensions(term()) :: map()
+  defp ensure_extensions(extensions) when is_map(extensions), do: extensions
+  defp ensure_extensions(_extensions), do: %{}
+
+  @spec ensure_declaration(term()) :: map()
+  defp ensure_declaration(declaration) when is_map(declaration), do: declaration
+  defp ensure_declaration(_declaration), do: %{}
+end

--- a/lib/x402/extensions/erc20_approval_gas_sponsoring.ex
+++ b/lib/x402/extensions/erc20_approval_gas_sponsoring.ex
@@ -1,0 +1,523 @@
+defmodule X402.Extensions.ERC20ApprovalGasSponsoring do
+  @moduledoc """
+  Builds and validates the `erc20ApprovalGasSponsoring` extension.
+
+  The extension enables a gasless [Permit2](https://github.com/Uniswap/permit2)
+  approval flow for ERC-20 tokens that do **not** implement EIP-2612. The
+  client signs — but does not broadcast — a normal EVM transaction calling
+  `approve(Permit2, amount)`; the facilitator funds the wallet's gas if
+  needed, broadcasts the approval, and settles via `x402Permit2Proxy` in one
+  atomic bundle.
+
+  Unlike `X402.Extensions.EIP2612GasSponsoring`, nothing here is EIP-712
+  typed data: the signed artifact is a full RLP-encoded transaction whose
+  `nonce` must match the wallet's current on-chain nonce and whose fees must
+  match live network prices. Producing it therefore requires chain access
+  and transaction-signing tooling outside this library — this module builds,
+  validates, and attaches the extension data *around* a pre-signed
+  transaction supplied by the caller.
+
+  Server side, `build_extension/0` declares support under
+  `extensions.erc20ApprovalGasSponsoring` in a `PAYMENT-REQUIRED` response,
+  and `extract_info/1` / `validate_info/1` check the client-populated data
+  echoed back in a `PaymentPayload`.
+
+  Client side, `build_info/1` assembles the wire info for a pre-signed
+  approval transaction, `put_info/2` attaches it to a payload's extensions,
+  and `enricher/1` packages both for `X402.Client.build_payment/3`:
+
+      {:ok, payload} =
+        X402.Client.build_payment(payment_required, signer,
+          extensions: [
+            X402.Extensions.ERC20ApprovalGasSponsoring.enricher(
+              from: wallet_address,
+              signed_transaction: signed_approve_tx_hex
+            )
+          ]
+        )
+
+  See the
+  [erc20ApprovalGasSponsoring extension spec](https://github.com/x402-foundation/x402/blob/main/specs/extensions/erc20_gas_sponsoring.md).
+  """
+
+  alias X402.Utils
+  alias X402.Wallet
+
+  @extension_key "erc20ApprovalGasSponsoring"
+  @permit2_address "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+  @info_version "1"
+  @schema_uri "https://json-schema.org/draft/2020-12/schema"
+  @max_uint256 Integer.to_string(Integer.pow(2, 256) - 1)
+
+  @required_fields ~w(from asset spender amount signedTransaction version)
+
+  @shared_opts [
+    from: [
+      type: :string,
+      required: true,
+      doc: "The address of the wallet that signed the approval transaction."
+    ],
+    signed_transaction: [
+      type: :string,
+      required: true,
+      doc: """
+      The RLP-encoded signed EIP-1559 transaction calling
+      `approve(spender, amount)`, as a `0x`-prefixed hex string. Its signer,
+      target contract, calldata, nonce, and fees are verified on-chain by the
+      facilitator.
+      """
+    ],
+    amount: [
+      type: {:or, [:non_neg_integer, :string]},
+      doc: """
+      The approval amount declared alongside the transaction, in atomic
+      units. Must match the amount in the transaction's calldata. Defaults
+      to MaxUint256, matching the reference client implementations.
+      """
+    ],
+    spender: [
+      type: :string,
+      doc: """
+      The approved spender declared alongside the transaction. Must match
+      the spender in the transaction's calldata. Defaults to the canonical
+      Permit2 contract.
+      """
+    ]
+  ]
+
+  @info_opts_schema @shared_opts ++
+                      [
+                        asset: [
+                          type: :string,
+                          required: true,
+                          doc: "The ERC-20 token contract the transaction approves."
+                        ]
+                      ]
+
+  @enrich_opts_schema @shared_opts ++
+                        [
+                          asset: [
+                            type: :string,
+                            doc: """
+                            The ERC-20 token contract the transaction
+                            approves. Defaults to the accepted payment
+                            requirements' `asset`.
+                            """
+                          ]
+                        ]
+
+  @typedoc "A built `extensions.erc20ApprovalGasSponsoring` declaration (`info` + `schema`)."
+  @type t :: %{binary() => map()}
+
+  @typedoc """
+  Client-populated extension info in wire shape: string keys `"from"`,
+  `"asset"`, `"spender"`, `"amount"`, `"signedTransaction"`, and
+  `"version"`.
+  """
+  @type info :: %{optional(binary()) => binary()}
+
+  @type info_error ::
+          :extension_missing
+          | {:missing_info_field, String.t()}
+          | {:invalid_info_field, String.t()}
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the extension key, `"erc20ApprovalGasSponsoring"`.
+
+  ## Examples
+
+      iex> X402.Extensions.ERC20ApprovalGasSponsoring.key()
+      "erc20ApprovalGasSponsoring"
+  """
+  @spec key() :: String.t()
+  def key, do: @extension_key
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the canonical Permit2 contract address — the default spender.
+
+  ## Examples
+
+      iex> X402.Extensions.ERC20ApprovalGasSponsoring.permit2_address()
+      "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+  """
+  @spec permit2_address() :: String.t()
+  def permit2_address, do: @permit2_address
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns MaxUint256 as a decimal string — the default approval amount.
+
+  ## Examples
+
+      iex> X402.Extensions.ERC20ApprovalGasSponsoring.max_uint256()
+      "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+  """
+  @spec max_uint256() :: String.t()
+  def max_uint256, do: @max_uint256
+
+  @doc since: "0.6.0"
+  @doc """
+  Builds the server-side extension declaration (`info` + `schema`).
+
+  Resource servers advertise support by placing the declaration under
+  `extensions.erc20ApprovalGasSponsoring` in a `PAYMENT-REQUIRED` response;
+  the client populates the actual approval data.
+
+  ## Examples
+
+      iex> ext = X402.Extensions.ERC20ApprovalGasSponsoring.build_extension()
+      iex> ext["info"]["version"]
+      "1"
+      iex> ext["schema"]["required"]
+      ["from", "asset", "spender", "amount", "signedTransaction", "version"]
+  """
+  @spec build_extension() :: t()
+  def build_extension do
+    %{
+      "info" => %{
+        "description" =>
+          "The facilitator accepts a raw signed approval transaction and will sponsor the gas fees.",
+        "version" => @info_version
+      },
+      "schema" => schema()
+    }
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the JSON Schema (Draft 2020-12) for the client-populated info.
+  """
+  @spec schema() :: map()
+  def schema do
+    %{
+      "$schema" => @schema_uri,
+      "type" => "object",
+      "properties" => %{
+        "from" => %{
+          "type" => "string",
+          "pattern" => "^0x[a-fA-F0-9]{40}$",
+          "description" => "The address of the sender."
+        },
+        "asset" => %{
+          "type" => "string",
+          "pattern" => "^0x[a-fA-F0-9]{40}$",
+          "description" => "The ERC-20 token contract address to approve."
+        },
+        "spender" => %{
+          "type" => "string",
+          "pattern" => "^0x[a-fA-F0-9]{40}$",
+          "description" => "The address of the spender (Canonical Permit2)."
+        },
+        "amount" => %{
+          "type" => "string",
+          "pattern" => "^[0-9]+$",
+          "description" => "Approval amount (uint256). Typically MaxUint."
+        },
+        "signedTransaction" => %{
+          "type" => "string",
+          "pattern" => "^0x[a-fA-F0-9]+$",
+          "description" => "RLP-encoded signed transaction calling ERC20.approve()."
+        },
+        "version" => %{
+          "type" => "string",
+          "pattern" => "^[0-9]+(\\.[0-9]+)*$",
+          "description" => "Schema version identifier."
+        }
+      },
+      "required" => @required_fields
+    }
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Builds the client-populated info for a pre-signed approval transaction.
+
+  Validates the declared fields structurally (the transaction itself is
+  opaque to this library — the facilitator decodes and verifies it against
+  the declared `from`, `asset`, `spender`, and `amount`) and returns the
+  wire-shaped info, ready for `put_info/2`.
+
+  ## Options
+
+  #{NimbleOptions.docs(@info_opts_schema)}
+
+  ## Examples
+
+      iex> {:ok, info} =
+      ...>   X402.Extensions.ERC20ApprovalGasSponsoring.build_info(
+      ...>     from: "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+      ...>     asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      ...>     signed_transaction: "0x02f8" <> String.duplicate("ab", 100)
+      ...>   )
+      iex> info["spender"]
+      "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+      iex> info["version"]
+      "1"
+
+      iex> X402.Extensions.ERC20ApprovalGasSponsoring.build_info(
+      ...>   from: "0x123",
+      ...>   asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      ...>   signed_transaction: "0xabcd"
+      ...> )
+      {:error, {:invalid_info_field, "from"}}
+  """
+  @spec build_info(keyword()) :: {:ok, info()} | {:error, {:invalid_info_field, String.t()}}
+  def build_info(opts) when is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @info_opts_schema)
+
+    from = Keyword.fetch!(opts, :from)
+    asset = Keyword.fetch!(opts, :asset)
+    spender = Keyword.get(opts, :spender, @permit2_address)
+    signed_transaction = Keyword.fetch!(opts, :signed_transaction)
+
+    with :ok <- validate_address("from", from),
+         :ok <- validate_address("asset", asset),
+         :ok <- validate_address("spender", spender),
+         {:ok, amount} <- normalize_amount(Keyword.get(opts, :amount, @max_uint256)),
+         :ok <- validate_signed_transaction(signed_transaction) do
+      {:ok,
+       %{
+         "from" => from,
+         "asset" => asset,
+         "spender" => spender,
+         "amount" => amount,
+         "signedTransaction" => signed_transaction,
+         "version" => @info_version
+       }}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Attaches client-populated info to a payload's extensions.
+
+  Places the info under `extensions.erc20ApprovalGasSponsoring.info`,
+  following the append-only rule: when the payload already echoes the
+  server's declaration, server-declared info fields are preserved (they win
+  over client values) and the declared `schema` is kept; the client's
+  fields are added alongside them.
+
+  ## Examples
+
+      iex> info = %{"from" => "0x1111111111111111111111111111111111111111"}
+      iex> payload = X402.Extensions.ERC20ApprovalGasSponsoring.put_info(%{"payload" => %{}}, info)
+      iex> payload["extensions"]["erc20ApprovalGasSponsoring"]["info"]["from"]
+      "0x1111111111111111111111111111111111111111"
+  """
+  @spec put_info(map(), info()) :: map()
+  def put_info(payload, info) when is_map(payload) and is_map(info) do
+    extensions = ensure_map(Utils.map_value(payload, {"extensions", :extensions}))
+    declaration = ensure_map(Map.get(extensions, @extension_key))
+    server_info = ensure_map(Map.get(declaration, "info"))
+    merged = Map.put(declaration, "info", Map.merge(info, server_info))
+    Map.put(payload, "extensions", Map.put(extensions, @extension_key, merged))
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Extracts the client-populated info from a `PaymentPayload` map.
+
+  Returns the info when the extension is present and every required field
+  is populated. Field formats are not checked here — see `validate_info/1`.
+
+  ## Examples
+
+      iex> X402.Extensions.ERC20ApprovalGasSponsoring.extract_info(%{"payload" => %{}})
+      {:error, :extension_missing}
+  """
+  @spec extract_info(map()) :: {:ok, info()} | {:error, info_error()}
+  def extract_info(payload) when is_map(payload) do
+    extensions = Utils.map_value(payload, {"extensions", :extensions})
+
+    with {:ok, info} <- fetch_info(extensions),
+         :ok <- ensure_fields_present(info) do
+      {:ok, info}
+    end
+  end
+
+  def extract_info(_payload), do: {:error, :extension_missing}
+
+  @doc since: "0.6.0"
+  @doc """
+  Validates the format of client-populated info.
+
+  Checks that addresses match `^0x[a-fA-F0-9]{40}$`, that `amount` is a
+  decimal string, that `signedTransaction` is a `0x`-prefixed hex string,
+  and that `version` is a dotted numeric version.
+
+  ## Examples
+
+      iex> X402.Extensions.ERC20ApprovalGasSponsoring.validate_info(%{
+      ...>   "from" => "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+      ...>   "asset" => "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      ...>   "spender" => "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+      ...>   "amount" => "10000",
+      ...>   "signedTransaction" => "0xabcdef",
+      ...>   "version" => "1"
+      ...> })
+      :ok
+
+      iex> X402.Extensions.ERC20ApprovalGasSponsoring.validate_info(%{"from" => "0x123"})
+      {:error, {:invalid_info_field, "from"}}
+  """
+  @spec validate_info(term()) :: :ok | {:error, info_error()}
+  def validate_info(info) when is_map(info) do
+    Enum.reduce_while(@required_fields, :ok, fn field, :ok ->
+      case Map.get(info, field) do
+        nil -> {:halt, {:error, {:missing_info_field, field}}}
+        value -> validate_field(field, value)
+      end
+    end)
+  end
+
+  def validate_info(_info), do: {:error, :extension_missing}
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns an enricher for `X402.Client.build_payment/3`'s `:extensions`.
+
+  The enricher attaches the pre-signed approval transaction via
+  `build_info/1` and `put_info/2` — but only when the server advertised
+  `erc20ApprovalGasSponsoring` in the `PaymentRequired` extensions;
+  otherwise the payload passes through unchanged. `:asset` defaults to the
+  accepted requirements' `asset`.
+
+  ## Options
+
+  #{NimbleOptions.docs(@enrich_opts_schema)}
+  """
+  @spec enricher(keyword()) ::
+          (map(), map() | nil ->
+             {:ok, map()} | {:error, {:invalid_info_field, String.t()} | :invalid_requirements})
+  def enricher(opts) when is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @enrich_opts_schema)
+    fn payload, payment_required -> enrich(payload, payment_required, opts) end
+  end
+
+  # -- Enrichment -------------------------------------------------------------
+
+  @spec enrich(map(), map() | nil, keyword()) ::
+          {:ok, map()} | {:error, {:invalid_info_field, String.t()} | :invalid_requirements}
+  defp enrich(payload, payment_required, opts) do
+    if advertised?(payment_required) do
+      with {:ok, opts} <- resolve_asset(opts, payload),
+           {:ok, info} <- build_info(opts) do
+        {:ok, put_info(payload, info)}
+      end
+    else
+      {:ok, payload}
+    end
+  end
+
+  @spec resolve_asset(keyword(), map()) :: {:ok, keyword()} | {:error, :invalid_requirements}
+  defp resolve_asset(opts, payload) do
+    if Keyword.has_key?(opts, :asset) do
+      {:ok, opts}
+    else
+      requirements = Utils.map_value(payload, {"accepted", :accepted}) || %{}
+
+      case Utils.map_value(requirements, {"asset", :asset}) do
+        asset when is_binary(asset) and asset != "" -> {:ok, Keyword.put(opts, :asset, asset)}
+        _asset -> {:error, :invalid_requirements}
+      end
+    end
+  end
+
+  @spec advertised?(term()) :: boolean()
+  defp advertised?(payment_required) when is_map(payment_required) do
+    case Utils.map_value(payment_required, {"extensions", :extensions}) do
+      extensions when is_map(extensions) -> Map.has_key?(extensions, @extension_key)
+      _extensions -> false
+    end
+  end
+
+  defp advertised?(_payment_required), do: false
+
+  # -- Info validation --------------------------------------------------------
+
+  @spec validate_address(String.t(), term()) ::
+          :ok | {:error, {:invalid_info_field, String.t()}}
+  defp validate_address(field, value) do
+    case Wallet.valid_evm?(value) do
+      true -> :ok
+      false -> {:error, {:invalid_info_field, field}}
+    end
+  end
+
+  @spec normalize_amount(term()) ::
+          {:ok, String.t()} | {:error, {:invalid_info_field, String.t()}}
+  defp normalize_amount(value) when is_integer(value) and value >= 0,
+    do: {:ok, Integer.to_string(value)}
+
+  defp normalize_amount(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {integer, ""} when integer >= 0 -> {:ok, Integer.to_string(integer)}
+      _parsed -> {:error, {:invalid_info_field, "amount"}}
+    end
+  end
+
+  defp normalize_amount(_value), do: {:error, {:invalid_info_field, "amount"}}
+
+  @spec validate_signed_transaction(term()) ::
+          :ok | {:error, {:invalid_info_field, String.t()}}
+  defp validate_signed_transaction(value) do
+    if is_binary(value) and value =~ ~r/^0x[a-fA-F0-9]+$/ do
+      :ok
+    else
+      {:error, {:invalid_info_field, "signedTransaction"}}
+    end
+  end
+
+  @spec fetch_info(term()) :: {:ok, map()} | {:error, :extension_missing}
+  defp fetch_info(extensions) when is_map(extensions) do
+    with %{} = extension <- Map.get(extensions, @extension_key),
+         %{} = info <- Map.get(extension, "info") do
+      {:ok, info}
+    else
+      _missing -> {:error, :extension_missing}
+    end
+  end
+
+  defp fetch_info(_extensions), do: {:error, :extension_missing}
+
+  @spec ensure_fields_present(map()) :: :ok | {:error, {:missing_info_field, String.t()}}
+  defp ensure_fields_present(info) do
+    Enum.reduce_while(@required_fields, :ok, fn field, :ok ->
+      case Map.get(info, field) do
+        nil -> {:halt, {:error, {:missing_info_field, field}}}
+        "" -> {:halt, {:error, {:missing_info_field, field}}}
+        _value -> {:cont, :ok}
+      end
+    end)
+  end
+
+  @spec validate_field(String.t(), term()) ::
+          {:cont, :ok} | {:halt, {:error, {:invalid_info_field, String.t()}}}
+  defp validate_field(field, value) do
+    case valid_field?(field, value) do
+      true -> {:cont, :ok}
+      false -> {:halt, {:error, {:invalid_info_field, field}}}
+    end
+  end
+
+  @spec valid_field?(String.t(), term()) :: boolean()
+  defp valid_field?(field, value) when field in ~w(from asset spender),
+    do: Wallet.valid_evm?(value)
+
+  defp valid_field?("amount", value),
+    do: is_binary(value) and value =~ ~r/^[0-9]+$/
+
+  defp valid_field?("signedTransaction", value),
+    do: is_binary(value) and value =~ ~r/^0x[a-fA-F0-9]+$/
+
+  defp valid_field?("version", value),
+    do: is_binary(value) and value =~ ~r/^[0-9]+(\.[0-9]+)*$/
+
+  # -- Payload helpers --------------------------------------------------------
+
+  @spec ensure_map(term()) :: map()
+  defp ensure_map(value) when is_map(value), do: value
+  defp ensure_map(_value), do: %{}
+end

--- a/mix.exs
+++ b/mix.exs
@@ -157,6 +157,7 @@ defmodule X402.MixProject do
         Extensions: [
           X402.Extensions.Bazaar,
           X402.Extensions.EIP2612GasSponsoring,
+          X402.Extensions.ERC20ApprovalGasSponsoring,
           X402.Extensions.SIWX,
           X402.Extensions.SIWX.Verifier,
           X402.Extensions.SIWX.Verifier.Default,

--- a/mix.exs
+++ b/mix.exs
@@ -136,7 +136,8 @@ defmodule X402.MixProject do
           X402.Client.Finch,
           X402.Signer,
           X402.Signer.LocalKey,
-          X402.EIP3009
+          X402.EIP3009,
+          X402.EIP712
         ],
         "Facilitator Client": [
           X402.Facilitator,

--- a/mix.exs
+++ b/mix.exs
@@ -156,6 +156,7 @@ defmodule X402.MixProject do
         ],
         Extensions: [
           X402.Extensions.Bazaar,
+          X402.Extensions.EIP2612GasSponsoring,
           X402.Extensions.SIWX,
           X402.Extensions.SIWX.Verifier,
           X402.Extensions.SIWX.Verifier.Default,

--- a/test/x402/client/finch_test.exs
+++ b/test/x402/client/finch_test.exs
@@ -96,6 +96,52 @@ defmodule X402.Client.FinchTest do
       assert payload["payload"]["authorization"]["to"] == @receiver
     end
 
+    test "forwards :extensions enrichers to build_payment", %{
+      bypass: bypass,
+      finch: finch,
+      signer: signer
+    } do
+      alias X402.Extensions.EIP2612GasSponsoring
+
+      test_pid = self()
+
+      payment_required =
+        Map.put(@payment_required, "extensions", %{
+          "eip2612GasSponsoring" => EIP2612GasSponsoring.build_extension()
+        })
+
+      Bypass.expect(bypass, "GET", "/sponsored", fn conn ->
+        case Conn.get_req_header(conn, "payment-signature") do
+          [] ->
+            {:ok, header} = PaymentRequired.encode(payment_required)
+
+            conn
+            |> Conn.put_resp_header("payment-required", header)
+            |> Conn.resp(402, "{}")
+
+          [header] ->
+            send(test_pid, {:payment_header, header})
+            {:ok, response_header} = PaymentResponse.encode(@settlement)
+
+            conn
+            |> Conn.put_resp_header("payment-response", response_header)
+            |> Conn.resp(200, "{}")
+        end
+      end)
+
+      assert {:ok, %{status: 200}} =
+               FinchClient.request(finch, url(bypass, "/sponsored"),
+                 signer: signer,
+                 extensions: [EIP2612GasSponsoring.enricher(signer, nonce: "0")]
+               )
+
+      assert_received {:payment_header, header}
+      assert {:ok, payload} = PaymentSignature.decode(header)
+      assert {:ok, info} = EIP2612GasSponsoring.extract_info(payload)
+      assert EIP2612GasSponsoring.validate_info(info) == :ok
+      assert info["from"] == signer.address
+    end
+
     test "returns non-402 responses untouched, without paying", %{
       bypass: bypass,
       finch: finch,

--- a/test/x402/client_test.exs
+++ b/test/x402/client_test.exs
@@ -263,6 +263,100 @@ defmodule X402.ClientTest do
     end
   end
 
+  describe "build_payment/3 :extensions" do
+    test "applies enrichers in order with the original payment_required" do
+      test_pid = self()
+
+      first = fn payload, payment_required ->
+        send(test_pid, {:first, payment_required})
+        {:ok, Map.put(payload, "first", true)}
+      end
+
+      second = fn payload, _payment_required ->
+        assert payload["first"] == true
+        {:ok, Map.put(payload, "second", true)}
+      end
+
+      assert {:ok, payload} =
+               Client.build_payment(@payment_required, signer(), extensions: [first, second])
+
+      assert payload["first"] == true
+      assert payload["second"] == true
+      assert_received {:first, @payment_required}
+    end
+
+    test "passes nil as payment_required for bare requirements" do
+      test_pid = self()
+
+      enricher = fn payload, payment_required ->
+        send(test_pid, {:enriched, payment_required})
+        {:ok, payload}
+      end
+
+      assert {:ok, _payload} =
+               Client.build_payment(@evm_requirements, signer(), extensions: [enricher])
+
+      assert_received {:enriched, nil}
+    end
+
+    test "propagates enricher errors and rejects invalid returns" do
+      failing = fn _payload, _payment_required -> {:error, :nope} end
+
+      assert Client.build_payment(@payment_required, signer(), extensions: [failing]) ==
+               {:error, :nope}
+
+      invalid = fn _payload, _payment_required -> :what end
+
+      assert Client.build_payment(@payment_required, signer(), extensions: [invalid]) ==
+               {:error, {:invalid_extension_result, :what}}
+    end
+
+    test "produces a valid eip2612GasSponsoring extension end to end" do
+      alias X402.Extensions.EIP2612GasSponsoring
+
+      signer = signer()
+
+      payment_required =
+        Map.put(@payment_required, "extensions", %{
+          "eip2612GasSponsoring" => EIP2612GasSponsoring.build_extension()
+        })
+
+      assert {:ok, payload} =
+               Client.build_payment(payment_required, signer,
+                 extensions: [EIP2612GasSponsoring.enricher(signer, nonce: "0")]
+               )
+
+      # the scheme payload and echo are untouched
+      assert PaymentRequirements.validate(payload["accepted"]) == :ok
+      assert %{"signature" => _, "authorization" => _} = payload["payload"]
+
+      extension = payload["extensions"]["eip2612GasSponsoring"]
+      assert extension["schema"] == EIP2612GasSponsoring.schema()
+
+      assert {:ok, info} = EIP2612GasSponsoring.extract_info(payload)
+      assert EIP2612GasSponsoring.validate_info(info) == :ok
+      assert info["from"] == signer.address
+      assert info["asset"] == @contract
+
+      # header round-trip keeps the extension intact
+      {:ok, header} = Client.encode_payment(payload)
+      assert PaymentSignature.decode(header) == {:ok, payload}
+    end
+
+    test "eip2612 enricher is a no-op when the server does not advertise it" do
+      alias X402.Extensions.EIP2612GasSponsoring
+
+      signer = signer()
+
+      assert {:ok, payload} =
+               Client.build_payment(@payment_required, signer,
+                 extensions: [EIP2612GasSponsoring.enricher(signer, nonce: "0")]
+               )
+
+      assert payload["extensions"] == %{}
+    end
+  end
+
   describe "encode_payment/1" do
     test "returns invalid_json for unencodable payloads" do
       assert Client.encode_payment(%{"pid" => self()}) == {:error, :invalid_json}

--- a/test/x402/eip712_test.exs
+++ b/test/x402/eip712_test.exs
@@ -1,0 +1,129 @@
+defmodule X402.EIP712Test do
+  use ExUnit.Case, async: true
+
+  doctest X402.EIP712
+
+  alias X402.EIP712
+  alias X402.TestPayments
+
+  @contract "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+
+  @domain %{
+    name: "USDC",
+    version: "2",
+    chain_id: 84_532,
+    verifying_contract: @contract
+  }
+
+  @requirements %{
+    "scheme" => "exact",
+    "network" => "eip155:84532",
+    "amount" => "10000",
+    "asset" => @contract,
+    "payTo" => "0x2222222222222222222222222222222222222222",
+    "maxTimeoutSeconds" => 300,
+    "extra" => %{"name" => "USDC", "version" => "2"}
+  }
+
+  describe "domain/1" do
+    test "derives the domain from requirements" do
+      assert EIP712.domain(@requirements) == {:ok, @domain}
+    end
+
+    test "does not restrict the assetTransferMethod" do
+      for method <- ["eip3009", "permit2"] do
+        requirements = put_in(@requirements, ["extra", "assetTransferMethod"], method)
+        assert EIP712.domain(requirements) == {:ok, @domain}
+      end
+    end
+
+    test "requires extra.name and extra.version" do
+      assert EIP712.domain(Map.put(@requirements, "extra", %{"version" => "2"})) ==
+               {:error, {:missing_extra, "name"}}
+
+      assert EIP712.domain(Map.put(@requirements, "extra", %{"name" => "USDC"})) ==
+               {:error, {:missing_extra, "version"}}
+    end
+
+    test "rejects non-EVM networks and malformed requirements" do
+      solana = Map.put(@requirements, "network", "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp")
+      assert EIP712.domain(solana) == {:error, :unsupported_network}
+
+      assert EIP712.domain("not a map") == {:error, :invalid_requirements}
+
+      assert EIP712.domain(Map.put(@requirements, "extra", "nope")) ==
+               {:error, :invalid_requirements}
+
+      assert EIP712.domain(Map.delete(@requirements, "asset")) == {:error, :invalid_requirements}
+    end
+  end
+
+  describe "domain_separator/1" do
+    test "accepts wire-style and internal keys" do
+      wire_domain = %{
+        "name" => "USDC",
+        "version" => "2",
+        "chainId" => 84_532,
+        "verifyingContract" => @contract
+      }
+
+      assert {:ok, separator} = EIP712.domain_separator(@domain)
+      assert byte_size(separator) == 32
+      assert EIP712.domain_separator(wire_domain) == {:ok, separator}
+    end
+
+    test "returns structured errors for missing or malformed fields" do
+      assert EIP712.domain_separator(Map.delete(@domain, :chain_id)) ==
+               {:error, {:missing_field, "chainId"}}
+
+      assert EIP712.domain_separator(%{@domain | verifying_contract: "0xnope"}) ==
+               {:error, :invalid_address}
+    end
+  end
+
+  describe "hash_struct/2 and digest/2" do
+    test "reproduce the EIP-3009 digest for the same vectors" do
+      authorization = %{
+        from: "0x1111111111111111111111111111111111111111",
+        to: "0x2222222222222222222222222222222222222222",
+        value: "1",
+        valid_after: "0",
+        valid_before: "9999999999",
+        nonce: "0x" <> String.duplicate("ab", 32)
+      }
+
+      type =
+        "TransferWithAuthorization(address from,address to,uint256 value," <>
+          "uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+
+      {:ok, from_word} = EIP712.encode_address(authorization.from)
+      {:ok, to_word} = EIP712.encode_address(authorization.to)
+      {:ok, value_word} = EIP712.encode_uint256(authorization.value)
+      {:ok, valid_after_word} = EIP712.encode_uint256(authorization.valid_after)
+      {:ok, valid_before_word} = EIP712.encode_uint256(authorization.valid_before)
+      {:ok, nonce_word} = EIP712.encode_bytes32(authorization.nonce)
+
+      {:ok, struct_hash} =
+        EIP712.hash_struct(type, [
+          from_word,
+          to_word,
+          value_word,
+          valid_after_word,
+          valid_before_word,
+          nonce_word
+        ])
+
+      assert {:ok, digest} = EIP712.digest(@domain, struct_hash)
+      assert digest == TestPayments.eip712_digest(@domain, authorization)
+    end
+
+    test "hash_struct/2 rejects words that are not 32 bytes" do
+      assert EIP712.hash_struct("Permit()", [<<1, 2, 3>>]) == {:error, :invalid_word}
+      assert EIP712.hash_struct("Permit()", [:not_a_word]) == {:error, :invalid_word}
+    end
+
+    test "digest/2 propagates domain errors" do
+      assert EIP712.digest(%{}, <<0::256>>) == {:error, {:missing_field, "name"}}
+    end
+  end
+end

--- a/test/x402/extensions/eip2612_gas_sponsoring_test.exs
+++ b/test/x402/extensions/eip2612_gas_sponsoring_test.exs
@@ -1,0 +1,338 @@
+defmodule X402.Extensions.EIP2612GasSponsoringTest do
+  use ExUnit.Case, async: true
+
+  doctest X402.Extensions.EIP2612GasSponsoring
+
+  alias X402.EIP3009
+  alias X402.EIP712
+  alias X402.Extensions.EIP2612GasSponsoring
+  alias X402.Signer.LocalKey
+
+  @receiver "0x209693Bc6afc0C5328bA36FaF03C514EF312287C"
+  @contract "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+  @permit2 "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+  @max_uint256 "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+
+  @requirements %{
+    "scheme" => "exact",
+    "network" => "eip155:84532",
+    "amount" => "10000",
+    "asset" => @contract,
+    "payTo" => @receiver,
+    "maxTimeoutSeconds" => 60,
+    "extra" => %{"assetTransferMethod" => "permit2", "name" => "USDC", "version" => "2"}
+  }
+
+  @valid_info %{
+    "from" => "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+    "asset" => @contract,
+    "spender" => @permit2,
+    "amount" => @max_uint256,
+    "nonce" => "0",
+    "deadline" => "1740672154",
+    "signature" => "0x" <> String.duplicate("ab", 65),
+    "version" => "1"
+  }
+
+  defp signer do
+    {:ok, signer} = LocalKey.new(:crypto.strong_rand_bytes(32))
+    signer
+  end
+
+  describe "build_extension/0" do
+    test "matches the spec's declaration shape" do
+      extension = EIP2612GasSponsoring.build_extension()
+
+      assert extension["info"] == %{
+               "description" =>
+                 "The facilitator accepts EIP-2612 gasless Permit to `Permit2` canonical contract.",
+               "version" => "1"
+             }
+
+      assert extension["schema"] == EIP2612GasSponsoring.schema()
+    end
+
+    test "the schema declares the spec's exact property names and patterns" do
+      schema = EIP2612GasSponsoring.schema()
+
+      assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+      assert schema["type"] == "object"
+
+      assert Map.keys(schema["properties"]) |> Enum.sort() ==
+               Enum.sort(~w(from asset spender amount nonce deadline signature version))
+
+      assert schema["required"] ==
+               ~w(from asset spender amount nonce deadline signature version)
+
+      for field <- ~w(from asset spender) do
+        assert schema["properties"][field]["pattern"] == "^0x[a-fA-F0-9]{40}$"
+      end
+
+      for field <- ~w(amount nonce deadline) do
+        assert schema["properties"][field]["pattern"] == "^[0-9]+$"
+      end
+
+      assert schema["properties"]["signature"]["pattern"] == "^0x[a-fA-F0-9]+$"
+      assert schema["properties"]["version"]["pattern"] == "^[0-9]+(\\.[0-9]+)*$"
+    end
+
+    test "round-trips through JSON" do
+      assert {:ok, json} = Jason.encode(EIP2612GasSponsoring.build_extension())
+      assert {:ok, _decoded} = Jason.decode(json)
+    end
+  end
+
+  describe "sign_permit/3" do
+    test "produces spec-shaped info with a recoverable signature" do
+      signer = signer()
+
+      assert {:ok, info} =
+               EIP2612GasSponsoring.sign_permit(@requirements, signer,
+                 nonce: "7",
+                 deadline: "1740672154"
+               )
+
+      assert Map.keys(info) |> Enum.sort() ==
+               Enum.sort(~w(from asset spender amount nonce deadline signature version))
+
+      assert info["from"] == signer.address
+      assert info["asset"] == @contract
+      assert info["spender"] == @permit2
+      assert info["amount"] == "10000"
+      assert info["nonce"] == "7"
+      assert info["deadline"] == "1740672154"
+      assert info["version"] == "1"
+      assert String.match?(info["signature"], ~r/^0x[0-9a-f]{130}$/)
+      assert EIP2612GasSponsoring.validate_info(info) == :ok
+
+      {:ok, domain} = EIP712.domain(@requirements)
+
+      {:ok, digest} =
+        EIP2612GasSponsoring.permit_digest(domain, %{
+          "owner" => info["from"],
+          "spender" => info["spender"],
+          "value" => info["amount"],
+          "nonce" => info["nonce"],
+          "deadline" => info["deadline"]
+        })
+
+      assert EIP3009.recover_signer(digest, info["signature"]) == {:ok, signer.address}
+    end
+
+    test "defaults the deadline to now + maxTimeoutSeconds" do
+      now = System.os_time(:second)
+
+      assert {:ok, info} = EIP2612GasSponsoring.sign_permit(@requirements, signer(), nonce: 0)
+      assert_in_delta String.to_integer(info["deadline"]), now + 60, 2
+    end
+
+    test "honors amount and spender overrides" do
+      spender = "0x3333333333333333333333333333333333333333"
+
+      assert {:ok, info} =
+               EIP2612GasSponsoring.sign_permit(@requirements, signer(),
+                 nonce: 1,
+                 amount: @max_uint256,
+                 spender: spender
+               )
+
+      assert info["amount"] == @max_uint256
+      assert info["spender"] == spender
+    end
+
+    test "normalizes integer options to decimal strings" do
+      assert {:ok, info} =
+               EIP2612GasSponsoring.sign_permit(@requirements, signer(),
+                 nonce: 3,
+                 deadline: 1_740_672_154,
+                 amount: 10_000
+               )
+
+      assert info["nonce"] == "3"
+      assert info["deadline"] == "1740672154"
+      assert info["amount"] == "10000"
+    end
+
+    test "rejects malformed nonce, deadline, and amount strings" do
+      signer = signer()
+
+      assert EIP2612GasSponsoring.sign_permit(@requirements, signer, nonce: "abc") ==
+               {:error, :invalid_nonce}
+
+      assert EIP2612GasSponsoring.sign_permit(@requirements, signer,
+               nonce: "0",
+               deadline: "soon"
+             ) == {:error, :invalid_deadline}
+
+      assert EIP2612GasSponsoring.sign_permit(@requirements, signer,
+               nonce: "0",
+               amount: "-1"
+             ) == {:error, :invalid_amount}
+    end
+
+    test "propagates domain and signer errors" do
+      missing_extra = Map.put(@requirements, "extra", %{"version" => "2"})
+
+      assert EIP2612GasSponsoring.sign_permit(missing_extra, signer(), nonce: "0") ==
+               {:error, {:missing_extra, "name"}}
+
+      assert EIP2612GasSponsoring.sign_permit(@requirements, :not_a_signer, nonce: "0") ==
+               {:error, :invalid_signer}
+    end
+
+    test "requires the nonce option" do
+      assert_raise NimbleOptions.ValidationError, fn ->
+        EIP2612GasSponsoring.sign_permit(@requirements, signer(), [])
+      end
+    end
+  end
+
+  describe "put_info/2" do
+    test "creates the extensions entry when absent" do
+      payload = EIP2612GasSponsoring.put_info(%{"payload" => %{}}, @valid_info)
+
+      assert payload["extensions"]["eip2612GasSponsoring"] == %{"info" => @valid_info}
+    end
+
+    test "preserves the echoed server declaration, server fields winning" do
+      declaration = EIP2612GasSponsoring.build_extension()
+
+      payload = %{
+        "payload" => %{},
+        "extensions" => %{
+          "eip2612GasSponsoring" => declaration,
+          "other" => %{"info" => %{}}
+        }
+      }
+
+      enriched = EIP2612GasSponsoring.put_info(payload, @valid_info)
+      extension = enriched["extensions"]["eip2612GasSponsoring"]
+
+      assert extension["schema"] == declaration["schema"]
+      assert extension["info"]["description"] == declaration["info"]["description"]
+      assert extension["info"]["version"] == declaration["info"]["version"]
+      assert extension["info"]["from"] == @valid_info["from"]
+      assert extension["info"]["signature"] == @valid_info["signature"]
+      assert enriched["extensions"]["other"] == %{"info" => %{}}
+    end
+  end
+
+  describe "extract_info/1" do
+    test "returns the info from a payment payload" do
+      payload = EIP2612GasSponsoring.put_info(%{"payload" => %{}}, @valid_info)
+
+      assert EIP2612GasSponsoring.extract_info(payload) == {:ok, @valid_info}
+    end
+
+    test "rejects payloads without the extension" do
+      assert EIP2612GasSponsoring.extract_info(%{}) == {:error, :extension_missing}
+
+      assert EIP2612GasSponsoring.extract_info(%{"extensions" => %{}}) ==
+               {:error, :extension_missing}
+
+      assert EIP2612GasSponsoring.extract_info(%{
+               "extensions" => %{"eip2612GasSponsoring" => %{}}
+             }) == {:error, :extension_missing}
+
+      assert EIP2612GasSponsoring.extract_info(%{
+               "extensions" => %{"eip2612GasSponsoring" => "nope"}
+             }) == {:error, :extension_missing}
+
+      assert EIP2612GasSponsoring.extract_info("nope") == {:error, :extension_missing}
+    end
+
+    test "rejects info with missing or empty fields" do
+      for field <- ~w(from asset spender amount nonce deadline signature version) do
+        payload =
+          EIP2612GasSponsoring.put_info(%{"payload" => %{}}, Map.delete(@valid_info, field))
+
+        assert EIP2612GasSponsoring.extract_info(payload) ==
+                 {:error, {:missing_info_field, field}}
+      end
+
+      payload = EIP2612GasSponsoring.put_info(%{"payload" => %{}}, %{@valid_info | "from" => ""})
+      assert EIP2612GasSponsoring.extract_info(payload) == {:error, {:missing_info_field, "from"}}
+    end
+  end
+
+  describe "validate_info/1" do
+    test "accepts the spec's example info" do
+      assert EIP2612GasSponsoring.validate_info(@valid_info) == :ok
+    end
+
+    test "rejects malformed fields" do
+      cases = [
+        {"from", "0x123"},
+        {"asset", "not-an-address"},
+        {"spender", "0x" <> String.duplicate("g", 40)},
+        {"amount", "10.5"},
+        {"nonce", "-1"},
+        {"deadline", "tomorrow"},
+        {"signature", "abcdef"},
+        {"version", "v1"}
+      ]
+
+      for {field, value} <- cases do
+        assert EIP2612GasSponsoring.validate_info(%{@valid_info | field => value}) ==
+                 {:error, {:invalid_info_field, field}}
+      end
+    end
+
+    test "rejects missing fields and non-maps" do
+      assert EIP2612GasSponsoring.validate_info(Map.delete(@valid_info, "nonce")) ==
+               {:error, {:missing_info_field, "nonce"}}
+
+      assert EIP2612GasSponsoring.validate_info("nope") == {:error, :extension_missing}
+    end
+  end
+
+  describe "enricher/2" do
+    test "signs and attaches the extension when the server advertises it" do
+      signer = signer()
+
+      payment_required = %{
+        "x402Version" => 2,
+        "accepts" => [@requirements],
+        "extensions" => %{"eip2612GasSponsoring" => EIP2612GasSponsoring.build_extension()}
+      }
+
+      payload = %{
+        "x402Version" => 2,
+        "accepted" => @requirements,
+        "payload" => %{},
+        "extensions" => payment_required["extensions"]
+      }
+
+      enricher = EIP2612GasSponsoring.enricher(signer, nonce: "0", deadline: "1740672154")
+
+      assert {:ok, enriched} = enricher.(payload, payment_required)
+      assert {:ok, info} = EIP2612GasSponsoring.extract_info(enriched)
+      assert EIP2612GasSponsoring.validate_info(info) == :ok
+      assert info["from"] == signer.address
+    end
+
+    test "passes the payload through when the extension is not advertised" do
+      payload = %{"accepted" => @requirements, "payload" => %{}}
+      enricher = EIP2612GasSponsoring.enricher(signer(), nonce: "0")
+
+      assert enricher.(payload, %{"accepts" => [@requirements]}) == {:ok, payload}
+      assert enricher.(payload, nil) == {:ok, payload}
+    end
+
+    test "propagates signing errors" do
+      payment_required = %{
+        "accepts" => [@requirements],
+        "extensions" => %{"eip2612GasSponsoring" => EIP2612GasSponsoring.build_extension()}
+      }
+
+      payload = %{
+        "accepted" => Map.put(@requirements, "extra", %{"version" => "2"}),
+        "payload" => %{}
+      }
+
+      enricher = EIP2612GasSponsoring.enricher(signer(), nonce: "0")
+
+      assert enricher.(payload, payment_required) == {:error, {:missing_extra, "name"}}
+    end
+  end
+end

--- a/test/x402/extensions/erc20_approval_gas_sponsoring_test.exs
+++ b/test/x402/extensions/erc20_approval_gas_sponsoring_test.exs
@@ -1,0 +1,307 @@
+defmodule X402.Extensions.ERC20ApprovalGasSponsoringTest do
+  use ExUnit.Case, async: true
+
+  doctest X402.Extensions.ERC20ApprovalGasSponsoring
+
+  alias X402.Extensions.ERC20ApprovalGasSponsoring
+
+  @from "0x857b06519E91e3A54538791bDbb0E22373e36b66"
+  @contract "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+  @permit2 "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+  @max_uint256 "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+  @signed_tx "0x02f8" <> String.duplicate("ab", 100)
+
+  @requirements %{
+    "scheme" => "exact",
+    "network" => "eip155:84532",
+    "amount" => "10000",
+    "asset" => @contract,
+    "payTo" => "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+    "maxTimeoutSeconds" => 60,
+    "extra" => %{"assetTransferMethod" => "permit2", "name" => "USDC", "version" => "2"}
+  }
+
+  @valid_info %{
+    "from" => @from,
+    "asset" => @contract,
+    "spender" => @permit2,
+    "amount" => @max_uint256,
+    "signedTransaction" => @signed_tx,
+    "version" => "1"
+  }
+
+  describe "build_extension/0" do
+    test "matches the spec's declaration shape" do
+      extension = ERC20ApprovalGasSponsoring.build_extension()
+
+      assert extension["info"] == %{
+               "description" =>
+                 "The facilitator accepts a raw signed approval transaction and will sponsor the gas fees.",
+               "version" => "1"
+             }
+
+      assert extension["schema"] == ERC20ApprovalGasSponsoring.schema()
+    end
+
+    test "the schema declares the spec's exact property names and patterns" do
+      schema = ERC20ApprovalGasSponsoring.schema()
+
+      assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+      assert schema["type"] == "object"
+
+      assert Map.keys(schema["properties"]) |> Enum.sort() ==
+               Enum.sort(~w(from asset spender amount signedTransaction version))
+
+      assert schema["required"] == ~w(from asset spender amount signedTransaction version)
+
+      for field <- ~w(from asset spender) do
+        assert schema["properties"][field]["pattern"] == "^0x[a-fA-F0-9]{40}$"
+      end
+
+      assert schema["properties"]["amount"]["pattern"] == "^[0-9]+$"
+      assert schema["properties"]["signedTransaction"]["pattern"] == "^0x[a-fA-F0-9]+$"
+      assert schema["properties"]["version"]["pattern"] == "^[0-9]+(\\.[0-9]+)*$"
+    end
+
+    test "round-trips through JSON" do
+      assert {:ok, json} = Jason.encode(ERC20ApprovalGasSponsoring.build_extension())
+      assert {:ok, _decoded} = Jason.decode(json)
+    end
+  end
+
+  describe "build_info/1" do
+    test "produces spec-shaped info with defaults" do
+      assert {:ok, info} =
+               ERC20ApprovalGasSponsoring.build_info(
+                 from: @from,
+                 asset: @contract,
+                 signed_transaction: @signed_tx
+               )
+
+      assert info == @valid_info
+      assert ERC20ApprovalGasSponsoring.validate_info(info) == :ok
+    end
+
+    test "honors amount and spender overrides, normalizing integers" do
+      spender = "0x3333333333333333333333333333333333333333"
+
+      assert {:ok, info} =
+               ERC20ApprovalGasSponsoring.build_info(
+                 from: @from,
+                 asset: @contract,
+                 signed_transaction: @signed_tx,
+                 amount: 10_000,
+                 spender: spender
+               )
+
+      assert info["amount"] == "10000"
+      assert info["spender"] == spender
+    end
+
+    test "rejects malformed fields with structured errors" do
+      base = [from: @from, asset: @contract, signed_transaction: @signed_tx]
+
+      assert ERC20ApprovalGasSponsoring.build_info(Keyword.put(base, :from, "0x123")) ==
+               {:error, {:invalid_info_field, "from"}}
+
+      assert ERC20ApprovalGasSponsoring.build_info(Keyword.put(base, :asset, "nope")) ==
+               {:error, {:invalid_info_field, "asset"}}
+
+      assert ERC20ApprovalGasSponsoring.build_info(Keyword.put(base, :spender, "0xdead")) ==
+               {:error, {:invalid_info_field, "spender"}}
+
+      assert ERC20ApprovalGasSponsoring.build_info(Keyword.put(base, :amount, "10.5")) ==
+               {:error, {:invalid_info_field, "amount"}}
+
+      assert ERC20ApprovalGasSponsoring.build_info(
+               Keyword.put(base, :signed_transaction, "not-hex")
+             ) == {:error, {:invalid_info_field, "signedTransaction"}}
+    end
+
+    test "requires from, asset, and signed_transaction" do
+      assert_raise NimbleOptions.ValidationError, fn ->
+        ERC20ApprovalGasSponsoring.build_info(from: @from, asset: @contract)
+      end
+    end
+  end
+
+  describe "put_info/2" do
+    test "creates the extensions entry when absent" do
+      payload = ERC20ApprovalGasSponsoring.put_info(%{"payload" => %{}}, @valid_info)
+
+      assert payload["extensions"]["erc20ApprovalGasSponsoring"] == %{"info" => @valid_info}
+    end
+
+    test "preserves the echoed server declaration, server fields winning" do
+      declaration = ERC20ApprovalGasSponsoring.build_extension()
+
+      payload = %{
+        "payload" => %{},
+        "extensions" => %{"erc20ApprovalGasSponsoring" => declaration}
+      }
+
+      enriched = ERC20ApprovalGasSponsoring.put_info(payload, @valid_info)
+      extension = enriched["extensions"]["erc20ApprovalGasSponsoring"]
+
+      assert extension["schema"] == declaration["schema"]
+      assert extension["info"]["description"] == declaration["info"]["description"]
+      assert extension["info"]["version"] == declaration["info"]["version"]
+      assert extension["info"]["signedTransaction"] == @signed_tx
+    end
+  end
+
+  describe "extract_info/1" do
+    test "returns the info from a payment payload" do
+      payload = ERC20ApprovalGasSponsoring.put_info(%{"payload" => %{}}, @valid_info)
+
+      assert ERC20ApprovalGasSponsoring.extract_info(payload) == {:ok, @valid_info}
+    end
+
+    test "rejects payloads without the extension" do
+      assert ERC20ApprovalGasSponsoring.extract_info(%{}) == {:error, :extension_missing}
+
+      assert ERC20ApprovalGasSponsoring.extract_info(%{"extensions" => %{}}) ==
+               {:error, :extension_missing}
+
+      assert ERC20ApprovalGasSponsoring.extract_info(%{
+               "extensions" => %{"erc20ApprovalGasSponsoring" => %{"info" => "nope"}}
+             }) == {:error, :extension_missing}
+
+      assert ERC20ApprovalGasSponsoring.extract_info("nope") == {:error, :extension_missing}
+    end
+
+    test "rejects info with missing or empty fields" do
+      for field <- ~w(from asset spender amount signedTransaction version) do
+        payload =
+          ERC20ApprovalGasSponsoring.put_info(%{"payload" => %{}}, Map.delete(@valid_info, field))
+
+        assert ERC20ApprovalGasSponsoring.extract_info(payload) ==
+                 {:error, {:missing_info_field, field}}
+      end
+
+      payload =
+        ERC20ApprovalGasSponsoring.put_info(%{"payload" => %{}}, %{
+          @valid_info
+          | "signedTransaction" => ""
+        })
+
+      assert ERC20ApprovalGasSponsoring.extract_info(payload) ==
+               {:error, {:missing_info_field, "signedTransaction"}}
+    end
+  end
+
+  describe "validate_info/1" do
+    test "accepts the spec's example info" do
+      assert ERC20ApprovalGasSponsoring.validate_info(@valid_info) == :ok
+    end
+
+    test "rejects malformed fields" do
+      cases = [
+        {"from", "0x123"},
+        {"asset", "not-an-address"},
+        {"spender", 42},
+        {"amount", "1e18"},
+        {"signedTransaction", "abcdef"},
+        {"version", "one"}
+      ]
+
+      for {field, value} <- cases do
+        assert ERC20ApprovalGasSponsoring.validate_info(%{@valid_info | field => value}) ==
+                 {:error, {:invalid_info_field, field}}
+      end
+    end
+
+    test "rejects missing fields and non-maps" do
+      assert ERC20ApprovalGasSponsoring.validate_info(Map.delete(@valid_info, "amount")) ==
+               {:error, {:missing_info_field, "amount"}}
+
+      assert ERC20ApprovalGasSponsoring.validate_info(nil) == {:error, :extension_missing}
+    end
+  end
+
+  describe "enricher/1" do
+    test "attaches the extension when the server advertises it" do
+      payment_required = %{
+        "x402Version" => 2,
+        "accepts" => [@requirements],
+        "extensions" => %{
+          "erc20ApprovalGasSponsoring" => ERC20ApprovalGasSponsoring.build_extension()
+        }
+      }
+
+      payload = %{
+        "x402Version" => 2,
+        "accepted" => @requirements,
+        "payload" => %{},
+        "extensions" => payment_required["extensions"]
+      }
+
+      enricher =
+        ERC20ApprovalGasSponsoring.enricher(from: @from, signed_transaction: @signed_tx)
+
+      assert {:ok, enriched} = enricher.(payload, payment_required)
+      assert {:ok, info} = ERC20ApprovalGasSponsoring.extract_info(enriched)
+      assert ERC20ApprovalGasSponsoring.validate_info(info) == :ok
+
+      # asset defaulted from the accepted requirements
+      assert info["asset"] == @contract
+      assert info["amount"] == @max_uint256
+    end
+
+    test "honors an explicit asset" do
+      other_asset = "0x4444444444444444444444444444444444444444"
+
+      payment_required = %{
+        "accepts" => [@requirements],
+        "extensions" => %{
+          "erc20ApprovalGasSponsoring" => ERC20ApprovalGasSponsoring.build_extension()
+        }
+      }
+
+      payload = %{"accepted" => @requirements, "payload" => %{}}
+
+      enricher =
+        ERC20ApprovalGasSponsoring.enricher(
+          from: @from,
+          asset: other_asset,
+          signed_transaction: @signed_tx
+        )
+
+      assert {:ok, enriched} = enricher.(payload, payment_required)
+      assert {:ok, info} = ERC20ApprovalGasSponsoring.extract_info(enriched)
+      assert info["asset"] == other_asset
+    end
+
+    test "passes the payload through when the extension is not advertised" do
+      payload = %{"accepted" => @requirements, "payload" => %{}}
+
+      enricher =
+        ERC20ApprovalGasSponsoring.enricher(from: @from, signed_transaction: @signed_tx)
+
+      assert enricher.(payload, %{"accepts" => [@requirements]}) == {:ok, payload}
+      assert enricher.(payload, nil) == {:ok, payload}
+    end
+
+    test "returns structured errors for unusable requirements or fields" do
+      payment_required = %{
+        "accepts" => [],
+        "extensions" => %{
+          "erc20ApprovalGasSponsoring" => ERC20ApprovalGasSponsoring.build_extension()
+        }
+      }
+
+      no_asset = %{"accepted" => Map.delete(@requirements, "asset"), "payload" => %{}}
+
+      enricher =
+        ERC20ApprovalGasSponsoring.enricher(from: @from, signed_transaction: @signed_tx)
+
+      assert enricher.(no_asset, payment_required) == {:error, :invalid_requirements}
+
+      bad_tx =
+        ERC20ApprovalGasSponsoring.enricher(from: @from, signed_transaction: "not-hex")
+
+      assert bad_tx.(%{"accepted" => @requirements, "payload" => %{}}, payment_required) ==
+               {:error, {:invalid_info_field, "signedTransaction"}}
+    end
+  end
+end


### PR DESCRIPTION
## What

Implements both gas-sponsoring extensions ([docs/ecosystem-comparison.md](https://github.com/cardotrejos/x402/blob/main/docs/ecosystem-comparison.md) §8 P2.4 — TS/Python/Go all ship both; we shipped neither). Four commits:

1. **`X402.EIP712`** (refactor first, per spec-conformance requirements): the EIP-712 hashing shared by EIP-3009 signing and the new Permit signing — domain derivation from requirements, struct hashing, word encoders, CAIP-2 chain-id parsing. `X402.EIP3009`'s public API unchanged (delegates).
2. **`X402.Extensions.EIP2612GasSponsoring`**: the client signs an EIP-712 `Permit(owner, spender, value, nonce, deadline)` over the token's domain. Defaults mirror the TS reference: spender = canonical Permit2, value = the advertised amount (the Permit2 proxy enforces permit value == permitted amount), deadline = now + maxTimeoutSeconds. `:nonce` is a required caller option — the SDK has no chain access to read `nonces(owner)` (documented). Spec-exact info keys and `{info, schema}` envelope.
3. **`X402.Extensions.ERC20ApprovalGasSponsoring`**: per its spec, the signed artifact is a full RLP-encoded `approve(Permit2, amount)` **transaction**, not EIP-712 typed data — so this module declares around a caller-supplied pre-signed transaction, with MaxUint256/Permit2 defaults matching the reference clients.
4. **Client integration**: `build_payment/3` (and `X402.Client.Finch`) accept an `:extensions` list of enricher functions applied after assembly, mirroring TS `x402Client` composition; enrichers no-op unless the server advertised the extension key (the spec's "must no-op internally" rule). Server-side `validate_info/1` gives strict accept/reject paths; `put_info/2` follows TS `mergeExtensions` semantics.

## Testing

124 doctests + 483 tests before rebase (union with current main verified locally after); Permit signature correctness proven by address recovery over `permit_digest/2`; Finch end-to-end test drives a Bypass 402 → enriched PAYMENT-SIGNATURE. Coverage: new modules 92.7–98.5%. All gates: format, credo --strict, dialyzer 0 errors, --no-optional-deps compile.

## Interactions

Touches `X402.Client`/`X402.Client.Finch` minimally (the `:extensions` option); no gate/signature/facilitator files. Will need a trivial CHANGELOG rebase against #64 (MCP), whichever lands second.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes EIP-712 signing paths and payment payload assembly for gas-sponsored approvals, but behavior is additive (optional enrichers) with broad test coverage including signature recovery and Finch 402 retries.
> 
> **Overview**
> Adds **gas-sponsoring** support for Permit2-style payments and refactors shared EIP-712 hashing so EIP-3009 and new permit signing reuse the same primitives.
> 
> **`X402.EIP712`** centralizes domain derivation from payment requirements, domain separator / struct hash / final digest, and ABI word encoders. **`X402.EIP3009`** keeps its public API and delegates hashing to `EIP712`.
> 
> **`X402.Extensions.EIP2612GasSponsoring`** implements `eip2612GasSponsoring`: server `build_extension/0`, client `sign_permit/3` (caller-supplied EIP-2612 nonce), `put_info/2`, and an **`enricher/2`** that only runs when the server advertised the extension.
> 
> **`X402.Extensions.ERC20ApprovalGasSponsoring`** implements `erc20ApprovalGasSponsoring` for tokens without EIP-2612: wraps a caller-provided signed `approve(Permit2, amount)` transaction via `build_info/1`, `put_info/2`, and **`enricher/1`**.
> 
> **`X402.Client.build_payment/3`** and **`X402.Client.Finch.request/3`** accept an **`extensions`** list of `(payload, payment_required)` enrichers applied after the payload is assembled; enrichers preserve append-only extension echo semantics. **`guides/client.md`** documents both flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e310432d4bc9c863adeefdfd9fbf8be1192ad6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->