### PR TITLE
feat: browser paywall for HTML 402 responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `X402.Extensions.PaymentIdentifier.RedisCache.Command` for testing without
   a live server). A live conformance suite tagged `:redis` (excluded by
   default) runs against `REDIS_URL`
+- **Browser paywall** (ecosystem report §8 P2.5): new `paywall:` option on
+  `X402.Plug.PaymentGate` (default `nil` — behavior unchanged). When set to a
+  module implementing the new `X402.Paywall` behaviour, pre-handler 402
+  responses to requests that look like a browser page load (`Accept` header
+  containing `text/html` **and** `User-Agent` containing `Mozilla`, the
+  heuristic shared by the reference Go/TypeScript middlewares) carry a
+  human-usable HTML body instead of the `{}` JSON body. The
+  `PAYMENT-REQUIRED` header is identical on both forms, and API clients,
+  absent-`Accept` requests, 400/500 statuses, and post-handler settlement
+  failures remain byte-identical to previous releases. Ships
+  `X402.Paywall.Default`, a self-contained few-KB page (inline CSS, no
+  external requests, no build step) that shows the advertised price, asset,
+  network, and recipient, embeds the exact Base64 `PAYMENT-REQUIRED` value
+  with manual retry instructions, and includes a dependency-free EIP-1193
+  wallet flow for `exact`/`eip3009` EVM options — sign the
+  `TransferWithAuthorization` typed data via `eth_signTypedData_v4`, retry
+  with `PAYMENT-SIGNATURE`, replace the document — degrading gracefully
+  without a wallet. All interpolated values are HTML-escaped and the embedded
+  config JSON is script-safe, so hostile route descriptions or service names
+  cannot inject markup. A renderer returning `{:error, reason}` logs a
+  warning and falls back to the JSON body. See the new "Browser Paywall"
+  guide.
 - **Local pre-verification checks in `X402.Plug.PaymentGate`** (option
   `local_prechecks:`, default `true`): before the facilitator round-trip, the
   gate now validates the EIP-3009-style `payload.authorization` object against

--- a/guides/paywall.md
+++ b/guides/paywall.md
@@ -1,0 +1,106 @@
+# Browser Paywall
+
+By default, `X402.Plug.PaymentGate` answers unpaid requests with a bare
+machine-readable 402: an empty JSON body plus the Base64 `PAYMENT-REQUIRED`
+header. That is exactly right for API clients and agents — and useless for a
+person who opens the gated URL in a browser.
+
+The `:paywall` option adds a human-usable HTML page for that case:
+
+```elixir
+plug X402.Plug.PaymentGate,
+  paywall: X402.Paywall.Default,
+  routes: [
+    %{
+      method: :get,
+      path: "/premium/report",
+      description: "Premium market report",
+      price: "10000",
+      network: "eip155:8453",
+      asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      pay_to: "0xYourWallet",
+      extra: %{"name" => "USD Coin", "version" => "2"}
+    }
+  ]
+```
+
+## Content negotiation
+
+The gate mirrors the browser heuristic used by the reference x402
+middlewares (Go and TypeScript): a request receives HTML only when its
+`Accept` header contains `text/html` **and** its `User-Agent` contains
+`Mozilla`. Everything else — an absent `Accept` header, `application/json`,
+`*/*`, curl, SDK clients — keeps today's JSON body.
+
+| Request                                             | 402 body |
+| --------------------------------------------------- | -------- |
+| Browser page load (`text/html` Accept + Mozilla UA) | HTML     |
+| `Accept: text/html` without a Mozilla User-Agent    | JSON     |
+| `Accept: application/json`, `*/*`, or no Accept     | JSON     |
+| Any request when `:paywall` is not set              | JSON     |
+
+Both forms carry the identical `PAYMENT-REQUIRED` header, so tooling that
+inspects headers works regardless of which body it receives. The paywall
+applies only to pre-handler 402 responses (missing or rejected payments);
+400 invalid-payload responses, 500 responses, and post-handler settlement
+failures are always JSON.
+
+Leaving `:paywall` unset (the default) keeps every response byte-identical
+to previous releases.
+
+## The default page
+
+`X402.Paywall.Default` renders a single self-contained page — inline CSS,
+no external requests, no build step, a few KB:
+
+  * the resource description plus amount, asset, network, and recipient for
+    every advertised payment option
+  * the exact Base64 `PAYMENT-REQUIRED` header value with manual retry
+    instructions, for people driving their own tooling
+  * a minimal EIP-1193 (`window.ethereum`) wallet flow for `"exact"` EVM
+    options using the default `eip3009` asset transfer method
+
+The wallet flow builds the `TransferWithAuthorization` EIP-712 typed data in
+the page from the advertised requirements (domain `name`/`version` from
+`extra`, chain id from the CAIP-2 network, verifying contract from `asset`),
+signs it with `eth_signTypedData_v4`, assembles the v2 `PaymentPayload`
+(echoing the selected requirement and any advertised extensions), retries the
+request with the `PAYMENT-SIGNATURE` header via `fetch`, and replaces the
+document with the paid response.
+
+Without a browser wallet — or when no advertised option is wallet-payable
+(non-EVM networks, `upto` routes, non-`eip3009` transfer methods, missing
+`extra.name`/`extra.version`) — the page degrades gracefully to the
+requirement details and the copyable header instructions.
+
+All interpolated values are HTML-escaped and the configuration JSON embedded
+for the script is encoded script-safe, so hostile route descriptions or
+service names cannot inject markup.
+
+## Custom paywalls
+
+Implement the `X402.Paywall` behaviour to serve your own page:
+
+```elixir
+defmodule MyApp.Paywall do
+  @behaviour X402.Paywall
+
+  @impl X402.Paywall
+  def render(payment_required, _conn_info) do
+    description = payment_required["resource"]["description"]
+    {:ok, MyAppWeb.PaywallHTML.page(description: description)}
+  end
+end
+```
+
+`render/2` receives the exact v2 `PaymentRequired` map the gate encodes into
+the `PAYMENT-REQUIRED` header — `X402.PaymentRequired.encode/1` reproduces
+the header value byte for byte — plus a `conn_info` map with the request
+`:method`, `:request_path`, and response `:status`. Return `{:ok, html}` with
+the complete page as iodata; returning `{:error, reason}` logs a warning and
+falls back to the JSON body, so a renderer failure never blocks the payment
+flow.
+
+Escape everything you interpolate: route descriptions and service names are
+configuration, but defense in depth is cheap and `X402.Paywall.Default`
+treats them as untrusted.

--- a/lib/x402/paywall.ex
+++ b/lib/x402/paywall.ex
@@ -1,0 +1,67 @@
+defmodule X402.Paywall do
+  @moduledoc """
+  Behaviour for rendering browser-facing HTML paywall pages.
+
+  When `X402.Plug.PaymentGate` is configured with `paywall: module`, 402
+  responses to requests that look like a browser page load carry an HTML body
+  rendered by the module instead of the default `{}` JSON body. A request is
+  treated as a browser page load when its `Accept` header contains
+  `text/html` **and** its `User-Agent` contains `Mozilla` — the same
+  heuristic the reference x402 middlewares use. The Base64 `PAYMENT-REQUIRED`
+  header is identical on both response forms; only the body differs.
+
+  `X402.Paywall.Default` ships a self-contained wallet-enabled page. Custom
+  implementations receive the exact v2 `PaymentRequired` payload the gate
+  encodes into the `PAYMENT-REQUIRED` header, so
+  `X402.PaymentRequired.encode/1` reproduces the header value byte for byte:
+
+      defmodule MyApp.Paywall do
+        @behaviour X402.Paywall
+
+        @impl X402.Paywall
+        def render(payment_required, _conn_info) do
+          {:ok, ~s(<h1>\#{payment_required["resource"]["description"]}</h1>)}
+        end
+      end
+
+  Returning `{:error, reason}` falls back to the default JSON body, so a
+  renderer failure never blocks the payment flow.
+  """
+
+  @typedoc """
+  Request details passed to `c:render/2`.
+
+  * `:method` — the HTTP request method (for example `"GET"`)
+  * `:request_path` — the decoded request path matched by the gate
+  * `:status` — the HTTP status of the response being rendered (always 402)
+  """
+  @type conn_info :: %{
+          method: String.t(),
+          request_path: String.t(),
+          status: pos_integer()
+        }
+
+  @doc """
+  Renders the HTML paywall page for a v2 `PaymentRequired` payload.
+
+  `payment_required` is the string-keyed map the gate encodes into the
+  `PAYMENT-REQUIRED` response header (`x402Version`, `error`, `resource`,
+  `accepts`, `extensions`). Returns `{:ok, html}` with the complete page as
+  iodata, or `{:error, reason}` to fall back to the JSON body.
+  """
+  @callback render(payment_required :: map(), conn_info()) ::
+              {:ok, iodata()} | {:error, term()}
+
+  @required_callbacks [render: 2]
+
+  @doc false
+  @spec validate_module(term()) :: {:ok, module()} | {:error, String.t()}
+  def validate_module(module) when is_atom(module) and not is_nil(module) do
+    case X402.Behaviour.implements?(module, @required_callbacks) do
+      true -> {:ok, module}
+      false -> {:error, "expected a module implementing X402.Paywall"}
+    end
+  end
+
+  def validate_module(_invalid), do: {:error, "expected a module implementing X402.Paywall"}
+end

--- a/lib/x402/paywall/default.ex
+++ b/lib/x402/paywall/default.ex
@@ -1,0 +1,453 @@
+defmodule X402.Paywall.Default do
+  @moduledoc """
+  Self-contained HTML paywall page for browser-facing 402 responses.
+
+  Renders a single lean page — inline CSS, no external requests, no build
+  step — from a v2 `PaymentRequired` payload:
+
+    * the resource description plus amount, asset, network, and recipient
+      for every advertised payment option
+    * the exact Base64 `PAYMENT-REQUIRED` header value for tooling, with
+      manual retry instructions
+    * a minimal EIP-1193 (`window.ethereum`) payment flow for `"exact"` EVM
+      options using the default `eip3009` asset transfer method: connect a
+      wallet, sign the `TransferWithAuthorization` typed data via
+      `eth_signTypedData_v4`, assemble the v2 `PaymentPayload`, and retry the
+      request with a `PAYMENT-SIGNATURE` header
+
+  Without a browser wallet — or when no advertised option is wallet-payable —
+  the page degrades to the requirement details and the manual header
+  instructions. All interpolated values are HTML-escaped and the embedded
+  configuration JSON is encoded script-safe, so route descriptions and
+  service names cannot inject markup.
+
+  Configure it through `X402.Plug.PaymentGate`:
+
+      plug X402.Plug.PaymentGate,
+        paywall: X402.Paywall.Default,
+        routes: [...]
+  """
+
+  @behaviour X402.Paywall
+
+  alias X402.PaymentRequired
+  alias X402.Utils
+
+  @default_title "Payment required"
+
+  @network_names %{
+    "eip155:1" => "Ethereum",
+    "eip155:10" => "OP Mainnet",
+    "eip155:137" => "Polygon",
+    "eip155:8453" => "Base",
+    "eip155:84532" => "Base Sepolia",
+    "eip155:43114" => "Avalanche",
+    "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" => "Solana",
+    "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1" => "Solana Devnet"
+  }
+
+  @page_style ~S"""
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body { margin: 0; padding: 2rem 1rem; display: flex; justify-content: center; font-family: system-ui, -apple-system, "Segoe UI", sans-serif; line-height: 1.5; background: #f4f5f7; color: #1c2024; }
+  main { width: 100%; max-width: 34rem; background: #fff; border: 1px solid #d9dde3; border-radius: 12px; padding: 1.75rem; }
+  .status { margin: 0 0 0.5rem; font-size: 0.8rem; letter-spacing: 0.08em; text-transform: uppercase; color: #6b7280; }
+  h1 { margin: 0 0 0.5rem; font-size: 1.4rem; }
+  .description { margin: 0 0 1.25rem; color: #4b5563; }
+  .option { border: 1px solid #e5e7eb; border-radius: 8px; padding: 0.75rem 1rem; margin: 0 0 1rem; }
+  .option h2 { margin: 0 0 0.5rem; font-size: 0.95rem; }
+  dl { margin: 0; }
+  dl div { display: flex; gap: 0.75rem; padding: 0.2rem 0; }
+  dt { flex: 0 0 6.5rem; color: #6b7280; }
+  dd { margin: 0; overflow-wrap: anywhere; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.85em; }
+  button { appearance: none; border: 0; border-radius: 8px; padding: 0.65rem 1.1rem; font-size: 1rem; font-weight: 600; background: #1d4ed8; color: #fff; cursor: pointer; }
+  button:disabled { opacity: 0.6; cursor: wait; }
+  #x402-status { min-height: 1.25rem; color: #4b5563; }
+  #x402-status[data-kind="error"] { color: #b91c1c; }
+  details { margin-top: 1.25rem; border-top: 1px solid #e5e7eb; padding-top: 1rem; }
+  summary { cursor: pointer; font-weight: 600; }
+  pre { background: #f4f5f7; border: 1px solid #e5e7eb; border-radius: 8px; padding: 0.75rem; overflow-x: auto; white-space: pre-wrap; word-break: break-all; font-size: 0.75rem; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #111418; color: #e5e7eb; }
+    main { background: #1a1f26; border-color: #2c333d; }
+    .description, dt, #x402-status { color: #9ca3af; }
+    #x402-status[data-kind="error"] { color: #f87171; }
+    .option, details { border-color: #2c333d; }
+    pre { background: #111418; border-color: #2c333d; }
+  }
+  """
+
+  # The script reads all dynamic data from the JSON <script type="application/json">
+  # config block, so it needs no interpolation and stays free of injection paths.
+  @page_script ~S"""
+  (function () {
+    "use strict";
+
+    var config = JSON.parse(document.getElementById("x402-config").textContent);
+    var button = document.getElementById("x402-pay");
+    var statusEl = document.getElementById("x402-status");
+
+    function setStatus(message, kind) {
+      statusEl.textContent = message;
+      statusEl.dataset.kind = kind || "info";
+    }
+
+    function walletPayable(option) {
+      var extra = option.extra || {};
+      var transferMethod = extra.assetTransferMethod || "eip3009";
+      return option.scheme === "exact" &&
+        typeof option.network === "string" &&
+        option.network.indexOf("eip155:") === 0 &&
+        transferMethod === "eip3009" &&
+        typeof extra.name === "string" &&
+        typeof extra.version === "string";
+    }
+
+    var option = (config.accepts || []).filter(walletPayable)[0];
+
+    if (!option) {
+      setStatus("No option payable with a browser wallet was advertised. See the tooling instructions below.");
+      return;
+    }
+
+    if (!window.ethereum || typeof window.ethereum.request !== "function") {
+      setStatus("No EIP-1193 browser wallet detected. See the tooling instructions below.");
+      return;
+    }
+
+    button.hidden = false;
+    button.addEventListener("click", pay);
+
+    function chainId(network) {
+      return parseInt(network.split(":")[1], 10);
+    }
+
+    function randomNonce() {
+      var bytes = new Uint8Array(32);
+      crypto.getRandomValues(bytes);
+      var hex = "";
+      for (var i = 0; i < bytes.length; i++) {
+        hex += bytes[i].toString(16).padStart(2, "0");
+      }
+      return "0x" + hex;
+    }
+
+    function buildTypedData(from) {
+      var now = Math.floor(Date.now() / 1000);
+      return {
+        types: {
+          EIP712Domain: [
+            { name: "name", type: "string" },
+            { name: "version", type: "string" },
+            { name: "chainId", type: "uint256" },
+            { name: "verifyingContract", type: "address" }
+          ],
+          TransferWithAuthorization: [
+            { name: "from", type: "address" },
+            { name: "to", type: "address" },
+            { name: "value", type: "uint256" },
+            { name: "validAfter", type: "uint256" },
+            { name: "validBefore", type: "uint256" },
+            { name: "nonce", type: "bytes32" }
+          ]
+        },
+        primaryType: "TransferWithAuthorization",
+        domain: {
+          name: option.extra.name,
+          version: option.extra.version,
+          chainId: chainId(option.network),
+          verifyingContract: option.asset
+        },
+        message: {
+          from: from,
+          to: option.payTo,
+          value: option.amount,
+          validAfter: String(now - 60),
+          validBefore: String(now + (option.maxTimeoutSeconds || 60)),
+          nonce: randomNonce()
+        }
+      };
+    }
+
+    function encodeBase64(text) {
+      var bytes = new TextEncoder().encode(text);
+      var binary = "";
+      for (var i = 0; i < bytes.length; i++) {
+        binary += String.fromCharCode(bytes[i]);
+      }
+      return btoa(binary);
+    }
+
+    async function ensureChain() {
+      var wanted = "0x" + chainId(option.network).toString(16);
+      var current = await window.ethereum.request({ method: "eth_chainId" });
+      if (String(current).toLowerCase() === wanted) {
+        return;
+      }
+      await window.ethereum.request({
+        method: "wallet_switchEthereumChain",
+        params: [{ chainId: wanted }]
+      });
+    }
+
+    function paymentError(response) {
+      var header = response.headers.get("payment-required");
+      if (!header) {
+        return null;
+      }
+      try {
+        return JSON.parse(atob(header)).error || null;
+      } catch (error) {
+        return null;
+      }
+    }
+
+    function showResult(text) {
+      var heading = document.createElement("h1");
+      heading.textContent = "Payment accepted";
+      var body = document.createElement("pre");
+      body.textContent = text;
+      document.querySelector("main").replaceChildren(heading, body);
+    }
+
+    async function deliver(response) {
+      var contentType = response.headers.get("content-type") || "";
+      var text = await response.text();
+      if (contentType.indexOf("text/html") === 0) {
+        document.open();
+        document.write(text);
+        document.close();
+      } else {
+        showResult(text);
+      }
+    }
+
+    async function pay() {
+      button.disabled = true;
+      try {
+        setStatus("Connecting wallet…");
+        var accounts = await window.ethereum.request({ method: "eth_requestAccounts" });
+        var from = accounts[0];
+        await ensureChain();
+        setStatus("Waiting for signature…");
+        var typedData = buildTypedData(from);
+        var signature = await window.ethereum.request({
+          method: "eth_signTypedData_v4",
+          params: [from, JSON.stringify(typedData)]
+        });
+        var paymentPayload = {
+          x402Version: 2,
+          accepted: option,
+          payload: { signature: signature, authorization: typedData.message }
+        };
+        if (config.extensions && Object.keys(config.extensions).length > 0) {
+          paymentPayload.extensions = config.extensions;
+        }
+        setStatus("Submitting payment…");
+        var response = await fetch(window.location.href, {
+          headers: { "PAYMENT-SIGNATURE": encodeBase64(JSON.stringify(paymentPayload)) }
+        });
+        if (!response.ok) {
+          throw new Error(paymentError(response) || "Payment failed with status " + response.status + ".");
+        }
+        setStatus("Payment accepted. Loading content…");
+        await deliver(response);
+      } catch (error) {
+        var message = error && error.message ? error.message : "Payment failed.";
+        if (error && error.code === 4001) {
+          message = "Signature request rejected.";
+        }
+        setStatus(message, "error");
+        button.disabled = false;
+      }
+    }
+  })();
+  """
+
+  @doc since: "0.6.0"
+  @doc """
+  Renders the default HTML paywall page.
+
+  Returns `{:error, reason}` when the payload cannot be encoded as a
+  `PAYMENT-REQUIRED` header value (see `X402.PaymentRequired.encode/1`).
+
+  ## Examples
+
+      iex> payment_required = %{
+      ...>   "x402Version" => 2,
+      ...>   "error" => "PAYMENT-SIGNATURE header is required",
+      ...>   "resource" => %{
+      ...>     "url" => "https://example.com/premium",
+      ...>     "description" => "Premium report",
+      ...>     "mimeType" => "application/json"
+      ...>   },
+      ...>   "accepts" => [
+      ...>     %{
+      ...>       "scheme" => "exact",
+      ...>       "network" => "eip155:84532",
+      ...>       "amount" => "10000",
+      ...>       "asset" => "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      ...>       "payTo" => "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      ...>       "maxTimeoutSeconds" => 60,
+      ...>       "extra" => %{"name" => "USDC", "version" => "2"}
+      ...>     }
+      ...>   ],
+      ...>   "extensions" => %{}
+      ...> }
+      iex> conn_info = %{method: "GET", request_path: "/premium", status: 402}
+      iex> {:ok, html} = X402.Paywall.Default.render(payment_required, conn_info)
+      iex> html =~ "Premium report" and html =~ "Base Sepolia"
+      true
+  """
+  @impl X402.Paywall
+  @spec render(map(), X402.Paywall.conn_info()) :: {:ok, iodata()} | {:error, term()}
+  def render(payment_required, conn_info)
+      when is_map(payment_required) and is_map(conn_info) do
+    case PaymentRequired.encode(payment_required) do
+      {:ok, encoded_header} -> {:ok, page(payment_required, encoded_header)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns a human-readable display name for a CAIP-2 network identifier.
+
+  ## Examples
+
+      iex> X402.Paywall.Default.network_display_name("eip155:8453")
+      "Base"
+
+      iex> X402.Paywall.Default.network_display_name("eip155:999999")
+      "EVM chain 999999"
+
+      iex> X402.Paywall.Default.network_display_name("otherchain:mainnet")
+      "otherchain:mainnet"
+  """
+  @spec network_display_name(String.t()) :: String.t()
+  def network_display_name(network) when is_binary(network) do
+    case Map.fetch(@network_names, network) do
+      {:ok, name} -> name
+      :error -> fallback_network_name(network)
+    end
+  end
+
+  @spec fallback_network_name(String.t()) :: String.t()
+  defp fallback_network_name("eip155:" <> chain_id), do: "EVM chain #{chain_id}"
+  defp fallback_network_name(network), do: network
+
+  @spec page(map(), String.t()) :: String.t()
+  defp page(payment_required, encoded_header) do
+    resource = ensure_map(Utils.map_value(payment_required, {"resource", :resource}))
+    accepts = ensure_list(Utils.map_value(payment_required, {"accepts", :accepts}))
+    title = page_title(resource)
+    description = Utils.map_value(resource, {"description", :description}) || @default_title
+    config_json = Jason.encode!(payment_required, escape: :html_safe)
+
+    """
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>#{escape(title)}</title>
+    <style>#{@page_style}</style>
+    </head>
+    <body>
+    <main>
+    <p class="status">HTTP 402 &middot; Payment required</p>
+    <h1>#{escape(title)}</h1>
+    <p class="description">#{escape(description)}</p>
+    #{options_html(accepts)}
+    <section class="wallet">
+    <button id="x402-pay" type="button" hidden>Pay with browser wallet</button>
+    <p id="x402-status" role="status"><noscript>Enable JavaScript to pay with a browser wallet, or use the tooling instructions below.</noscript></p>
+    </section>
+    <details>
+    <summary>Pay with your own tooling</summary>
+    <p>This response also carries the value below in its <code>PAYMENT-REQUIRED</code> header. Decode the Base64 JSON, sign a payment for one of the advertised options, and retry the request with the signed payload Base64-encoded in a <code>PAYMENT-SIGNATURE</code> header.</p>
+    <pre>#{escape(encoded_header)}</pre>
+    </details>
+    </main>
+    <script type="application/json" id="x402-config">#{config_json}</script>
+    <script>#{@page_script}</script>
+    </body>
+    </html>
+    """
+  end
+
+  @spec page_title(map()) :: String.t()
+  defp page_title(resource) do
+    case Utils.map_value(resource, {"serviceName", :serviceName}) do
+      service_name when is_binary(service_name) and service_name != "" -> service_name
+      _missing -> @default_title
+    end
+  end
+
+  @spec options_html([term()]) :: String.t()
+  defp options_html([]), do: ~s(<p class="description">No payment options were advertised.</p>)
+
+  defp options_html(accepts) do
+    total = length(accepts)
+
+    accepts
+    |> Enum.with_index(1)
+    |> Enum.map_join("\n", fn {accept, index} -> option_html(accept, index, total) end)
+  end
+
+  @spec option_html(term(), pos_integer(), pos_integer()) :: String.t()
+  defp option_html(accept, index, total) when is_map(accept) do
+    scheme = Utils.map_value(accept, {"scheme", :scheme})
+    network = Utils.map_value(accept, {"network", :network})
+
+    """
+    <section class="option">
+    #{option_heading(index, total)}<dl>
+    <div><dt>Amount</dt><dd><code>#{escape(Utils.map_value(accept, {"amount", :amount}))}</code> atomic units#{amount_note(scheme)}</dd></div>
+    <div><dt>Network</dt><dd>#{escape(network_name(network))} &middot; <code>#{escape(network)}</code></dd></div>
+    <div><dt>Asset</dt><dd><code>#{escape(Utils.map_value(accept, {"asset", :asset}))}</code></dd></div>
+    <div><dt>Pay to</dt><dd><code>#{escape(Utils.map_value(accept, {"payTo", :payTo}))}</code></dd></div>
+    <div><dt>Scheme</dt><dd><code>#{escape(scheme)}</code></dd></div>
+    </dl>
+    </section>
+    """
+  end
+
+  defp option_html(_accept, _index, _total), do: ""
+
+  @spec option_heading(pos_integer(), pos_integer()) :: String.t()
+  defp option_heading(_index, 1), do: ""
+  defp option_heading(index, _total), do: "<h2>Option #{index}</h2>\n"
+
+  @spec amount_note(term()) :: String.t()
+  defp amount_note("upto"), do: " (maximum)"
+  defp amount_note(_scheme), do: ""
+
+  @spec network_name(term()) :: String.t()
+  defp network_name(network) when is_binary(network), do: network_display_name(network)
+  defp network_name(_network), do: "Unknown network"
+
+  @spec ensure_map(term()) :: map()
+  defp ensure_map(value) when is_map(value), do: value
+  defp ensure_map(_value), do: %{}
+
+  @spec ensure_list(term()) :: [term()]
+  defp ensure_list(value) when is_list(value), do: value
+  defp ensure_list(_value), do: []
+
+  @spec escape(term()) :: String.t()
+  defp escape(nil), do: ""
+
+  defp escape(value) when is_binary(value) do
+    value
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
+    |> String.replace("\"", "&quot;")
+    |> String.replace("'", "&#39;")
+  end
+
+  defp escape(value) when is_number(value) or is_atom(value), do: value |> to_string() |> escape()
+  defp escape(value), do: value |> inspect() |> escape()
+end

--- a/lib/x402/paywall/default.ex
+++ b/lib/x402/paywall/default.ex
@@ -214,7 +214,17 @@ defmodule X402.Paywall.Default do
     async function deliver(response) {
       var contentType = response.headers.get("content-type") || "";
       var text = await response.text();
-      if (contentType.indexOf("text/html") === 0) {
+      var sameOrigin = false;
+      try {
+        sameOrigin = new URL(response.url).origin === window.location.origin;
+      } catch (error) {
+        sameOrigin = false;
+      }
+      // Only replace the document with HTML that is same-origin and was not
+      // reached through a redirect: document.write executes the body as the
+      // CURRENT origin, so a followed redirect to attacker-readable HTML
+      // would run as first-party script on the gated host.
+      if (contentType.indexOf("text/html") === 0 && sameOrigin && !response.redirected) {
         document.open();
         document.write(text);
         document.close();
@@ -252,7 +262,19 @@ defmodule X402.Paywall.Default do
           throw new Error(paymentError(response) || "Payment failed with status " + response.status + ".");
         }
         setStatus("Payment accepted. Loading content…");
-        await deliver(response);
+        // The payment has settled: a failure from here on must never
+        // re-enable the pay button — a retry would sign a fresh nonce and
+        // settle a second payment for the same page view.
+        try {
+          await deliver(response);
+        } catch (error) {
+          setStatus(
+            "Payment accepted, but the content could not be displayed. " +
+              "Do not pay again — refresh or contact the site with your receipt.",
+            "error"
+          );
+        }
+        return;
       } catch (error) {
         var message = error && error.message ? error.message : "Payment failed.";
         if (error && error.code === 4001) {

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -1524,8 +1524,13 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
 
       case paywall.render(required_payload, conn_info) do
         {:ok, html} ->
+          # The paywall exposes a one-click wallet-signature flow; deny
+          # framing so a third-party page cannot overlay it and clickjack an
+          # EIP-3009 authorization.
           conn
           |> put_resp_content_type("text/html")
+          |> put_resp_header("x-frame-options", "DENY")
+          |> put_resp_header("content-security-policy", "frame-ancestors 'none'")
           |> resp(402, html)
 
         {:error, reason} ->

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -30,6 +30,16 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     and
     [HTTP transport](https://github.com/x402-foundation/x402/blob/main/specs/transports-v2/http.md).
 
+    ## Browser paywall
+
+    With `paywall: X402.Paywall.Default` (or any `X402.Paywall`
+    implementation), pre-handler 402 responses to browser page loads —
+    `Accept` containing `text/html` and `User-Agent` containing `Mozilla`,
+    the heuristic shared by the reference x402 middlewares — carry a
+    human-usable HTML page instead of the `{}` JSON body. The
+    `PAYMENT-REQUIRED` header is identical on both forms and all other
+    responses are unchanged. See the "Browser Paywall" guide.
+
     ## Replay protection
 
     When `:payment_identifier_cache` is configured, the gate claims the SHA-256
@@ -82,6 +92,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     alias X402.PaymentRequirements
     alias X402.PaymentResponse
     alias X402.PaymentSignature
+    alias X402.Paywall
     alias X402.Utils
 
     require Logger
@@ -305,6 +316,22 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
         pass through untouched. Failures answer 402 without a facilitator
         round-trip.
         """
+      ],
+      paywall: [
+        type: {:or, [nil, {:custom, Paywall, :validate_module, []}]},
+        default: nil,
+        doc: """
+        Optional browser paywall renderer implementing `X402.Paywall`
+        (`X402.Paywall.Default` ships a self-contained wallet-enabled page).
+        When set, pre-handler 402 responses to requests that look like a
+        browser page load — `Accept` header containing `text/html` **and**
+        `User-Agent` containing `Mozilla`, mirroring the reference x402
+        middlewares — carry the rendered HTML body instead of the default
+        `{}` JSON body. The `PAYMENT-REQUIRED` header is identical on both
+        forms, and every other response (API clients, absent `Accept`
+        headers, 400/500 statuses, post-handler settlement failures) is
+        byte-identical to running without `:paywall`.
+        """
       ]
     ]
 
@@ -318,7 +345,8 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
             payment_identifier_cache: Cache.adapter() | nil,
             claim_order: claim_order(),
             routes: [compiled_route()],
-            local_prechecks: boolean()
+            local_prechecks: boolean(),
+            paywall: module() | nil
           }
 
     @typedoc false
@@ -461,7 +489,8 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
           validated_opts
           |> Keyword.fetch!(:routes)
           |> Enum.map(&compile_route/1),
-        local_prechecks: Keyword.fetch!(validated_opts, :local_prechecks)
+        local_prechecks: Keyword.fetch!(validated_opts, :local_prechecks),
+        paywall: Keyword.fetch!(validated_opts, :paywall)
       }
     end
 
@@ -527,7 +556,8 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
             route,
             request_path,
             "PAYMENT-SIGNATURE header is required",
-            status: 402
+            status: 402,
+            paywall: opts.paywall
           )
 
         {:ok, header} ->
@@ -547,7 +577,8 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
             request_path,
             rejection_error(reason),
             status: status_for_reason(reason),
-            reason: reason
+            reason: reason,
+            paywall: opts.paywall
           )
       end
     end
@@ -601,7 +632,8 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
             request_path,
             rejection_error(reason),
             status: status_for_reason(reason),
-            reason: reason
+            reason: reason,
+            paywall: opts.paywall
           )
       end
     end
@@ -1442,6 +1474,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     defp payment_error_conn(conn, route, request_path, error_message, opts) do
       status = Keyword.get(opts, :status, 402)
       reason = Keyword.get(opts, :reason)
+      paywall = Keyword.get(opts, :paywall)
       required_payload = payment_required_payload(conn, route, request_path, error_message)
 
       with {:ok, encoded_required} <- PaymentRequired.encode(required_payload),
@@ -1449,10 +1482,77 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
         response_conn
         |> put_resp_header("payment-required", encoded_required)
         |> delete_resp_header("content-length")
-        |> put_resp_content_type("application/json")
-        |> resp(status, "{}")
+        |> put_payment_error_body(status, required_payload, request_path, paywall)
       else
         {:error, _reason} -> internal_error_conn(conn)
+      end
+    end
+
+    # The HTML paywall applies only to 402 responses to requests that look
+    # like a browser page load. Every other combination — no :paywall
+    # configured, non-402 statuses, API clients — keeps the empty JSON body,
+    # byte-identical to running without the option.
+    @spec put_payment_error_body(
+            Plug.Conn.t(),
+            integer(),
+            map(),
+            String.t(),
+            module() | nil
+          ) :: Plug.Conn.t()
+    defp put_payment_error_body(conn, 402, required_payload, request_path, paywall)
+         when not is_nil(paywall) do
+      case browser_request?(conn) do
+        true -> paywall_response(conn, required_payload, request_path, paywall)
+        false -> json_error_body(conn, 402)
+      end
+    end
+
+    defp put_payment_error_body(conn, status, _required_payload, _request_path, _paywall) do
+      json_error_body(conn, status)
+    end
+
+    @spec json_error_body(Plug.Conn.t(), integer()) :: Plug.Conn.t()
+    defp json_error_body(conn, status) do
+      conn
+      |> put_resp_content_type("application/json")
+      |> resp(status, "{}")
+    end
+
+    @spec paywall_response(Plug.Conn.t(), map(), String.t(), module()) :: Plug.Conn.t()
+    defp paywall_response(conn, required_payload, request_path, paywall) do
+      conn_info = %{method: conn.method, request_path: request_path, status: 402}
+
+      case paywall.render(required_payload, conn_info) do
+        {:ok, html} ->
+          conn
+          |> put_resp_content_type("text/html")
+          |> resp(402, html)
+
+        {:error, reason} ->
+          Logger.warning(
+            "[X402.Plug.PaymentGate] paywall renderer #{inspect(paywall)} failed " <>
+              "(#{inspect(reason)}); falling back to the JSON 402 body"
+          )
+
+          json_error_body(conn, 402)
+      end
+    end
+
+    # Mirrors the browser heuristic of the reference x402 middlewares (Go and
+    # TypeScript): a request is a browser page load when its Accept header
+    # contains "text/html" AND its User-Agent contains "Mozilla". Absent
+    # headers never match, so API clients keep the JSON body.
+    @spec browser_request?(Plug.Conn.t()) :: boolean()
+    defp browser_request?(conn) do
+      String.contains?(first_req_header(conn, "accept"), "text/html") and
+        String.contains?(first_req_header(conn, "user-agent"), "Mozilla")
+    end
+
+    @spec first_req_header(Plug.Conn.t(), String.t()) :: String.t()
+    defp first_req_header(conn, name) do
+      case get_req_header(conn, name) do
+        [value | _rest] when is_binary(value) -> value
+        _missing -> ""
       end
     end
 

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -1549,7 +1549,12 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     # headers never match, so API clients keep the JSON body.
     @spec browser_request?(Plug.Conn.t()) :: boolean()
     defp browser_request?(conn) do
-      String.contains?(first_req_header(conn, "accept"), "text/html") and
+      # GET only: the paywall page's payment retry re-issues the request as a
+      # plain GET of the current URL, so serving it for a browser form POST
+      # would silently retry with the wrong method (and without the form
+      # body). Non-GET browser requests keep the JSON 402.
+      conn.method == "GET" and
+        String.contains?(first_req_header(conn, "accept"), "text/html") and
         String.contains?(first_req_header(conn, "user-agent"), "Mozilla")
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -123,6 +123,7 @@ defmodule X402.MixProject do
         "guides/client.md": [title: "Paying for Resources"],
         "guides/plug-integration.md": [title: "Plug/Phoenix Integration"],
         "guides/mcp.md": [title: "Paid MCP Tools"],
+        "guides/paywall.md": [title: "Browser Paywall"],
         "guides/live-smoke-tests.md": [title: "Live Smoke Tests"]
       ],
       groups_for_extras: [
@@ -154,7 +155,9 @@ defmodule X402.MixProject do
           X402.Hooks.Default
         ],
         "Plug Integration": [
-          X402.Plug.PaymentGate
+          X402.Plug.PaymentGate,
+          X402.Paywall,
+          X402.Paywall.Default
         ],
         "MCP Transport": [
           X402.MCP,

--- a/test/x402/paywall/default_test.exs
+++ b/test/x402/paywall/default_test.exs
@@ -150,5 +150,23 @@ defmodule X402.Paywall.DefaultTest do
       refute html =~ "@import"
       assert byte_size(html) < 16_384
     end
+
+    test "guards content delivery against cross-origin and redirected HTML" do
+      assert {:ok, html} = Default.render(payment_required(), @conn_info)
+
+      # document.write executes as the current origin — the script must gate
+      # it on same-origin, non-redirected responses (security review finding).
+      assert html =~ "response.redirected"
+      assert html =~ "window.location.origin"
+      assert html =~ ~r/sameOrigin && !response\.redirected/
+    end
+
+    test "never re-enables payment after a settled payment fails to display" do
+      assert {:ok, html} = Default.render(payment_required(), @conn_info)
+
+      # A deliver() failure after response.ok must not re-enable the pay
+      # button — a retry would sign a fresh nonce and settle a second payment.
+      assert html =~ "Do not pay again"
+    end
   end
 end

--- a/test/x402/paywall/default_test.exs
+++ b/test/x402/paywall/default_test.exs
@@ -1,0 +1,154 @@
+defmodule X402.Paywall.DefaultTest do
+  use ExUnit.Case, async: true
+  doctest X402.Paywall.Default
+
+  alias X402.PaymentRequired
+  alias X402.Paywall.Default
+
+  @conn_info %{method: "GET", request_path: "/api/resource", status: 402}
+
+  @accept %{
+    "scheme" => "exact",
+    "network" => "eip155:84532",
+    "amount" => "10000",
+    "asset" => "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+    "payTo" => "0x1111111111111111111111111111111111111111",
+    "maxTimeoutSeconds" => 60,
+    "extra" => %{"name" => "USDC", "version" => "2"}
+  }
+
+  defp payment_required(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "x402Version" => 2,
+        "error" => "PAYMENT-SIGNATURE header is required",
+        "resource" => %{
+          "url" => "http://www.example.com/api/resource",
+          "description" => "Premium market data",
+          "mimeType" => "application/json"
+        },
+        "accepts" => [@accept],
+        "extensions" => %{}
+      },
+      overrides
+    )
+  end
+
+  describe "render/2" do
+    test "renders price, network, asset, and recipient" do
+      assert {:ok, html} = Default.render(payment_required(), @conn_info)
+
+      assert html =~ "10000"
+      assert html =~ "eip155:84532"
+      assert html =~ "Base Sepolia"
+      assert html =~ "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+      assert html =~ "0x1111111111111111111111111111111111111111"
+      assert html =~ "Premium market data"
+    end
+
+    test "embeds the exact Base64 PAYMENT-REQUIRED header value" do
+      payload = payment_required()
+      {:ok, encoded_header} = PaymentRequired.encode(payload)
+
+      assert {:ok, html} = Default.render(payload, @conn_info)
+      assert html =~ encoded_header
+    end
+
+    test "uses the service name as the page title when present" do
+      payload =
+        payment_required(%{
+          "resource" => %{
+            "url" => "http://www.example.com/api/resource",
+            "description" => "Premium market data",
+            "mimeType" => "application/json",
+            "serviceName" => "Acme Data"
+          }
+        })
+
+      assert {:ok, html} = Default.render(payload, @conn_info)
+      assert html =~ "<title>Acme Data</title>"
+      assert html =~ "<h1>Acme Data</h1>"
+    end
+
+    test "escapes hostile descriptions and service names" do
+      payload =
+        payment_required(%{
+          "resource" => %{
+            "url" => "http://www.example.com/api/resource",
+            "description" => "<script>alert('desc')</script>",
+            "mimeType" => "application/json",
+            "serviceName" => "\"><img src=x onerror=alert(1)>"
+          }
+        })
+
+      assert {:ok, html} = Default.render(payload, @conn_info)
+
+      refute html =~ "<script>alert"
+      refute html =~ "<img src=x"
+      assert html =~ "&lt;script&gt;alert(&#39;desc&#39;)&lt;/script&gt;"
+      assert html =~ "&quot;&gt;&lt;img src=x onerror=alert(1)&gt;"
+    end
+
+    test "keeps the embedded configuration JSON script-safe" do
+      payload =
+        payment_required(%{
+          "resource" => %{
+            "url" => "http://www.example.com/api/resource",
+            "description" => "</script><script>alert('json')</script>",
+            "mimeType" => "application/json"
+          }
+        })
+
+      assert {:ok, html} = Default.render(payload, @conn_info)
+
+      # The hostile description must never appear as a raw closing tag,
+      # neither in the markup nor inside the JSON config block.
+      refute html =~ "</script><script>alert"
+    end
+
+    test "labels upto amounts as maximums" do
+      payload = payment_required(%{"accepts" => [Map.put(@accept, "scheme", "upto")]})
+
+      assert {:ok, html} = Default.render(payload, @conn_info)
+      assert html =~ "(maximum)"
+    end
+
+    test "numbers the options when several are advertised" do
+      solana = %{
+        @accept
+        | "network" => "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+          "asset" => "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          "extra" => %{}
+      }
+
+      assert {:ok, html} =
+               Default.render(payment_required(%{"accepts" => [@accept, solana]}), @conn_info)
+
+      assert html =~ "Option 1"
+      assert html =~ "Option 2"
+      assert html =~ "Solana"
+    end
+
+    test "renders a note when no options are advertised" do
+      assert {:ok, html} = Default.render(payment_required(%{"accepts" => []}), @conn_info)
+      assert html =~ "No payment options were advertised."
+    end
+
+    test "returns an error for payloads the header encoder rejects" do
+      payload = payment_required(%{"extensions" => %{"bad" => {:not, :json}}})
+
+      assert {:error, :invalid_json} = Default.render(payload, @conn_info)
+    end
+
+    test "produces a lean, self-contained page" do
+      assert {:ok, html} = Default.render(payment_required(), @conn_info)
+
+      # No external requests: no src/href/url() pointing anywhere.
+      refute html =~ "http-equiv"
+      refute html =~ ~r/<(script|link|img|iframe)[^>]*\ssrc=/
+      refute html =~ "<link"
+      refute html =~ "@import"
+      assert byte_size(html) < 16_384
+    end
+  end
+end

--- a/test/x402/paywall_test.exs
+++ b/test/x402/paywall_test.exs
@@ -1,0 +1,39 @@
+defmodule X402.PaywallTest do
+  use ExUnit.Case, async: true
+  doctest X402.Paywall
+
+  alias X402.Paywall
+
+  defmodule Implementing do
+    @behaviour X402.Paywall
+
+    @impl X402.Paywall
+    def render(_payment_required, _conn_info), do: {:ok, "<html></html>"}
+  end
+
+  defmodule NotImplementing do
+  end
+
+  describe "validate_module/1" do
+    test "accepts a module implementing the behaviour" do
+      assert Paywall.validate_module(Implementing) == {:ok, Implementing}
+      assert Paywall.validate_module(X402.Paywall.Default) == {:ok, X402.Paywall.Default}
+    end
+
+    test "rejects a module without render/2" do
+      assert Paywall.validate_module(NotImplementing) ==
+               {:error, "expected a module implementing X402.Paywall"}
+    end
+
+    test "rejects nil and non-module values" do
+      assert Paywall.validate_module(nil) ==
+               {:error, "expected a module implementing X402.Paywall"}
+
+      assert Paywall.validate_module("X402.Paywall.Default") ==
+               {:error, "expected a module implementing X402.Paywall"}
+
+      assert Paywall.validate_module({Implementing, []}) ==
+               {:error, "expected a module implementing X402.Paywall"}
+    end
+  end
+end

--- a/test/x402/plug/payment_gate_test.exs
+++ b/test/x402/plug/payment_gate_test.exs
@@ -1985,6 +1985,21 @@ defmodule X402.Plug.PaymentGateTest do
       assert conn.resp_body =~ @asset
     end
 
+    test "denies framing on the HTML paywall (clickjacking defense)" do
+      conn =
+        conn(:get, "/api/resource")
+        |> browser_conn()
+        |> run_request(routes: [@route], facilitator: self(), paywall: X402.Paywall.Default)
+
+      assert get_resp_header(conn, "x-frame-options") == ["DENY"]
+      assert get_resp_header(conn, "content-security-policy") == ["frame-ancestors 'none'"]
+
+      # JSON 402s keep their existing header surface.
+      json = run_request(conn(:get, "/api/resource"), routes: [@route], facilitator: self())
+      assert get_resp_header(json, "x-frame-options") == []
+      assert get_resp_header(json, "content-security-policy") == []
+    end
+
     test "serves HTML for a bare text/html Accept with a Mozilla User-Agent" do
       conn =
         conn(:get, "/api/resource")

--- a/test/x402/plug/payment_gate_test.exs
+++ b/test/x402/plug/payment_gate_test.exs
@@ -1934,6 +1934,217 @@ defmodule X402.Plug.PaymentGateTest do
   end
 
   # ---------------------------------------------------------------------------
+  # Browser paywall (:paywall option)
+  # ---------------------------------------------------------------------------
+
+  defmodule CustomPaywall do
+    @moduledoc false
+    @behaviour X402.Paywall
+
+    @impl X402.Paywall
+    def render(payment_required, conn_info) do
+      {:ok,
+       "custom-paywall:#{conn_info.method}:#{conn_info.request_path}:" <>
+         "#{conn_info.status}:#{payment_required["error"]}"}
+    end
+  end
+
+  defmodule FailingPaywall do
+    @moduledoc false
+    @behaviour X402.Paywall
+
+    @impl X402.Paywall
+    def render(_payment_required, _conn_info), do: {:error, :boom}
+  end
+
+  @browser_accept "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+  @browser_user_agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+
+  defp browser_conn(conn) do
+    conn
+    |> put_req_header("accept", @browser_accept)
+    |> put_req_header("user-agent", @browser_user_agent)
+  end
+
+  defp maybe_put_req_header(conn, _name, nil), do: conn
+  defp maybe_put_req_header(conn, name, value), do: put_req_header(conn, name, value)
+
+  describe "browser paywall" do
+    test "serves HTML to browser page loads when :paywall is set" do
+      conn =
+        conn(:get, "/api/resource")
+        |> browser_conn()
+        |> run_request(routes: [@route], facilitator: self(), paywall: X402.Paywall.Default)
+
+      assert conn.status == 402
+      assert conn.halted
+      assert get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
+      assert conn.resp_body =~ "<!DOCTYPE html>"
+      assert conn.resp_body =~ @amount
+      assert conn.resp_body =~ @network
+      assert conn.resp_body =~ @asset
+    end
+
+    test "serves HTML for a bare text/html Accept with a Mozilla User-Agent" do
+      conn =
+        conn(:get, "/api/resource")
+        |> put_req_header("accept", "text/html")
+        |> put_req_header("user-agent", @browser_user_agent)
+        |> run_request(routes: [@route], facilitator: self(), paywall: X402.Paywall.Default)
+
+      assert conn.status == 402
+      assert get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
+    end
+
+    test "keeps JSON across the API-client Accept/User-Agent matrix" do
+      matrix = [
+        {nil, nil},
+        {@browser_accept, nil},
+        {"text/html", nil},
+        {nil, @browser_user_agent},
+        {"application/json", @browser_user_agent},
+        {"*/*", @browser_user_agent},
+        {"application/json, text/plain", @browser_user_agent}
+      ]
+
+      for {accept, user_agent} <- matrix do
+        conn =
+          conn(:get, "/api/resource")
+          |> maybe_put_req_header("accept", accept)
+          |> maybe_put_req_header("user-agent", user_agent)
+          |> run_request(routes: [@route], facilitator: self(), paywall: X402.Paywall.Default)
+
+        assert conn.status == 402
+        assert conn.resp_body == "{}"
+        assert get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
+        assert get_resp_header(conn, "payment-required") != []
+      end
+    end
+
+    test "sends the identical PAYMENT-REQUIRED header on HTML and JSON forms" do
+      opts = [routes: [@route], facilitator: self(), paywall: X402.Paywall.Default]
+
+      html_conn = conn(:get, "/api/resource") |> browser_conn() |> run_request(opts)
+      json_conn = run_request(conn(:get, "/api/resource"), opts)
+
+      bare_conn =
+        run_request(conn(:get, "/api/resource"), routes: [@route], facilitator: self())
+
+      [header] = get_resp_header(html_conn, "payment-required")
+      assert get_resp_header(json_conn, "payment-required") == [header]
+      assert get_resp_header(bare_conn, "payment-required") == [header]
+
+      # The page embeds the exact header value for tooling.
+      assert html_conn.resp_body =~ header
+    end
+
+    test "the :paywall default leaves browser 402 responses byte-identical" do
+      default_conn =
+        conn(:get, "/api/resource")
+        |> browser_conn()
+        |> run_request(routes: [@route], facilitator: self())
+
+      explicit_nil_conn =
+        conn(:get, "/api/resource")
+        |> browser_conn()
+        |> run_request(routes: [@route], facilitator: self(), paywall: nil)
+
+      assert default_conn.status == 402
+      assert default_conn.resp_body == "{}"
+      assert get_resp_header(default_conn, "content-type") == ["application/json; charset=utf-8"]
+
+      assert explicit_nil_conn.status == default_conn.status
+      assert explicit_nil_conn.resp_body == default_conn.resp_body
+      assert Enum.sort(explicit_nil_conn.resp_headers) == Enum.sort(default_conn.resp_headers)
+    end
+
+    test "escapes hostile route descriptions and service names" do
+      route =
+        @route
+        |> Map.put(:description, "<script>alert('pwn')</script>")
+        |> Map.put(:service_name, "\"><img src=x onerror=alert(1)>")
+
+      conn =
+        conn(:get, "/api/resource")
+        |> browser_conn()
+        |> run_request(routes: [route], facilitator: self(), paywall: X402.Paywall.Default)
+
+      assert conn.status == 402
+      refute conn.resp_body =~ "<script>alert"
+      refute conn.resp_body =~ "<img src=x"
+      assert conn.resp_body =~ "&lt;script&gt;alert(&#39;pwn&#39;)&lt;/script&gt;"
+      assert conn.resp_body =~ "&quot;&gt;&lt;img src=x onerror=alert(1)&gt;"
+    end
+
+    test "dispatches to a custom X402.Paywall module" do
+      conn =
+        conn(:get, "/api/resource")
+        |> browser_conn()
+        |> run_request(routes: [@route], facilitator: self(), paywall: CustomPaywall)
+
+      assert conn.status == 402
+      assert get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
+
+      assert conn.resp_body ==
+               "custom-paywall:GET:/api/resource:402:PAYMENT-SIGNATURE header is required"
+    end
+
+    test "falls back to JSON when the paywall renderer fails" do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          conn =
+            conn(:get, "/api/resource")
+            |> browser_conn()
+            |> run_request(routes: [@route], facilitator: self(), paywall: FailingPaywall)
+
+          assert conn.status == 402
+          assert conn.resp_body == "{}"
+          assert get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
+          assert get_resp_header(conn, "payment-required") != []
+        end)
+
+      assert log =~ "paywall renderer"
+      assert log =~ ":boom"
+    end
+
+    test "keeps 400 invalid-payload responses JSON even for browsers" do
+      conn =
+        conn(:get, "/api/resource")
+        |> browser_conn()
+        |> put_req_header("payment-signature", "%%% not base64 %%%")
+        |> run_request(routes: [@route], facilitator: self(), paywall: X402.Paywall.Default)
+
+      assert conn.status == 400
+      assert conn.resp_body == "{}"
+      assert get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
+    end
+
+    test "serves the paywall on browser 402s for rejected payments" do
+      reject =
+        start_mock_facilitator(
+          verify:
+            {:ok, %{status: 200, body: %{"isValid" => false, "invalidReason" => "declined"}}}
+        )
+
+      conn =
+        conn(:get, "/api/resource")
+        |> browser_conn()
+        |> put_req_header("payment-signature", valid_payment_header())
+        |> run_request(routes: [@route], facilitator: reject, paywall: X402.Paywall.Default)
+
+      assert conn.status == 402
+      assert get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
+      assert conn.resp_body =~ "<!DOCTYPE html>"
+    end
+
+    test "init rejects modules that do not implement X402.Paywall" do
+      assert_raise NimbleOptions.ValidationError, ~r/X402\.Paywall/, fn ->
+        PaymentGate.init(routes: [@route], paywall: __MODULE__)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Helpers
   # ---------------------------------------------------------------------------
 

--- a/test/x402/plug/payment_gate_test.exs
+++ b/test/x402/plug/payment_gate_test.exs
@@ -2000,6 +2000,19 @@ defmodule X402.Plug.PaymentGateTest do
       assert get_resp_header(json, "content-security-policy") == []
     end
 
+    test "keeps JSON for non-GET browser requests (paywall retry is a GET)" do
+      route = Map.put(@route, :method, :post)
+
+      conn =
+        conn(:post, "/api/resource")
+        |> browser_conn()
+        |> run_request(routes: [route], facilitator: self(), paywall: X402.Paywall.Default)
+
+      assert conn.status == 402
+      assert get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
+      refute conn.resp_body =~ "<!DOCTYPE html>"
+    end
+
     test "serves HTML for a bare text/html Accept with a Mozilla User-Agent" do
       conn =
         conn(:get, "/api/resource")


### PR DESCRIPTION
## What

Adds an HTML paywall for browser traffic hitting gated routes ([docs/ecosystem-comparison.md](https://github.com/cardotrejos/x402/blob/main/docs/ecosystem-comparison.md) §8 P2.5 — TS/Python/Go all ship one; the Go reference embeds a 2.2MB bundle, ours is ~10KB, inline CSS, zero external requests).

- **Negotiation**: exact parity with the reference middlewares — HTML only when `Accept` contains `text/html` AND `User-Agent` contains `Mozilla`; absent headers, `*/*`, JSON clients keep today's JSON byte-for-byte. Applies only to pre-handler 402s; 400/500 and settlement-failure paths stay JSON (browsers never navigate with a PAYMENT-SIGNATURE; documented).
- **`X402.Paywall` behaviour** (`render(payment_required, conn_info)`, Plug-free so `--no-optional-deps` compiles) with a `paywall:` gate option (NimbleOptions, default `nil` = today's behavior exactly). A renderer error logs and falls back to JSON — a paywall bug can never block payments.
- **`X402.Paywall.Default`**: EIP-1193 wallet flow for exact/eip3009 (connect → chain switch → `eth_signTypedData_v4` mirroring `X402.EIP3009`'s exact typed data → assemble v2 PaymentPayload echoing the selected requirements + extensions → fetch retry). upto/Solana/no-wallet/no-JS degrade to requirement details + copyable PAYMENT-REQUIRED instructions.
- **XSS**: everything escaped server-side; dynamic data reaches the script only via a `<script type="application/json">` block (`Jason escape: :html_safe`); JS renders via `textContent`. Tested with hostile description/serviceName.

## Byte-compat proof (default off)

The `paywall: nil` code path is literally the old JSON pipeline in the same position; the gate-test diff is purely additive; an explicit test compares status/body/complete sorted headers for default vs `paywall: nil`; a header-identity test asserts the PAYMENT-REQUIRED value is byte-equal across HTML form, JSON form, and a bare run.

## Testing

27 new tests/doctests (negotiation matrix, byte-compat, header identity, XSS, custom renderer dispatch, renderer-error fallback, 400-stays-JSON). Full suite on current main: 107 doctests + 520 tests, 0 failures. All gates green incl. dialyzer and --no-optional-deps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment UX and in-browser signing (wallet + HTML injection defenses); default-off path preserves prior wire behavior, but misconfigured custom paywalls or browser heuristics could surprise operators.
> 
> **Overview**
> Adds an opt-in **browser paywall** for `X402.Plug.PaymentGate` via a new `paywall:` option (default `nil`, so existing JSON `{}` 402 bodies are unchanged).
> 
> When a module implementing **`X402.Paywall`** is configured, **pre-handler 402** responses can return **HTML** instead of empty JSON for requests that look like a browser page load: **GET**, `Accept` containing `text/html`, and `User-Agent` containing `Mozilla` (same heuristic as reference x402 middleware). The **`PAYMENT-REQUIRED`** header is unchanged; API clients, non-GET browser requests, **400/500**, and paths that do not pass `paywall` into the error builder (e.g. post-handler settlement failures) still get JSON.
> 
> **`X402.Paywall.Default`** ships a self-contained page (inline CSS/JS, no external assets) that lists payment options, shows the Base64 header for manual tooling, and optionally runs an EIP-1193 **`exact` / `eip3009`** flow (`eth_signTypedData_v4`, retry with `PAYMENT-SIGNATURE`). HTML responses add **clickjacking** headers (`X-Frame-Options`, CSP `frame-ancestors`). Renderer `{:error, _}` logs and falls back to JSON.
> 
> Also adds **`guides/paywall.md`**, CHANGELOG/mix docs entries, and tests for negotiation, byte-compat, XSS escaping, and custom/failing renderers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b976bb8a49a184eea60d31c733fa8de2f5200724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->