### PR TITLE
feat: local EVM payment verification — X402.Verify.EVM, X402.RPC, X402.ERC6492

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are answered with HTTP 400 by the gate. Shared EVM authorization
   pre-checks are reusable via `X402.Scheme.EVM.authorization_precheck/3`.
   See the new Custom Payment Schemes guide
+- **Full local payment verification for EVM `exact`/`eip3009` payments**
+  (`X402.Verify.EVM`, ecosystem report §8 P1.2 and the verification half of
+  P2.1): runs the reference facilitator verify checklist locally instead of
+  trusting a remote facilitator's verdict, at three explicit levels that
+  never silently downgrade — `:structural` (pure checks: scheme/network/
+  domain requirements, payload shape, `payTo` equality, exact amount, timing
+  with the 6-second settlement buffer), `:signature` (EIP-712 digest
+  recomputation + EOA recovery via the optional crypto deps, else
+  `{:error, :missing_dependency}`), and `:full` (on-chain: chain-id
+  cross-check, payer-bytecode signature routing — ECDSA with no code, strict
+  ERC-1271 `isValidSignature` with code and no ECDSA fallback — asset
+  bytecode presence, `balanceOf` funding, and `transferWithAuthorization`
+  `eth_call` simulation with failure diagnosis mirroring the reference
+  `invalidReason` set, else `{:error, :rpc_not_configured}`). ERC-6492
+  counterfactual signatures copy the reference Go fail-closed design: the
+  deployment factory must be explicitly allowlisted
+  (`eip6492_allowed_factories`, default `[]` rejects all) and validity is
+  proven only by an atomic Multicall3 deploy-and-transfer simulation.
+  `reason_string/1` maps local reason atoms onto the canonical cross-SDK
+  `invalidReason` strings. Documented in the new "Local Payment
+  Verification" guide, including the `before_verify` hook pattern for
+  gating `X402.Plug.PaymentGate` requests on local verification.
+- `X402.RPC` — a minimal Ethereum JSON-RPC client over the user's own Finch
+  pool (`eth_call`, `eth_getCode`, `eth_chainId`, and ordered batch requests
+  in one HTTP round-trip), with NimbleOptions-validated configuration,
+  structured errors, `[:x402, :rpc, :request]` telemetry, and the same
+  https-with-localhost-exemption enforcement as `X402.Facilitator.HTTP`.
+  Compiles and fails cleanly (`{:error, :missing_dependency}`) without the
+  optional Finch dependency.
+- `X402.ERC6492` — pure parsing and building of ERC-6492 counterfactual
+  signature wrappers (magic-suffix detection, bounds-checked ABI decoding of
+  the factory/calldata/inner-signature tuple); classification policy lives
+  in the verifier, which never treats a wrapper as proof by itself.
 - **Local pre-verification checks in `X402.Plug.PaymentGate`** (option
   `local_prechecks:`, default `true`): before the facilitator round-trip, the
   gate now validates the EIP-3009-style `payload.authorization` object against

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ facilitator, chain, or web framework.
 - Complete v2 payment-requirement and extension-echo validation
 - Payer client with EIP-3009 signing and an automatic `402 → sign → retry` Finch flow
 - Facilitator `/verify` and `/settle` client with retries, hooks, and telemetry
+- Local payment verification (EIP-712 + ERC-1271/6492, balance and simulation checks) without trusting a facilitator
 - Plug/Phoenix payment gate that settles only after successful resource handling
 - `"exact"` and metered `"upto"` authorization flows
 - Optional payment-identifier idempotency cache and SIWX support
@@ -235,6 +236,7 @@ Facilitator requests use the v2 wire object:
 
 - [Getting Started](https://hexdocs.pm/x402/getting-started.html)
 - [Plug/Phoenix Integration](https://hexdocs.pm/x402/plug-integration.html)
+- [Local Payment Verification](https://hexdocs.pm/x402/local-verification.html)
 - [Live Smoke Tests](https://hexdocs.pm/x402/live-smoke-tests.html)
 - [API Reference](https://hexdocs.pm/x402/api-reference.html)
 - [Official x402 v2 specification](https://github.com/x402-foundation/x402/blob/main/specs/x402-specification-v2.md)

--- a/guides/local-verification.md
+++ b/guides/local-verification.md
@@ -1,0 +1,187 @@
+# Local Payment Verification
+
+By default an x402 resource server delegates payment verification to a remote
+facilitator: the server's security posture equals the facilitator's, fully.
+`X402.Verify.EVM` removes that dependency for EVM `exact`/`eip3009` payments
+by running the facilitator verify checklist locally — the same checks the
+reference TypeScript, Go, and Python facilitator engines perform, from
+EIP-712 signature recovery to on-chain `transferWithAuthorization`
+simulation.
+
+Use it to cross-check a facilitator you do not fully trust, to reject junk
+before paying for a facilitator round-trip, or as the verification core of
+your own facilitator.
+
+## Verification levels
+
+The `:level` option is required and explicit. A level whose capability is
+missing returns an error — verification never silently downgrades to a
+weaker check.
+
+| Level | Checks | Needs |
+|---|---|---|
+| `:structural` | scheme, network, EIP-712 domain requirements, payload shape, `payTo` recipient equality, exact amount equality, `validAfter`/`validBefore` with the 6-second settlement buffer | nothing |
+| `:signature` | `:structural` + EIP-712 digest recomputation and EOA signature recovery | `ex_keccak`, `ex_secp256k1` (optional deps), else `{:error, :missing_dependency}` |
+| `:full` | `:signature` + chain-id cross-check, payer-bytecode signature routing (ECDSA / ERC-1271), ERC-6492 handling, asset bytecode presence, `balanceOf` funding, `eth_call` transfer simulation with failure diagnosis | an `X402.RPC` endpoint, else `{:error, :rpc_not_configured}` |
+
+At `:signature`, smart-wallet signatures (ERC-1271 contracts, ERC-6492
+wrappers) are rejected with `{:error, {:invalid, :smart_wallet_requires_rpc}}`
+rather than assumed valid — proving them requires the chain.
+
+## Quick start
+
+Add the optional dependencies and a Finch pool:
+
+```elixir
+def deps do
+  [
+    {:x402, "~> 0.6"},
+    {:finch, "~> 0.19"},
+    {:ex_secp256k1, "~> 0.8"},
+    {:ex_keccak, "~> 0.7"}
+  ]
+end
+```
+
+Verify a decoded payment:
+
+```elixir
+{:ok, payload} = X402.PaymentSignature.decode_and_validate(header_value, requirements)
+
+{:ok, rpc} =
+  X402.RPC.new(
+    rpc_url: "https://sepolia.base.org",
+    finch: MyApp.Finch
+  )
+
+case X402.Verify.EVM.verify(payload, requirements, level: :full, rpc: rpc) do
+  {:ok, %{payer: payer, signature_type: type}} ->
+    # Every check passed: signature, funding, timing, and a simulated
+    # transferWithAuthorization all hold at this instant.
+    {:ok, payer, type}
+
+  {:error, {:invalid, reason}} ->
+    # The payment is definitively invalid (e.g. :recipient_mismatch,
+    # :insufficient_balance, :nonce_already_used).
+    {:reject, reason}
+
+  {:error, other} ->
+    # Could not verify: :missing_dependency, :rpc_not_configured,
+    # {:rpc_error, _}, {:chain_id_mismatch, _, _}. Fail closed.
+    {:reject, other}
+end
+```
+
+`X402.RPC.new/1` enforces `https://` (plain `http://` only for
+`localhost`) and rides on your own Finch pool — configure TLS peer
+verification as shown in `X402.Facilitator.HTTP.secure_pool_opts/0`.
+
+Pure levels need no RPC at all:
+
+```elixir
+{:ok, _} = X402.Verify.EVM.verify(payload, requirements, level: :signature)
+```
+
+## Gating requests with the `before_verify` hook
+
+`X402.Plug.PaymentGate` already runs cheap structural prechecks
+(`local_prechecks: true`) before every facilitator call. To add cryptographic
+verification without waiting for the scheme-behaviour integration, run
+`X402.Verify.EVM` from a `before_verify` hook — the gate aborts with a 402
+when the hook halts:
+
+```elixir
+defmodule MyApp.LocalVerification do
+  @behaviour X402.Hooks
+
+  alias X402.Hooks.Context
+
+  @impl true
+  def before_verify(%Context{payload: payload, requirements: requirements} = context, _metadata) do
+    case X402.Verify.EVM.verify(payload, requirements, level: :signature) do
+      {:ok, _verification} -> {:cont, context}
+      {:error, reason} -> {:halt, {:local_verification_failed, reason}}
+    end
+  end
+
+  @impl true
+  def after_verify(context, _metadata), do: {:cont, context}
+  @impl true
+  def on_verify_failure(context, _metadata), do: {:cont, context}
+  @impl true
+  def before_settle(context, _metadata), do: {:cont, context}
+  @impl true
+  def after_settle(context, _metadata), do: {:cont, context}
+  @impl true
+  def on_settle_failure(context, _metadata), do: {:cont, context}
+end
+
+plug X402.Plug.PaymentGate,
+  accepts: [requirements],
+  facilitator: [url: "https://facilitator.example.com", finch: MyApp.Finch],
+  hooks: MyApp.LocalVerification
+```
+
+`level: :signature` is a good fit here: it proves the EOA signature without
+adding RPC latency to the request path, while the facilitator (or a
+`level: :full` check) remains the authority on chain state. Payments the
+signature level cannot prove — smart-wallet signers — halt fail-closed; relax
+that only by running `level: :full` with an `:rpc` config in the hook.
+
+## ERC-6492 counterfactual wallets
+
+A payment signed by a not-yet-deployed smart wallet arrives as an ERC-6492
+wrapper: the wallet's inner signature plus the factory call that would deploy
+it. Following the reference Go design, such a signature is **never** valid on
+the strength of the wrapper alone:
+
+1. The factory must appear in `:eip6492_allowed_factories`. The default is
+   `[]`, which rejects every counterfactual payment with
+   `{:invalid, :eip6492_factory_not_allowed}` — list only factories you
+   trust, since settlement executes their calldata.
+2. Validity is proven exclusively by an atomic Multicall3 simulation that
+   deploys the wallet and executes the transfer in a single `eth_call`. With
+   `simulate: false` counterfactual payments are rejected with
+   `{:invalid, :undeployed_smart_wallet}`.
+
+```elixir
+X402.Verify.EVM.verify(payload, requirements,
+  level: :full,
+  rpc: rpc,
+  eip6492_allowed_factories: ["0x0BA5ED0c6AA8c49038F819E587E2633c4A9F428a"]
+)
+```
+
+Deployed smart wallets (including ERC-7702-delegated EOAs) take the strict
+ERC-1271 path: `isValidSignature` must return the magic value, with no ECDSA
+fallback — the same routing on-chain `SignatureChecker` implementations use,
+so a locally accepted signature is one the token contract would accept.
+
+## Failure diagnosis
+
+When the `eth_call` simulation fails, the module mirrors the reference
+facilitators' diagnosis: the revert reason is classified first
+(nonce already used, expired window, insufficient balance, invalid
+signature), and unrecognized failures trigger one batched probe of
+`authorizationState`, `name`, `version`, and `balanceOf` to produce the most
+specific reason — `:eip3009_not_supported`, `:nonce_already_used`,
+`:token_name_mismatch`, `:token_version_mismatch`, `:insufficient_balance`,
+or `:simulation_failed`.
+
+`X402.Verify.EVM.reason_string/1` maps each reason atom onto the canonical
+cross-SDK `invalidReason` string (for example `:nonce_already_used` →
+`"invalid_exact_evm_nonce_already_used"`), so a future facilitator engine can
+answer wire-compatible verify responses.
+
+## What local verification cannot tell you
+
+- **Replay across servers.** A valid authorization can be presented to many
+  resource servers until it is settled on chain. Local verification proves
+  the payment *could* settle — pair it with the payment-identifier replay
+  cache and settlement.
+- **Race to settlement.** Funding and nonce state hold at the instant of the
+  `eth_call`; they can change before you settle. Settlement remains the only
+  proof of payment.
+- **Non-EVM schemes.** Only `exact` with the default `eip3009` asset transfer
+  method is supported; other schemes and networks return
+  `{:error, {:invalid, ...}}` rather than guessing.

--- a/lib/x402/erc6492.ex
+++ b/lib/x402/erc6492.ex
@@ -1,0 +1,252 @@
+defmodule X402.ERC6492 do
+  @moduledoc """
+  ERC-6492 signature wrapper parsing and building.
+
+  [ERC-6492](https://eips.ethereum.org/EIPS/eip-6492) lets a not-yet-deployed
+  ("counterfactual") smart wallet produce a verifiable signature by wrapping
+  the wallet's inner signature together with the factory call that would
+  deploy it:
+
+      abi.encode((factory, factoryCalldata, innerSignature)) || magic_suffix
+
+  where the magic suffix is the 32-byte value `0x6492...6492`.
+
+  This module is pure binary handling — no cryptography and no RPC. Whether a
+  wrapped signature is actually *valid* is decided by `X402.Verify.EVM`:
+  a counterfactual signature is never accepted until an on-chain simulation
+  proves the deployed wallet would accept it (fail-closed, mirroring the
+  reference Go implementation).
+  """
+
+  @magic_suffix :binary.copy(<<0x64, 0x92>>, 16)
+
+  @zero_address "0x" <> String.duplicate("0", 40)
+
+  @typedoc """
+  A parsed signature.
+
+  `wrapped?` is `true` when the ERC-6492 magic suffix was present. `factory`
+  and `factory_calldata` are `nil` unless the wrapper carried deployment
+  information (a non-zero factory address with non-empty calldata).
+  `inner_signature` is the raw signature bytes — the unwrapped inner
+  signature for wrapped input, the input itself otherwise.
+  """
+  @type parsed :: %{
+          wrapped?: boolean(),
+          factory: String.t() | nil,
+          factory_calldata: binary() | nil,
+          inner_signature: binary()
+        }
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the 32-byte ERC-6492 magic suffix.
+
+  ## Examples
+
+      iex> byte_size(X402.ERC6492.magic_suffix())
+      32
+  """
+  @spec magic_suffix() :: <<_::256>>
+  def magic_suffix, do: @magic_suffix
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns `true` when the signature carries the ERC-6492 magic suffix.
+
+  Accepts raw bytes or a `0x`-prefixed hex string.
+
+  ## Examples
+
+      iex> X402.ERC6492.wrapped?(<<1, 2, 3>>)
+      false
+
+      iex> {:ok, wrapped} =
+      ...>   X402.ERC6492.wrap(
+      ...>     "0x2222222222222222222222222222222222222222",
+      ...>     <<0xAB>>,
+      ...>     :binary.copy(<<0x01>>, 65)
+      ...>   )
+      iex> X402.ERC6492.wrapped?(wrapped)
+      true
+  """
+  @spec wrapped?(binary()) :: boolean()
+  def wrapped?(signature) when is_binary(signature) do
+    case decode_signature_bytes(signature) do
+      {:ok, bytes} -> magic_suffix?(bytes)
+      {:error, _reason} -> false
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Parses a signature, unwrapping the ERC-6492 envelope when present.
+
+  Accepts raw bytes or a `0x`-prefixed hex string. Signatures without the
+  magic suffix parse as `wrapped?: false` with the bytes passed through as
+  `inner_signature`. A wrapper whose factory is the zero address or whose
+  calldata is empty parses with `factory: nil` (no deployment information),
+  matching the reference implementations.
+
+  Returns `{:error, :invalid_erc6492_wrapper}` when the magic suffix is
+  present but the ABI-encoded prefix is malformed, and
+  `{:error, :invalid_signature}` for non-hex string input.
+
+  ## Examples
+
+      iex> {:ok, parsed} = X402.ERC6492.parse(:binary.copy(<<0x01>>, 65))
+      iex> {parsed.wrapped?, parsed.factory, byte_size(parsed.inner_signature)}
+      {false, nil, 65}
+
+      iex> inner = :binary.copy(<<0x07>>, 65)
+      iex> {:ok, wrapped} =
+      ...>   X402.ERC6492.wrap("0x2222222222222222222222222222222222222222", <<0xAB, 0xCD>>, inner)
+      iex> {:ok, parsed} = X402.ERC6492.parse(wrapped)
+      iex> {parsed.wrapped?, parsed.factory, parsed.factory_calldata, parsed.inner_signature}
+      {true, "0x2222222222222222222222222222222222222222", <<0xAB, 0xCD>>, inner}
+
+      iex> X402.ERC6492.parse("0xzz")
+      {:error, :invalid_signature}
+  """
+  @spec parse(binary()) ::
+          {:ok, parsed()} | {:error, :invalid_signature | :invalid_erc6492_wrapper}
+  def parse(signature) when is_binary(signature) do
+    with {:ok, bytes} <- decode_signature_bytes(signature) do
+      case magic_suffix?(bytes) do
+        true ->
+          parse_wrapper(binary_part(bytes, 0, byte_size(bytes) - 32))
+
+        false ->
+          {:ok, %{wrapped?: false, factory: nil, factory_calldata: nil, inner_signature: bytes}}
+      end
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Builds an ERC-6492 wrapped signature from its parts.
+
+  `factory` is a `0x`-prefixed EVM address; `factory_calldata` and
+  `inner_signature` are raw bytes. Returns the raw wrapped bytes
+  (`abi.encode((address, bytes, bytes)) || magic_suffix`).
+
+  ## Examples
+
+      iex> {:ok, wrapped} =
+      ...>   X402.ERC6492.wrap(
+      ...>     "0x2222222222222222222222222222222222222222",
+      ...>     <<0xAB>>,
+      ...>     :binary.copy(<<0x01>>, 65)
+      ...>   )
+      iex> X402.ERC6492.wrapped?(wrapped)
+      true
+
+      iex> X402.ERC6492.wrap("0x123", <<>>, <<>>)
+      {:error, :invalid_address}
+  """
+  @spec wrap(String.t(), binary(), binary()) :: {:ok, binary()} | {:error, :invalid_address}
+  def wrap(factory, factory_calldata, inner_signature)
+      when is_binary(factory) and is_binary(factory_calldata) and is_binary(inner_signature) do
+    with {:ok, factory_word} <- X402.EIP3009.encode_address(factory) do
+      calldata_offset = 3 * 32
+      signature_offset = calldata_offset + 32 + padded_size(factory_calldata)
+
+      encoded =
+        factory_word <>
+          <<calldata_offset::unsigned-big-integer-size(256)>> <>
+          <<signature_offset::unsigned-big-integer-size(256)>> <>
+          encode_dynamic_bytes(factory_calldata) <>
+          encode_dynamic_bytes(inner_signature) <>
+          @magic_suffix
+
+      {:ok, encoded}
+    end
+  end
+
+  # -- Wrapper decoding -------------------------------------------------------
+
+  @spec parse_wrapper(binary()) :: {:ok, parsed()} | {:error, :invalid_erc6492_wrapper}
+  defp parse_wrapper(
+         <<0::unsigned-big-integer-size(96), factory_bytes::binary-size(20),
+           calldata_offset::unsigned-big-integer-size(256),
+           signature_offset::unsigned-big-integer-size(256), _rest::binary>> = encoded
+       ) do
+    with {:ok, factory_calldata} <- decode_dynamic_bytes(encoded, calldata_offset),
+         {:ok, inner_signature} <- decode_dynamic_bytes(encoded, signature_offset) do
+      factory = "0x" <> Base.encode16(factory_bytes, case: :lower)
+
+      case factory != @zero_address and factory_calldata != <<>> do
+        true ->
+          {:ok,
+           %{
+             wrapped?: true,
+             factory: factory,
+             factory_calldata: factory_calldata,
+             inner_signature: inner_signature
+           }}
+
+        false ->
+          {:ok,
+           %{
+             wrapped?: true,
+             factory: nil,
+             factory_calldata: nil,
+             inner_signature: inner_signature
+           }}
+      end
+    end
+  end
+
+  defp parse_wrapper(_encoded), do: {:error, :invalid_erc6492_wrapper}
+
+  @spec decode_dynamic_bytes(binary(), non_neg_integer()) ::
+          {:ok, binary()} | {:error, :invalid_erc6492_wrapper}
+  defp decode_dynamic_bytes(encoded, offset)
+       when is_integer(offset) and offset + 32 <= byte_size(encoded) do
+    <<length::unsigned-big-integer-size(256)>> = binary_part(encoded, offset, 32)
+
+    case offset + 32 + length <= byte_size(encoded) do
+      true -> {:ok, binary_part(encoded, offset + 32, length)}
+      false -> {:error, :invalid_erc6492_wrapper}
+    end
+  end
+
+  defp decode_dynamic_bytes(_encoded, _offset), do: {:error, :invalid_erc6492_wrapper}
+
+  # -- Encoding helpers -------------------------------------------------------
+
+  @spec encode_dynamic_bytes(binary()) :: binary()
+  defp encode_dynamic_bytes(bytes) do
+    <<byte_size(bytes)::unsigned-big-integer-size(256)>> <> pad_right(bytes)
+  end
+
+  @spec pad_right(binary()) :: binary()
+  defp pad_right(bytes) do
+    case rem(byte_size(bytes), 32) do
+      0 -> bytes
+      remainder -> bytes <> :binary.copy(<<0>>, 32 - remainder)
+    end
+  end
+
+  @spec padded_size(binary()) :: non_neg_integer()
+  defp padded_size(bytes), do: byte_size(pad_right(bytes))
+
+  # -- Input decoding ---------------------------------------------------------
+
+  @spec decode_signature_bytes(binary()) :: {:ok, binary()} | {:error, :invalid_signature}
+  defp decode_signature_bytes("0x" <> hex) do
+    case Base.decode16(hex, case: :mixed) do
+      {:ok, bytes} -> {:ok, bytes}
+      :error -> {:error, :invalid_signature}
+    end
+  end
+
+  defp decode_signature_bytes(bytes) when is_binary(bytes), do: {:ok, bytes}
+
+  @spec magic_suffix?(binary()) :: boolean()
+  defp magic_suffix?(bytes) when byte_size(bytes) >= 32 do
+    binary_part(bytes, byte_size(bytes) - 32, 32) == @magic_suffix
+  end
+
+  defp magic_suffix?(_bytes), do: false
+end

--- a/lib/x402/erc6492.ex
+++ b/lib/x402/erc6492.ex
@@ -147,7 +147,7 @@ defmodule X402.ERC6492 do
   @spec wrap(String.t(), binary(), binary()) :: {:ok, binary()} | {:error, :invalid_address}
   def wrap(factory, factory_calldata, inner_signature)
       when is_binary(factory) and is_binary(factory_calldata) and is_binary(inner_signature) do
-    with {:ok, factory_word} <- X402.EIP3009.encode_address(factory) do
+    with {:ok, factory_word} <- X402.EIP712.encode_address(factory) do
       calldata_offset = 3 * 32
       signature_offset = calldata_offset + 32 + padded_size(factory_calldata)
 

--- a/lib/x402/rpc.ex
+++ b/lib/x402/rpc.ex
@@ -1,0 +1,384 @@
+defmodule X402.RPC do
+  @moduledoc """
+  Minimal Ethereum JSON-RPC client over Finch.
+
+  Provides exactly the read-only RPC surface local payment verification needs:
+  `eth_call`, `eth_getCode`, `eth_chainId`, and ordered batch requests. It is
+  not a general-purpose Ethereum client — there is no transaction signing, no
+  filter/subscription support, and no ABI layer.
+
+  Requires the optional `:finch` dependency at runtime; every request returns
+  `{:error, :missing_dependency}` when Finch is unavailable. Users bring their
+  own Finch pool, exactly as with `X402.Facilitator.HTTP`:
+
+      {:ok, rpc} =
+        X402.RPC.new(
+          rpc_url: "https://sepolia.base.org",
+          finch: MyApp.Finch
+        )
+
+      {:ok, "0x14a34"} = X402.RPC.chain_id(rpc)
+
+  ## TLS Verification
+
+  `rpc_url` must use `https://` (plain `http://` is allowed only for
+  `localhost`), and TLS peer verification must be configured on the Finch
+  pool — see `X402.Facilitator.HTTP.secure_pool_opts/0` for a ready-made
+  configuration.
+
+  ## Telemetry
+
+  Every request emits `[:x402, :rpc, :request]` with `:status` (`:ok` or
+  `:error`) and `:method` metadata (the string method name, or `:batch`).
+  """
+
+  alias X402.Telemetry
+  alias X402.Utils
+
+  @enforce_keys [:rpc_url, :finch]
+  defstruct [:rpc_url, :finch, timeout: 5_000]
+
+  @typedoc "A Finch pool identifier, as accepted by `Finch.request/3`."
+  @type finch_name :: atom() | pid() | {:via, module(), term()}
+
+  @typedoc "Validated JSON-RPC endpoint configuration built by `new/1`."
+  @type t :: %__MODULE__{rpc_url: String.t(), finch: finch_name(), timeout: pos_integer()}
+
+  @typedoc "A JSON-RPC error object returned by the node."
+  @type jsonrpc_error :: %{code: integer() | nil, message: String.t() | nil, data: term()}
+
+  @typedoc "Structured request errors."
+  @type error ::
+          :missing_dependency
+          | :insecure_rpc_url
+          | {:transport_error, term()}
+          | {:http_error, non_neg_integer()}
+          | {:invalid_response, term()}
+          | {:jsonrpc_error, jsonrpc_error()}
+
+  @typedoc "One request in a batch: a JSON-RPC method name and its params."
+  @type batch_request :: {String.t(), list()}
+
+  @typedoc "Per-request outcome inside a successful batch response."
+  @type batch_result :: {:ok, term()} | {:error, {:jsonrpc_error, jsonrpc_error()}}
+
+  @config_schema [
+    rpc_url: [
+      type: :string,
+      required: true,
+      doc: """
+      The JSON-RPC endpoint URL. Must use `https://`; plain `http://` is
+      accepted only for `localhost` (local development nodes and tests).
+      """
+    ],
+    finch: [
+      type: {:custom, __MODULE__, :validate_finch_name, []},
+      required: true,
+      doc: "The Finch pool name (atom, pid, or `{:via, module, term}`)."
+    ],
+    timeout: [
+      type: :pos_integer,
+      default: 5_000,
+      doc: "Receive timeout per HTTP request, in milliseconds."
+    ]
+  ]
+
+  @json_headers [{"content-type", "application/json"}, {"accept", "application/json"}]
+
+  @doc since: "0.6.0"
+  @doc """
+  Builds a validated RPC configuration.
+
+  Options are validated with `NimbleOptions`:
+
+  #{NimbleOptions.docs(@config_schema)}
+
+  Returns `{:error, :insecure_rpc_url}` when `rpc_url` does not use
+  `https://` (with a `localhost` exemption for development nodes).
+
+  ## Examples
+
+      iex> {:ok, rpc} = X402.RPC.new(rpc_url: "https://sepolia.base.org", finch: MyFinch)
+      iex> rpc.timeout
+      5000
+
+      iex> X402.RPC.new(rpc_url: "http://rpc.example.com", finch: MyFinch)
+      {:error, :insecure_rpc_url}
+  """
+  @spec new(keyword()) :: {:ok, t()} | {:error, :insecure_rpc_url}
+  def new(opts) when is_list(opts) do
+    validated = NimbleOptions.validate!(opts, @config_schema)
+    rpc_url = Keyword.fetch!(validated, :rpc_url)
+
+    case validate_url_scheme(rpc_url) do
+      :ok ->
+        {:ok,
+         %__MODULE__{
+           rpc_url: rpc_url,
+           finch: Keyword.fetch!(validated, :finch),
+           timeout: Keyword.fetch!(validated, :timeout)
+         }}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Performs a single JSON-RPC request.
+
+  Returns the decoded `"result"` value on success, or a structured error —
+  node-side failures come back as `{:error, {:jsonrpc_error, %{code: _,
+  message: _, data: _}}}` and transport failures as
+  `{:error, {:transport_error, reason}}`.
+  """
+  @spec request(t(), String.t(), list()) :: {:ok, term()} | {:error, error()}
+  def request(%__MODULE__{} = rpc, method, params) when is_binary(method) and is_list(params) do
+    body = %{"jsonrpc" => "2.0", "id" => 1, "method" => method, "params" => params}
+
+    case post(rpc, body) do
+      {:ok, decoded} ->
+        emit_result(decode_single(decoded), method)
+
+      {:error, reason} ->
+        Telemetry.emit(:rpc, :request, :error, %{method: method, reason: reason})
+        {:error, reason}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Performs an ordered JSON-RPC batch request in one HTTP round-trip.
+
+  Takes a list of `{method, params}` tuples and returns `{:ok, results}`
+  where `results` has one entry per request, **in request order** (responses
+  are re-ordered by id): each entry is `{:ok, result}` or
+  `{:error, {:jsonrpc_error, error}}`. Transport-level failures fail the
+  whole batch with `{:error, reason}`.
+
+  An empty request list returns `{:ok, []}` without any HTTP call.
+  """
+  @spec batch(t(), [batch_request()]) :: {:ok, [batch_result()]} | {:error, error()}
+  def batch(%__MODULE__{}, []), do: {:ok, []}
+
+  def batch(%__MODULE__{} = rpc, requests) when is_list(requests) do
+    body =
+      requests
+      |> Enum.with_index(1)
+      |> Enum.map(fn {{method, params}, id} when is_binary(method) and is_list(params) ->
+        %{"jsonrpc" => "2.0", "id" => id, "method" => method, "params" => params}
+      end)
+
+    case post(rpc, body) do
+      {:ok, responses} ->
+        emit_result(decode_batch(responses, length(requests)), :batch)
+
+      {:error, reason} ->
+        Telemetry.emit(:rpc, :request, :error, %{method: :batch, reason: reason})
+        {:error, reason}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Performs an `eth_call` against the given block (default `"latest"`).
+
+  The call object accepts `:to`, `:data`, and optionally `:from` (atom or
+  string keys). Returns the raw `0x`-prefixed return data.
+  """
+  @spec call(t(), map(), String.t()) :: {:ok, String.t()} | {:error, error()}
+  def call(%__MODULE__{} = rpc, call_object, block \\ "latest") when is_map(call_object) do
+    request(rpc, "eth_call", [normalize_call_object(call_object), block])
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the bytecode at `address` via `eth_getCode` (default block
+  `"latest"`).
+
+  A plain externally-owned account returns `{:ok, "0x"}`.
+  """
+  @spec get_code(t(), String.t(), String.t()) :: {:ok, String.t()} | {:error, error()}
+  def get_code(%__MODULE__{} = rpc, address, block \\ "latest") when is_binary(address) do
+    request(rpc, "eth_getCode", [address, block])
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the chain id via `eth_chainId`, as the node's hex string
+  (for example `"0x14a34"` for Base Sepolia).
+  """
+  @spec chain_id(t()) :: {:ok, String.t()} | {:error, error()}
+  def chain_id(%__MODULE__{} = rpc), do: request(rpc, "eth_chainId", [])
+
+  @doc since: "0.6.0"
+  @doc """
+  Validates that a value is an `%X402.RPC{}` configuration.
+
+  Designed for `NimbleOptions` custom validation (used by
+  `X402.Verify.EVM`).
+  """
+  @spec validate_config(term()) :: {:ok, t()} | {:error, String.t()}
+  def validate_config(%__MODULE__{} = rpc), do: {:ok, rpc}
+
+  def validate_config(_other),
+    do: {:error, "expected an %X402.RPC{} configuration built with X402.RPC.new/1"}
+
+  @doc false
+  @spec validate_finch_name(term()) :: {:ok, finch_name()} | {:error, String.t()}
+  def validate_finch_name(name) when is_atom(name) and not is_nil(name), do: {:ok, name}
+  def validate_finch_name(pid) when is_pid(pid), do: {:ok, pid}
+  def validate_finch_name({:via, module, _term} = via) when is_atom(module), do: {:ok, via}
+
+  def validate_finch_name(_other),
+    do: {:error, "expected a Finch pool name (atom, pid, or {:via, module, term})"}
+
+  # -- Transport --------------------------------------------------------------
+
+  @spec post(t(), map() | list()) :: {:ok, term()} | {:error, error()}
+  defp post(%__MODULE__{} = rpc, body) do
+    with {:ok, finch_module} <- ensure_finch_module(),
+         {:ok, encoded} <- encode_body(body),
+         {:ok, response_body} <- perform_request(rpc, finch_module, encoded) do
+      decode_body(response_body)
+    end
+  end
+
+  @spec perform_request(t(), module(), iodata()) ::
+          {:ok, binary()}
+          | {:error, {:transport_error, term()} | {:http_error, non_neg_integer()}}
+  defp perform_request(rpc, finch_module, encoded) do
+    request = finch_module.build(:post, rpc.rpc_url, @json_headers, encoded)
+
+    response =
+      try do
+        finch_module.request(request, rpc.finch, receive_timeout: rpc.timeout)
+      catch
+        :exit, reason -> {:error, reason}
+      end
+
+    case response do
+      {:ok, %{status: status, body: response_body}} when status in 200..299 ->
+        {:ok, response_body}
+
+      {:ok, %{status: status}} when is_integer(status) ->
+        {:error, {:http_error, status}}
+
+      {:error, reason} ->
+        {:error, {:transport_error, reason}}
+    end
+  end
+
+  @spec encode_body(term()) :: {:ok, iodata()} | {:error, {:invalid_response, term()}}
+  defp encode_body(body) do
+    case Jason.encode(body) do
+      {:ok, encoded} -> {:ok, encoded}
+      {:error, reason} -> {:error, {:invalid_response, reason}}
+    end
+  end
+
+  @spec decode_body(binary()) :: {:ok, term()} | {:error, {:invalid_response, term()}}
+  defp decode_body(body) do
+    case Jason.decode(body) do
+      {:ok, decoded} -> {:ok, decoded}
+      {:error, reason} -> {:error, {:invalid_response, reason}}
+    end
+  end
+
+  # -- Response decoding ------------------------------------------------------
+
+  @spec decode_single(term()) :: {:ok, term()} | {:error, error()}
+  defp decode_single(%{"error" => error}) when is_map(error),
+    do: {:error, {:jsonrpc_error, normalize_jsonrpc_error(error)}}
+
+  defp decode_single(%{"result" => result}), do: {:ok, result}
+  defp decode_single(other), do: {:error, {:invalid_response, other}}
+
+  @spec decode_batch(term(), pos_integer()) :: {:ok, [batch_result()]} | {:error, error()}
+  defp decode_batch(responses, count) when is_list(responses) do
+    by_id = Map.new(responses, fn response -> {response_id(response), response} end)
+
+    results =
+      Enum.map(1..count, fn id ->
+        case Map.fetch(by_id, id) do
+          {:ok, response} -> decode_single(response)
+          :error -> {:error, {:invalid_response, {:missing_response, id}}}
+        end
+      end)
+
+    case Enum.find(results, &match?({:error, {:invalid_response, _reason}}, &1)) do
+      nil -> {:ok, results}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp decode_batch(other, _count), do: {:error, {:invalid_response, other}}
+
+  @spec response_id(term()) :: term()
+  defp response_id(%{"id" => id}), do: id
+  defp response_id(_response), do: nil
+
+  @spec normalize_jsonrpc_error(map()) :: jsonrpc_error()
+  defp normalize_jsonrpc_error(error) do
+    %{
+      code: normalize_code(Map.get(error, "code")),
+      message: normalize_message(Map.get(error, "message")),
+      data: Map.get(error, "data")
+    }
+  end
+
+  defp normalize_code(code) when is_integer(code), do: code
+  defp normalize_code(_code), do: nil
+
+  defp normalize_message(message) when is_binary(message), do: message
+  defp normalize_message(_message), do: nil
+
+  # -- Helpers ----------------------------------------------------------------
+
+  @spec emit_result({:ok, term()} | {:error, error()}, String.t() | :batch) ::
+          {:ok, term()} | {:error, error()}
+  defp emit_result({:ok, _result} = ok, method) do
+    Telemetry.emit(:rpc, :request, :ok, %{method: method})
+    ok
+  end
+
+  defp emit_result({:error, reason} = error, method) do
+    Telemetry.emit(:rpc, :request, :error, %{method: method, reason: reason})
+    error
+  end
+
+  @spec normalize_call_object(map()) :: map()
+  defp normalize_call_object(call_object) do
+    [{"to", :to}, {"data", :data}, {"from", :from}]
+    |> Enum.reduce(%{}, fn {string_key, atom_key}, acc ->
+      case Utils.map_value(call_object, {string_key, atom_key}) do
+        nil -> acc
+        value -> Map.put(acc, string_key, value)
+      end
+    end)
+  end
+
+  @spec ensure_finch_module() :: {:ok, module()} | {:error, :missing_dependency}
+  defp ensure_finch_module do
+    finch_module = Module.concat(["Finch"])
+
+    case Code.ensure_loaded?(finch_module) and function_exported?(finch_module, :request, 3) and
+           function_exported?(finch_module, :build, 4) do
+      true -> {:ok, finch_module}
+      false -> {:error, :missing_dependency}
+    end
+  end
+
+  # Mirrors X402.Facilitator.HTTP: JSON-RPC requests carry payment payloads,
+  # so plaintext transport is refused. Loopback hosts are exempt because they
+  # cannot be intercepted by a network attacker (local dev nodes, tests).
+  @spec validate_url_scheme(String.t()) :: :ok | {:error, :insecure_rpc_url}
+  defp validate_url_scheme(rpc_url) do
+    case URI.parse(rpc_url) do
+      %URI{scheme: "https"} -> :ok
+      %URI{scheme: "http", host: host} when host in ["localhost", "127.0.0.1", "::1"] -> :ok
+      _uri -> {:error, :insecure_rpc_url}
+    end
+  end
+end

--- a/lib/x402/telemetry.ex
+++ b/lib/x402/telemetry.ex
@@ -18,13 +18,16 @@ defmodule X402.Telemetry do
   - `[:x402, :client, :sign]`
   - `[:x402, :client, :build]`
   - `[:x402, :client, :request]`
+  - `[:x402, :rpc, :request]`
+  - `[:x402, :verify, :evm]`
 
   Metadata always includes `:status` (`:ok` or `:error`) and may include
   additional operation-specific fields such as `:reason`, `:header`, or
   `:fields`.
   """
 
-  @type module_name :: :payment_required | :payment_signature | :payment_response | :client
+  @type module_name ::
+          :payment_required | :payment_signature | :payment_response | :client | :rpc | :verify
   @type operation ::
           :encode
           | :decode
@@ -34,6 +37,7 @@ defmodule X402.Telemetry do
           | :sign
           | :build
           | :request
+          | :evm
   @type status :: :ok | :error
 
   @doc since: "0.1.0"

--- a/lib/x402/verify/evm.ex
+++ b/lib/x402/verify/evm.ex
@@ -99,6 +99,7 @@ defmodule X402.Verify.EVM do
   """
 
   alias X402.EIP3009
+  alias X402.EIP712
   alias X402.ERC6492
   alias X402.RPC
   alias X402.Telemetry
@@ -990,13 +991,13 @@ defmodule X402.Verify.EVM do
 
   @spec authorization_state_args(map()) :: binary()
   defp authorization_state_args(ctx) do
-    {:ok, nonce_word} = EIP3009.encode_bytes32(ctx.nonce)
+    {:ok, nonce_word} = EIP712.encode_bytes32(ctx.nonce)
     address_word(ctx.payer) <> nonce_word
   end
 
   @spec address_word(String.t()) :: binary()
   defp address_word(address) do
-    {:ok, word} = EIP3009.encode_address(address)
+    {:ok, word} = EIP712.encode_address(address)
     word
   end
 
@@ -1025,17 +1026,17 @@ defmodule X402.Verify.EVM do
   @spec authorization_words(map()) :: binary()
   defp authorization_words(ctx) do
     authorization = ctx.authorization
-    {:ok, from} = EIP3009.encode_address(Utils.map_value(authorization, {"from", :from}))
-    {:ok, to} = EIP3009.encode_address(Utils.map_value(authorization, {"to", :to}))
-    {:ok, value} = EIP3009.encode_uint256(ctx.value)
+    {:ok, from} = EIP712.encode_address(Utils.map_value(authorization, {"from", :from}))
+    {:ok, to} = EIP712.encode_address(Utils.map_value(authorization, {"to", :to}))
+    {:ok, value} = EIP712.encode_uint256(ctx.value)
 
     {:ok, valid_after} =
-      EIP3009.encode_uint256(Utils.map_value(authorization, {"validAfter", :valid_after}))
+      EIP712.encode_uint256(Utils.map_value(authorization, {"validAfter", :valid_after}))
 
     {:ok, valid_before} =
-      EIP3009.encode_uint256(Utils.map_value(authorization, {"validBefore", :valid_before}))
+      EIP712.encode_uint256(Utils.map_value(authorization, {"validBefore", :valid_before}))
 
-    {:ok, nonce} = EIP3009.encode_bytes32(ctx.nonce)
+    {:ok, nonce} = EIP712.encode_bytes32(ctx.nonce)
 
     from <> to <> value <> valid_after <> valid_before <> nonce
   end

--- a/lib/x402/verify/evm.ex
+++ b/lib/x402/verify/evm.ex
@@ -1,0 +1,1198 @@
+defmodule X402.Verify.EVM do
+  @moduledoc """
+  Local verification of EVM `exact`/`eip3009` payment payloads.
+
+  Runs the full facilitator verify checklist from the exact-EVM scheme
+  specification locally, so an Elixir resource server can cryptographically
+  verify payments instead of trusting a remote facilitator's `verify`
+  endpoint. The checks mirror the reference TypeScript/Go/Python facilitator
+  engines check for check.
+
+  ## Verification levels
+
+  The `:level` option is required and explicit — a level whose capabilities
+  are unavailable returns an error instead of silently downgrading:
+
+  * `:structural` — pure checks, no cryptography and no RPC: scheme,
+    network, and EIP-712 domain requirements; payload shape; `payTo`
+    recipient equality; exact amount equality; and the
+    `validAfter`/`validBefore` window with the reference implementations'
+    6-second settlement buffer.
+
+  * `:signature` — everything in `:structural`, plus EIP-712 digest
+    recomputation and EOA signature recovery (requires the optional
+    `ex_keccak` and `ex_secp256k1` dependencies, otherwise
+    `{:error, :missing_dependency}`). Smart-wallet signatures (ERC-1271 /
+    ERC-6492) cannot be proven without RPC and are rejected with
+    `{:error, {:invalid, :smart_wallet_requires_rpc}}` — fail closed, never
+    assume.
+
+  * `:full` — everything in `:signature`, plus on-chain checks over a
+    configured `X402.RPC` endpoint (otherwise
+    `{:error, :rpc_not_configured}`): chain-id cross-check, signature
+    routing by payer bytecode (EOA `ecrecover` when the payer has no code,
+    strict ERC-1271 `isValidSignature` when it does — no ECDSA fallback,
+    matching on-chain `SignatureChecker` semantics), ERC-6492 counterfactual
+    handling, asset bytecode presence, `balanceOf` funding, and an
+    `eth_call` simulation of `transferWithAuthorization` with failure
+    diagnosis (nonce already used, insufficient balance, token domain
+    mismatch, ...).
+
+  ## ERC-6492 counterfactual signatures (fail-closed)
+
+  A wrapped signature from an undeployed wallet is **never** accepted on the
+  strength of the wrapper alone (the reference Go design):
+
+  * the deployment factory must appear in `:eip6492_allowed_factories`
+    (default `[]` — all counterfactual payments are rejected with
+    `{:invalid, :eip6492_factory_not_allowed}` until factories are
+    explicitly trusted), and
+  * validity is proven only by an atomic Multicall3 simulation that deploys
+    the wallet and executes the transfer in a single `eth_call`. With
+    `simulate: false` counterfactual payments are rejected with
+    `{:invalid, :undeployed_smart_wallet}`.
+
+  ## Example
+
+      {:ok, payload} = X402.PaymentSignature.decode_and_validate(header, requirements)
+
+      {:ok, rpc} = X402.RPC.new(rpc_url: "https://sepolia.base.org", finch: MyApp.Finch)
+
+      case X402.Verify.EVM.verify(payload, requirements, level: :full, rpc: rpc) do
+        {:ok, %{payer: payer}} -> grant_access(payer)
+        {:error, _reason} -> deny_access()
+      end
+
+  The result never silently downgrades: `{:ok, result}` means the payment
+  passed every check the stated `:level` includes, and `result.level` echoes
+  that level.
+
+  Structural-only verification is pure and needs no optional dependency:
+
+      iex> requirements = %{
+      ...>   "scheme" => "exact",
+      ...>   "network" => "eip155:84532",
+      ...>   "amount" => "10000",
+      ...>   "asset" => "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      ...>   "payTo" => "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      ...>   "maxTimeoutSeconds" => 60,
+      ...>   "extra" => %{"name" => "USDC", "version" => "2"}
+      ...> }
+      iex> payload = %{
+      ...>   "x402Version" => 2,
+      ...>   "accepted" => requirements,
+      ...>   "payload" => %{
+      ...>     "signature" => "0x" <> String.duplicate("11", 65),
+      ...>     "authorization" => %{
+      ...>       "from" => "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+      ...>       "to" => "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      ...>       "value" => "10000",
+      ...>       "validAfter" => "0",
+      ...>       "validBefore" => "32503680000",
+      ...>       "nonce" => "0x" <> String.duplicate("ab", 32)
+      ...>     }
+      ...>   }
+      ...> }
+      iex> {:ok, result} = X402.Verify.EVM.verify(payload, requirements, level: :structural)
+      iex> {result.level, result.payer}
+      {:structural, "0x857b06519e91e3a54538791bdbb0e22373e36b66"}
+  """
+
+  alias X402.EIP3009
+  alias X402.ERC6492
+  alias X402.RPC
+  alias X402.Telemetry
+  alias X402.Utils
+  alias X402.Wallet
+
+  # Settlement buffer applied to validBefore, matching the reference
+  # facilitators (block inclusion time).
+  @time_buffer_seconds 6
+
+  # Canonical Multicall3 deployment (same address on all supported chains).
+  @multicall3_address "0xcA11bde05977b3631167028862bE2a173976CA11"
+
+  # Function selectors (first 4 bytes of keccak256 of the signature). They are
+  # hardcoded so the module works without the optional keccak dependency; the
+  # test suite recomputes them with ExKeccak to guard against typos.
+  @selector_is_valid_signature <<0x16, 0x26, 0xBA, 0x7E>>
+  @selector_balance_of <<0x70, 0xA0, 0x82, 0x31>>
+  @selector_authorization_state <<0xE9, 0x4A, 0x01, 0x02>>
+  @selector_transfer_vrs <<0xE3, 0xEE, 0x16, 0x0E>>
+  @selector_transfer_bytes <<0xCF, 0x09, 0x29, 0x95>>
+  @selector_name <<0x06, 0xFD, 0xDE, 0x03>>
+  @selector_version <<0x54, 0xFD, 0x4D, 0x50>>
+  @selector_aggregate3 <<0x82, 0xAD, 0x56, 0xCB>>
+
+  @erc1271_magic_value <<0x16, 0x26, 0xBA, 0x7E>>
+
+  @typedoc "Requested verification depth."
+  @type level :: :structural | :signature | :full
+
+  @typedoc "How the payment signature was (or would be) verified."
+  @type signature_type :: :eoa | :erc1271 | :erc6492_counterfactual
+
+  @typedoc """
+  A successful verification.
+
+  `payer` is the lowercase authorization `from` address. `level` echoes the
+  level that was run. `signature_type` is `nil` at `:structural` (no
+  signature classification happens without cryptography).
+  """
+  @type verification :: %{
+          payer: String.t(),
+          level: level(),
+          signature_type: signature_type() | nil
+        }
+
+  @typedoc """
+  Why a payment was rejected.
+
+  Reasons map onto the canonical cross-SDK `invalidReason` strings via
+  `reason_string/1` where an equivalent exists.
+  """
+  @type invalid_reason ::
+          :invalid_payload
+          | :invalid_authorization
+          | :invalid_requirements
+          | :scheme_mismatch
+          | :unsupported_transfer_method
+          | :unsupported_network
+          | :network_mismatch
+          | :missing_eip712_domain
+          | :recipient_mismatch
+          | :value_mismatch
+          | :valid_before_expired
+          | :valid_after_in_future
+          | :invalid_signature
+          | :smart_wallet_requires_rpc
+          | :undeployed_smart_wallet
+          | :eip6492_factory_not_allowed
+          | :asset_not_deployed_contract
+          | :balance_check_failed
+          | :insufficient_balance
+          | :eip3009_not_supported
+          | :nonce_already_used
+          | :token_name_mismatch
+          | :token_version_mismatch
+          | :simulation_failed
+
+  @typedoc "Verification errors."
+  @type error ::
+          {:invalid, invalid_reason()}
+          | :missing_dependency
+          | :rpc_not_configured
+          | {:rpc_error, RPC.error()}
+          | {:chain_id_mismatch, non_neg_integer(), non_neg_integer()}
+
+  @verify_opts_schema [
+    level: [
+      type: {:in, [:structural, :signature, :full]},
+      required: true,
+      doc: """
+      Verification depth. `:structural` needs nothing, `:signature` needs the
+      optional crypto dependencies, `:full` additionally needs `:rpc`. A
+      level never silently downgrades.
+      """
+    ],
+    rpc: [
+      type: {:custom, RPC, :validate_config, []},
+      doc: "An `X402.RPC` configuration. Required for level `:full`."
+    ],
+    simulate: [
+      type: :boolean,
+      default: true,
+      doc: """
+      Whether level `:full` simulates `transferWithAuthorization` via
+      `eth_call`. Counterfactual ERC-6492 payments always require simulation
+      and are rejected when it is disabled.
+      """
+    ],
+    verify_chain_id: [
+      type: :boolean,
+      default: true,
+      doc: """
+      Whether level `:full` cross-checks `eth_chainId` against the CAIP-2
+      network in the requirements, guarding against a misconfigured RPC
+      endpoint. Adds no extra round-trip (batched with the other reads).
+      """
+    ],
+    eip6492_allowed_factories: [
+      type: {:list, :string},
+      default: [],
+      doc: """
+      Factory contract addresses trusted to deploy counterfactual ERC-6492
+      smart wallets (case-insensitive). The default empty list rejects every
+      counterfactual payment.
+      """
+    ],
+    multicall_address: [
+      type: :string,
+      default: @multicall3_address,
+      doc: "The Multicall3 contract used for atomic ERC-6492 deploy-and-transfer simulation."
+    ]
+  ]
+
+  @doc since: "0.6.0", group: :verification
+  @doc """
+  Verifies a decoded v2 `PaymentPayload` against payment requirements.
+
+  `payment_payload` is the decoded v2 envelope (as returned by
+  `X402.PaymentSignature.decode_and_validate/2`) and `requirements` the
+  matched `PaymentRequirements` object. Both accept string or atom keys.
+
+  Returns `{:ok, verification}` when the payment passes every check the
+  stated `:level` includes, `{:error, {:invalid, reason}}` when a check
+  fails, and a capability error (`:missing_dependency`,
+  `:rpc_not_configured`) when the level cannot run — never a silent
+  downgrade. RPC transport failures return `{:error, {:rpc_error, reason}}`
+  (fail closed: the payment is not proven valid).
+
+  ## Options
+
+  #{NimbleOptions.docs(@verify_opts_schema)}
+
+  ## Examples
+
+      iex> X402.Verify.EVM.verify(%{"x402Version" => 2}, %{}, level: :structural)
+      {:error, {:invalid, :invalid_payload}}
+  """
+  @spec verify(map(), map(), keyword()) :: {:ok, verification()} | {:error, error()}
+  def verify(payment_payload, requirements, opts)
+      when is_map(payment_payload) and is_map(requirements) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @verify_opts_schema)
+    level = Keyword.fetch!(opts, :level)
+
+    case do_verify(payment_payload, requirements, level, opts) do
+      {:ok, result} ->
+        Telemetry.emit(:verify, :evm, :ok, %{level: level})
+        {:ok, result}
+
+      {:error, reason} ->
+        Telemetry.emit(:verify, :evm, :error, %{level: level, reason: reason})
+        {:error, reason}
+    end
+  end
+
+  @doc since: "0.6.0", group: :verification
+  @doc """
+  Maps an `invalid` reason atom to the canonical cross-SDK `invalidReason`
+  string used by the reference facilitators.
+
+  Local-only reasons without a canonical wire equivalent fall back to their
+  atom name.
+
+  ## Examples
+
+      iex> X402.Verify.EVM.reason_string(:recipient_mismatch)
+      "invalid_exact_evm_recipient_mismatch"
+
+      iex> X402.Verify.EVM.reason_string(:nonce_already_used)
+      "invalid_exact_evm_nonce_already_used"
+
+      iex> X402.Verify.EVM.reason_string(:invalid_payload)
+      "invalid_payload"
+  """
+  @spec reason_string(invalid_reason()) :: String.t()
+  def reason_string(reason) when is_atom(reason) do
+    Map.get(reason_strings(), reason, Atom.to_string(reason))
+  end
+
+  @spec reason_strings() :: %{invalid_reason() => String.t()}
+  defp reason_strings do
+    %{
+      scheme_mismatch: "invalid_exact_evm_scheme",
+      unsupported_transfer_method: "invalid_exact_evm_scheme",
+      network_mismatch: "invalid_exact_evm_network_mismatch",
+      unsupported_network: "invalid_exact_evm_network_mismatch",
+      missing_eip712_domain: "invalid_exact_evm_missing_eip712_domain",
+      recipient_mismatch: "invalid_exact_evm_recipient_mismatch",
+      invalid_signature: "invalid_exact_evm_signature",
+      smart_wallet_requires_rpc: "invalid_exact_evm_signature",
+      valid_before_expired: "invalid_exact_evm_payload_authorization_valid_before",
+      valid_after_in_future: "invalid_exact_evm_payload_authorization_valid_after",
+      value_mismatch: "invalid_exact_evm_payload_authorization_value_mismatch",
+      undeployed_smart_wallet: "invalid_exact_evm_payload_undeployed_smart_wallet",
+      eip6492_factory_not_allowed: "eip6492_factory_not_allowed",
+      asset_not_deployed_contract: "asset_not_deployed_contract",
+      insufficient_balance: "invalid_exact_evm_insufficient_balance",
+      balance_check_failed: "invalid_exact_evm_transaction_simulation_failed",
+      eip3009_not_supported: "invalid_exact_evm_eip3009_not_supported",
+      nonce_already_used: "invalid_exact_evm_nonce_already_used",
+      token_name_mismatch: "invalid_exact_evm_token_name_mismatch",
+      token_version_mismatch: "invalid_exact_evm_token_version_mismatch",
+      simulation_failed: "invalid_exact_evm_transaction_simulation_failed"
+    }
+  end
+
+  # -- Pipeline ---------------------------------------------------------------
+
+  @spec do_verify(map(), map(), level(), keyword()) ::
+          {:ok, verification()} | {:error, error()}
+  defp do_verify(payment_payload, requirements, level, opts) do
+    with {:ok, ctx} <- build_context(payment_payload, requirements) do
+      run_level(level, ctx, opts)
+    end
+  end
+
+  @spec run_level(level(), map(), keyword()) :: {:ok, verification()} | {:error, error()}
+  defp run_level(:structural, ctx, _opts), do: {:ok, result(ctx, :structural, nil)}
+  defp run_level(:signature, ctx, _opts), do: signature_verify(ctx)
+  defp run_level(:full, ctx, opts), do: full_verify(ctx, opts)
+
+  @spec result(map(), level(), signature_type() | nil) :: verification()
+  defp result(ctx, level, signature_type),
+    do: %{payer: ctx.payer, level: level, signature_type: signature_type}
+
+  # -- Structural checks (no crypto, no RPC) ----------------------------------
+
+  @spec build_context(map(), map()) :: {:ok, map()} | {:error, {:invalid, invalid_reason()}}
+  defp build_context(payment_payload, requirements) do
+    accepted = Utils.map_value(payment_payload, {"accepted", :accepted})
+    scheme_payload = Utils.map_value(payment_payload, {"payload", :payload})
+
+    with :ok <- ensure_maps(accepted, scheme_payload),
+         :ok <- check_scheme(accepted, requirements),
+         :ok <- check_network_match(accepted, requirements),
+         {:ok, domain} <- derive_domain(requirements),
+         {:ok, signature_bytes} <- extract_signature(scheme_payload),
+         {:ok, authorization} <- extract_authorization(scheme_payload),
+         {:ok, timing} <- extract_timing(authorization),
+         {:ok, value} <- extract_amount(Utils.map_value(authorization, {"value", :value})),
+         {:ok, amount} <- extract_amount(Utils.map_value(requirements, {"amount", :amount})),
+         :ok <- check_recipient(authorization, requirements),
+         :ok <- check_value(value, amount),
+         :ok <- check_timing(timing) do
+      {:ok,
+       %{
+         domain: domain,
+         authorization: authorization,
+         signature_bytes: signature_bytes,
+         payer: String.downcase(Utils.map_value(authorization, {"from", :from})),
+         asset: domain.verifying_contract,
+         chain_id: domain.chain_id,
+         extra_name: domain.name,
+         extra_version: domain.version,
+         value: value,
+         nonce: Utils.map_value(authorization, {"nonce", :nonce})
+       }}
+    end
+  end
+
+  @spec ensure_maps(term(), term()) :: :ok | {:error, {:invalid, :invalid_payload}}
+  defp ensure_maps(accepted, scheme_payload)
+       when is_map(accepted) and is_map(scheme_payload),
+       do: :ok
+
+  defp ensure_maps(_accepted, _scheme_payload), do: {:error, {:invalid, :invalid_payload}}
+
+  @spec check_scheme(map(), map()) :: :ok | {:error, {:invalid, :scheme_mismatch}}
+  defp check_scheme(accepted, requirements) do
+    accepted_scheme = Utils.map_value(accepted, {"scheme", :scheme})
+    required_scheme = Utils.map_value(requirements, {"scheme", :scheme})
+
+    case accepted_scheme == "exact" and required_scheme == "exact" do
+      true -> :ok
+      false -> {:error, {:invalid, :scheme_mismatch}}
+    end
+  end
+
+  @spec check_network_match(map(), map()) :: :ok | {:error, {:invalid, :network_mismatch}}
+  defp check_network_match(accepted, requirements) do
+    accepted_network = Utils.map_value(accepted, {"network", :network})
+    required_network = Utils.map_value(requirements, {"network", :network})
+
+    case is_binary(accepted_network) and accepted_network == required_network do
+      true -> :ok
+      false -> {:error, {:invalid, :network_mismatch}}
+    end
+  end
+
+  @spec derive_domain(map()) :: {:ok, EIP3009.domain()} | {:error, {:invalid, invalid_reason()}}
+  defp derive_domain(requirements) do
+    with {:ok, domain} <- map_domain_error(EIP3009.domain(requirements)),
+         true <- Wallet.valid_evm?(domain.verifying_contract) do
+      {:ok, domain}
+    else
+      false -> {:error, {:invalid, :invalid_requirements}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @spec map_domain_error({:ok, EIP3009.domain()} | {:error, EIP3009.domain_error()}) ::
+          {:ok, EIP3009.domain()} | {:error, {:invalid, invalid_reason()}}
+  defp map_domain_error({:ok, domain}), do: {:ok, domain}
+
+  defp map_domain_error({:error, {:missing_extra, _key}}),
+    do: {:error, {:invalid, :missing_eip712_domain}}
+
+  defp map_domain_error({:error, {:unsupported_transfer_method, _method}}),
+    do: {:error, {:invalid, :unsupported_transfer_method}}
+
+  defp map_domain_error({:error, :unsupported_network}),
+    do: {:error, {:invalid, :unsupported_network}}
+
+  defp map_domain_error({:error, _reason}), do: {:error, {:invalid, :invalid_requirements}}
+
+  @spec extract_signature(map()) :: {:ok, binary()} | {:error, {:invalid, :invalid_signature}}
+  defp extract_signature(scheme_payload) do
+    with "0x" <> hex when hex != "" <- Utils.map_value(scheme_payload, {"signature", :signature}),
+         {:ok, bytes} <- Base.decode16(hex, case: :mixed) do
+      {:ok, bytes}
+    else
+      _other -> {:error, {:invalid, :invalid_signature}}
+    end
+  end
+
+  @spec extract_authorization(map()) ::
+          {:ok, map()} | {:error, {:invalid, :invalid_authorization}}
+  defp extract_authorization(scheme_payload) do
+    authorization = Utils.map_value(scheme_payload, {"authorization", :authorization})
+
+    with true <- is_map(authorization),
+         from = Utils.map_value(authorization, {"from", :from}),
+         to = Utils.map_value(authorization, {"to", :to}),
+         nonce = Utils.map_value(authorization, {"nonce", :nonce}),
+         true <- Wallet.valid_evm?(from),
+         true <- Wallet.valid_evm?(to),
+         true <- valid_nonce?(nonce) do
+      {:ok, authorization}
+    else
+      _other -> {:error, {:invalid, :invalid_authorization}}
+    end
+  end
+
+  @spec valid_nonce?(term()) :: boolean()
+  defp valid_nonce?("0x" <> hex) when byte_size(hex) == 64,
+    do: match?({:ok, _bytes}, Base.decode16(hex, case: :mixed))
+
+  defp valid_nonce?(_nonce), do: false
+
+  @spec extract_timing(map()) ::
+          {:ok, %{valid_after: non_neg_integer(), valid_before: non_neg_integer()}}
+          | {:error, {:invalid, :invalid_authorization}}
+  defp extract_timing(authorization) do
+    with {:ok, valid_after} <-
+           parse_non_neg_integer(Utils.map_value(authorization, {"validAfter", :valid_after})),
+         {:ok, valid_before} <-
+           parse_non_neg_integer(Utils.map_value(authorization, {"validBefore", :valid_before})) do
+      {:ok, %{valid_after: valid_after, valid_before: valid_before}}
+    else
+      :error -> {:error, {:invalid, :invalid_authorization}}
+    end
+  end
+
+  @spec extract_amount(term()) ::
+          {:ok, non_neg_integer()} | {:error, {:invalid, :invalid_authorization}}
+  defp extract_amount(value) do
+    case parse_non_neg_integer(value) do
+      {:ok, parsed} -> {:ok, parsed}
+      :error -> {:error, {:invalid, :invalid_authorization}}
+    end
+  end
+
+  @spec parse_non_neg_integer(term()) :: {:ok, non_neg_integer()} | :error
+  defp parse_non_neg_integer(value) when is_integer(value) and value >= 0, do: {:ok, value}
+
+  defp parse_non_neg_integer(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {parsed, ""} when parsed >= 0 -> {:ok, parsed}
+      _parsed -> :error
+    end
+  end
+
+  defp parse_non_neg_integer(_value), do: :error
+
+  @spec check_recipient(map(), map()) :: :ok | {:error, {:invalid, :recipient_mismatch}}
+  defp check_recipient(authorization, requirements) do
+    to = Utils.map_value(authorization, {"to", :to})
+    pay_to = Utils.map_value(requirements, {"payTo", :payTo})
+
+    case is_binary(pay_to) and String.downcase(to) == String.downcase(pay_to) do
+      true -> :ok
+      false -> {:error, {:invalid, :recipient_mismatch}}
+    end
+  end
+
+  @spec check_value(non_neg_integer(), non_neg_integer()) ::
+          :ok | {:error, {:invalid, :value_mismatch}}
+  defp check_value(value, amount) when value == amount, do: :ok
+  defp check_value(_value, _amount), do: {:error, {:invalid, :value_mismatch}}
+
+  @spec check_timing(%{valid_after: non_neg_integer(), valid_before: non_neg_integer()}) ::
+          :ok | {:error, {:invalid, :valid_before_expired | :valid_after_in_future}}
+  defp check_timing(%{valid_after: valid_after, valid_before: valid_before}) do
+    now = System.system_time(:second)
+
+    cond do
+      valid_before < now + @time_buffer_seconds -> {:error, {:invalid, :valid_before_expired}}
+      valid_after > now -> {:error, {:invalid, :valid_after_in_future}}
+      true -> :ok
+    end
+  end
+
+  # -- Level :signature (EOA crypto, no RPC) ----------------------------------
+
+  @spec signature_verify(map()) :: {:ok, verification()} | {:error, error()}
+  defp signature_verify(ctx) do
+    with {:ok, parsed} <- parse_signature(ctx.signature_bytes),
+         {:ok, digest} <- compute_digest(ctx),
+         :ok <- ensure_offline_verifiable(parsed),
+         :ok <- verify_eoa(ctx, digest, parsed.inner_signature) do
+      {:ok, result(ctx, :signature, :eoa)}
+    end
+  end
+
+  # A wrapped or non-65-byte signature belongs to a smart wallet; without RPC
+  # it cannot be proven valid, so it is rejected rather than assumed.
+  @spec ensure_offline_verifiable(ERC6492.parsed()) ::
+          :ok | {:error, {:invalid, :smart_wallet_requires_rpc}}
+  defp ensure_offline_verifiable(%{wrapped?: false, inner_signature: inner})
+       when byte_size(inner) == 65,
+       do: :ok
+
+  defp ensure_offline_verifiable(_parsed), do: {:error, {:invalid, :smart_wallet_requires_rpc}}
+
+  @spec parse_signature(binary()) ::
+          {:ok, ERC6492.parsed()} | {:error, {:invalid, :invalid_signature}}
+  defp parse_signature(signature_bytes) do
+    case ERC6492.parse(signature_bytes) do
+      {:ok, parsed} -> {:ok, parsed}
+      {:error, _reason} -> {:error, {:invalid, :invalid_signature}}
+    end
+  end
+
+  @spec compute_digest(map()) :: {:ok, <<_::256>>} | {:error, error()}
+  defp compute_digest(ctx) do
+    case EIP3009.eip712_digest(ctx.domain, ctx.authorization) do
+      {:ok, digest} -> {:ok, digest}
+      {:error, :missing_dependency} -> {:error, :missing_dependency}
+      {:error, _reason} -> {:error, {:invalid, :invalid_authorization}}
+    end
+  end
+
+  @spec verify_eoa(map(), binary(), binary()) ::
+          :ok | {:error, :missing_dependency | {:invalid, :invalid_signature}}
+  defp verify_eoa(_ctx, _digest, inner_signature) when byte_size(inner_signature) != 65,
+    do: {:error, {:invalid, :invalid_signature}}
+
+  defp verify_eoa(ctx, digest, inner_signature) do
+    case EIP3009.recover_signer(digest, inner_signature) do
+      {:ok, recovered} when recovered == ctx.payer -> :ok
+      {:ok, _other} -> {:error, {:invalid, :invalid_signature}}
+      {:error, :missing_dependency} -> {:error, :missing_dependency}
+      {:error, _reason} -> {:error, {:invalid, :invalid_signature}}
+    end
+  end
+
+  # -- Level :full (RPC) ------------------------------------------------------
+
+  @spec full_verify(map(), keyword()) :: {:ok, verification()} | {:error, error()}
+  defp full_verify(ctx, opts) do
+    with {:ok, rpc} <- fetch_rpc(opts),
+         {:ok, parsed} <- parse_signature(ctx.signature_bytes),
+         {:ok, digest} <- compute_digest(ctx),
+         {:ok, chain_state} <- preflight(rpc, ctx, opts),
+         :ok <- check_chain_id(chain_state, ctx, opts),
+         :ok <- check_asset_deployed(chain_state),
+         :ok <- check_balance(chain_state, ctx),
+         {:ok, signature_type} <- classify_and_verify(rpc, ctx, parsed, digest, chain_state, opts),
+         :ok <- maybe_simulate(rpc, ctx, parsed, signature_type, opts) do
+      {:ok, result(ctx, :full, signature_type)}
+    end
+  end
+
+  @spec fetch_rpc(keyword()) :: {:ok, RPC.t()} | {:error, :rpc_not_configured}
+  defp fetch_rpc(opts) do
+    case Keyword.get(opts, :rpc) do
+      %RPC{} = rpc -> {:ok, rpc}
+      nil -> {:error, :rpc_not_configured}
+    end
+  end
+
+  # One batched round-trip: chain id (optional), payer code, asset code,
+  # payer balance.
+  @spec preflight(RPC.t(), map(), keyword()) :: {:ok, map()} | {:error, error()}
+  defp preflight(rpc, ctx, opts) do
+    verify_chain_id? = Keyword.fetch!(opts, :verify_chain_id)
+
+    base_requests = [
+      {"eth_getCode", [ctx.payer, "latest"]},
+      {"eth_getCode", [ctx.asset, "latest"]},
+      {"eth_call", [%{"to" => ctx.asset, "data" => balance_of_calldata(ctx)}, "latest"]}
+    ]
+
+    requests =
+      case verify_chain_id? do
+        true -> [{"eth_chainId", []} | base_requests]
+        false -> base_requests
+      end
+
+    with {:ok, results} <- rpc_batch(rpc, requests) do
+      {chain_id_result, [payer_code, asset_code, balance]} =
+        case verify_chain_id? do
+          true ->
+            [chain_id_result | rest] = results
+            {chain_id_result, rest}
+
+          false ->
+            {nil, results}
+        end
+
+      with {:ok, payer_code} <- expect_rpc_ok(payer_code),
+           {:ok, asset_code} <- expect_rpc_ok(asset_code) do
+        {:ok,
+         %{
+           chain_id: chain_id_result,
+           payer_code: payer_code,
+           asset_code: asset_code,
+           balance: balance
+         }}
+      end
+    end
+  end
+
+  @spec rpc_batch(RPC.t(), [RPC.batch_request()]) ::
+          {:ok, [RPC.batch_result()]} | {:error, {:rpc_error, RPC.error()}}
+  defp rpc_batch(rpc, requests) do
+    case RPC.batch(rpc, requests) do
+      {:ok, results} -> {:ok, results}
+      {:error, reason} -> {:error, {:rpc_error, reason}}
+    end
+  end
+
+  # eth_getCode / eth_chainId are not expected to fail with a node-side
+  # error; when they do, verification cannot conclude anything — fail closed
+  # as an RPC error rather than an invalid payment.
+  @spec expect_rpc_ok(RPC.batch_result()) :: {:ok, term()} | {:error, {:rpc_error, RPC.error()}}
+  defp expect_rpc_ok({:ok, value}), do: {:ok, value}
+  defp expect_rpc_ok({:error, reason}), do: {:error, {:rpc_error, reason}}
+
+  @spec check_chain_id(map(), map(), keyword()) ::
+          :ok | {:error, {:rpc_error, RPC.error()} | {:chain_id_mismatch, term(), term()}}
+  defp check_chain_id(%{chain_id: nil}, _ctx, _opts), do: :ok
+
+  defp check_chain_id(%{chain_id: chain_id_result}, ctx, _opts) do
+    with {:ok, hex} <- expect_rpc_ok(chain_id_result) do
+      case parse_quantity(hex) do
+        {:ok, actual} when actual == ctx.chain_id -> :ok
+        {:ok, actual} -> {:error, {:chain_id_mismatch, ctx.chain_id, actual}}
+        :error -> {:error, {:rpc_error, {:invalid_response, hex}}}
+      end
+    end
+  end
+
+  # eth_call on an EOA asset returns empty data without reverting, so a
+  # simulation would "pass" while settling nothing — reject explicitly.
+  @spec check_asset_deployed(map()) :: :ok | {:error, {:invalid, :asset_not_deployed_contract}}
+  defp check_asset_deployed(%{asset_code: code}) do
+    case deployed_code?(code) do
+      true -> :ok
+      false -> {:error, {:invalid, :asset_not_deployed_contract}}
+    end
+  end
+
+  @spec check_balance(map(), map()) ::
+          :ok | {:error, {:invalid, :insufficient_balance | :balance_check_failed}}
+  defp check_balance(%{balance: {:ok, hex}}, ctx) do
+    case decode_uint_return(hex) do
+      {:ok, balance} when balance >= ctx.value -> :ok
+      {:ok, _balance} -> {:error, {:invalid, :insufficient_balance}}
+      :error -> {:error, {:invalid, :balance_check_failed}}
+    end
+  end
+
+  defp check_balance(%{balance: {:error, _reason}}, _ctx),
+    do: {:error, {:invalid, :balance_check_failed}}
+
+  # Signature routing mirrors on-chain SignatureChecker semantics: bytecode
+  # at the payer decides the path — ecrecover with no code, strict ERC-1271
+  # with code (no ECDSA fallback), counterfactual ERC-6492 deferred to the
+  # atomic deploy-and-transfer simulation.
+  @spec classify_and_verify(RPC.t(), map(), ERC6492.parsed(), binary(), map(), keyword()) ::
+          {:ok, signature_type()} | {:error, error()}
+  defp classify_and_verify(rpc, ctx, parsed, digest, chain_state, opts) do
+    deployed? = deployed_code?(chain_state.payer_code)
+    deployment_info? = parsed.factory != nil
+
+    cond do
+      deployed? ->
+        with :ok <- verify_erc1271(rpc, ctx, digest, parsed.inner_signature) do
+          {:ok, :erc1271}
+        end
+
+      deployment_info? ->
+        with :ok <- check_counterfactual_policy(parsed, opts) do
+          {:ok, :erc6492_counterfactual}
+        end
+
+      true ->
+        with :ok <- verify_eoa(ctx, digest, parsed.inner_signature) do
+          {:ok, :eoa}
+        end
+    end
+  end
+
+  @spec verify_erc1271(RPC.t(), map(), binary(), binary()) ::
+          :ok | {:error, {:invalid, :invalid_signature} | {:rpc_error, RPC.error()}}
+  defp verify_erc1271(rpc, ctx, digest, inner_signature) do
+    calldata =
+      @selector_is_valid_signature <>
+        digest <> <<64::unsigned-big-integer-size(256)>> <> encode_dynamic_bytes(inner_signature)
+
+    case RPC.call(rpc, %{"to" => ctx.payer, "data" => hex(calldata)}) do
+      {:ok, return_hex} ->
+        case erc1271_magic?(return_hex) do
+          true -> :ok
+          false -> {:error, {:invalid, :invalid_signature}}
+        end
+
+      # A revert from isValidSignature means the contract rejects the
+      # signature — invalid, matching the reference implementations.
+      {:error, {:jsonrpc_error, _error}} ->
+        {:error, {:invalid, :invalid_signature}}
+
+      {:error, reason} ->
+        {:error, {:rpc_error, reason}}
+    end
+  end
+
+  @spec erc1271_magic?(term()) :: boolean()
+  defp erc1271_magic?(return_hex) do
+    case unhex(return_hex) do
+      {:ok, <<magic::binary-size(4), _rest::binary>>} -> magic == @erc1271_magic_value
+      _other -> false
+    end
+  end
+
+  @spec check_counterfactual_policy(ERC6492.parsed(), keyword()) ::
+          :ok
+          | {:error, {:invalid, :eip6492_factory_not_allowed | :undeployed_smart_wallet}}
+  defp check_counterfactual_policy(parsed, opts) do
+    allowed =
+      opts
+      |> Keyword.fetch!(:eip6492_allowed_factories)
+      |> Enum.map(&String.downcase(String.trim(&1)))
+
+    cond do
+      String.downcase(parsed.factory) not in allowed ->
+        {:error, {:invalid, :eip6492_factory_not_allowed}}
+
+      not Keyword.fetch!(opts, :simulate) ->
+        # A counterfactual signature is only ever proven by simulation;
+        # without it the payment stays unproven — fail closed.
+        {:error, {:invalid, :undeployed_smart_wallet}}
+
+      true ->
+        :ok
+    end
+  end
+
+  # -- Simulation -------------------------------------------------------------
+
+  @spec maybe_simulate(RPC.t(), map(), ERC6492.parsed(), signature_type(), keyword()) ::
+          :ok | {:error, error()}
+  defp maybe_simulate(rpc, ctx, parsed, :erc6492_counterfactual, opts),
+    do: simulate_counterfactual(rpc, ctx, parsed, opts)
+
+  defp maybe_simulate(rpc, ctx, parsed, _signature_type, opts) do
+    case Keyword.fetch!(opts, :simulate) do
+      true -> simulate_transfer(rpc, ctx, parsed)
+      false -> :ok
+    end
+  end
+
+  @spec simulate_transfer(RPC.t(), map(), ERC6492.parsed()) :: :ok | {:error, error()}
+  defp simulate_transfer(rpc, ctx, parsed) do
+    with {:ok, calldata} <- transfer_calldata(ctx, parsed.inner_signature) do
+      case RPC.call(rpc, %{"to" => ctx.asset, "data" => hex(calldata)}) do
+        {:ok, _return} -> :ok
+        {:error, {:jsonrpc_error, error}} -> handle_simulation_revert(rpc, ctx, error)
+        {:error, reason} -> {:error, {:rpc_error, reason}}
+      end
+    end
+  end
+
+  # Counterfactual wallets are deployed and charged in a single atomic
+  # eth_call through Multicall3 — factory deployment then
+  # transferWithAuthorization, with the deployment's state visible to the
+  # transfer. This is the only check that can prove an ERC-6492
+  # counterfactual signature.
+  @spec simulate_counterfactual(RPC.t(), map(), ERC6492.parsed(), keyword()) ::
+          :ok | {:error, error()}
+  defp simulate_counterfactual(rpc, ctx, parsed, opts) do
+    with {:ok, transfer} <- transfer_calldata(ctx, parsed.inner_signature) do
+      calldata =
+        aggregate3_calldata([
+          {parsed.factory, parsed.factory_calldata},
+          {ctx.asset, transfer}
+        ])
+
+      multicall = Keyword.fetch!(opts, :multicall_address)
+
+      case RPC.call(rpc, %{"to" => multicall, "data" => hex(calldata)}) do
+        {:ok, return_hex} -> check_counterfactual_result(rpc, ctx, return_hex)
+        {:error, {:jsonrpc_error, error}} -> handle_simulation_revert(rpc, ctx, error)
+        {:error, reason} -> {:error, {:rpc_error, reason}}
+      end
+    end
+  end
+
+  @spec check_counterfactual_result(RPC.t(), map(), term()) :: :ok | {:error, error()}
+  defp check_counterfactual_result(rpc, ctx, return_hex) do
+    case decode_aggregate3_return(return_hex) do
+      {:ok, [_deploy_result, {true, _return_data}]} ->
+        :ok
+
+      {:ok, [_deploy_result, {false, return_data}]} ->
+        case classify_revert_text(decode_revert_string(return_data) || "") do
+          nil -> diagnose(rpc, ctx)
+          reason -> {:error, {:invalid, reason}}
+        end
+
+      _other ->
+        {:error, {:invalid, :simulation_failed}}
+    end
+  end
+
+  @spec handle_simulation_revert(RPC.t(), map(), RPC.jsonrpc_error()) :: {:error, error()}
+  defp handle_simulation_revert(rpc, ctx, error) do
+    case classify_revert_text(revert_text(error)) do
+      nil -> diagnose(rpc, ctx)
+      reason -> {:error, {:invalid, reason}}
+    end
+  end
+
+  # Combines the node's error message with any ABI-encoded Error(string)
+  # revert reason carried in the error data.
+  @spec revert_text(RPC.jsonrpc_error()) :: String.t()
+  defp revert_text(error) do
+    message = error.message || ""
+
+    data_text =
+      case error.data do
+        "0x" <> _rest = data ->
+          case unhex(data) do
+            {:ok, bytes} -> decode_revert_string(bytes) || ""
+            _other -> ""
+          end
+
+        _other ->
+          ""
+      end
+
+    message <> " " <> data_text
+  end
+
+  # Maps a revert reason onto the reference implementations' error codes
+  # (parseEip3009TransferError). Returns nil when unrecognized so the caller
+  # can fall back to the diagnostic probes.
+  @spec classify_revert_text(String.t()) :: invalid_reason() | nil
+  defp classify_revert_text(text) do
+    cond do
+      text =~ ~r/authorization is (already )?used|AuthorizationAlreadyUsed|used or canceled/i ->
+        :nonce_already_used
+
+      text =~ ~r/authorization is expired|AuthorizationExpired|valid before/i ->
+        :valid_before_expired
+
+      text =~ ~r/authorization is not yet valid|AuthorizationNotYetValid/i ->
+        :valid_after_in_future
+
+      text =~ ~r/transfer amount exceeds balance|insufficient.*balance|ERC20InsufficientBalance/i ->
+        :insufficient_balance
+
+      text =~ ~r/invalid signature|SignerMismatch|InvalidSignatureV|InvalidSignatureS/i ->
+        :invalid_signature
+
+      true ->
+        nil
+    end
+  end
+
+  # One diagnostic batch after an unclassified simulation failure, mirroring
+  # the reference multicall probe: authorizationState, token name/version,
+  # and balance, most-specific reason first.
+  @spec diagnose(RPC.t(), map()) :: {:error, error()}
+  defp diagnose(rpc, ctx) do
+    requests = [
+      eth_call_request(ctx.asset, @selector_authorization_state <> authorization_state_args(ctx)),
+      eth_call_request(ctx.asset, @selector_name),
+      eth_call_request(ctx.asset, @selector_version),
+      eth_call_request(ctx.asset, @selector_balance_of <> address_word(ctx.payer))
+    ]
+
+    case RPC.batch(rpc, requests) do
+      {:ok, [auth_state, name, version, balance]} ->
+        {:error, {:invalid, diagnose_reason(ctx, auth_state, name, version, balance)}}
+
+      {:error, _reason} ->
+        {:error, {:invalid, :simulation_failed}}
+    end
+  end
+
+  @spec diagnose_reason(
+          map(),
+          RPC.batch_result(),
+          RPC.batch_result(),
+          RPC.batch_result(),
+          RPC.batch_result()
+        ) :: invalid_reason()
+  defp diagnose_reason(ctx, auth_state, name, version, balance) do
+    cond do
+      match?({:error, _reason}, auth_state) -> :eip3009_not_supported
+      decoded_bool(auth_state) == true -> :nonce_already_used
+      string_mismatch?(name, ctx.extra_name) -> :token_name_mismatch
+      string_mismatch?(version, ctx.extra_version) -> :token_version_mismatch
+      balance_below?(balance, ctx.value) -> :insufficient_balance
+      true -> :simulation_failed
+    end
+  end
+
+  @spec decoded_bool(RPC.batch_result()) :: boolean() | nil
+  defp decoded_bool({:ok, hex}) do
+    case decode_uint_return(hex) do
+      {:ok, value} -> value != 0
+      :error -> nil
+    end
+  end
+
+  defp decoded_bool(_result), do: nil
+
+  @spec string_mismatch?(RPC.batch_result(), String.t()) :: boolean()
+  defp string_mismatch?({:ok, hex}, expected) do
+    case decode_string_return(hex) do
+      {:ok, actual} -> actual != expected
+      :error -> false
+    end
+  end
+
+  defp string_mismatch?(_result, _expected), do: false
+
+  @spec balance_below?(RPC.batch_result(), non_neg_integer()) :: boolean()
+  defp balance_below?({:ok, hex}, amount) do
+    case decode_uint_return(hex) do
+      {:ok, balance} -> balance < amount
+      :error -> false
+    end
+  end
+
+  defp balance_below?(_result, _amount), do: false
+
+  # -- Calldata construction --------------------------------------------------
+
+  @spec eth_call_request(String.t(), binary()) :: RPC.batch_request()
+  defp eth_call_request(to, calldata),
+    do: {"eth_call", [%{"to" => to, "data" => hex(calldata)}, "latest"]}
+
+  @spec balance_of_calldata(map()) :: String.t()
+  defp balance_of_calldata(ctx), do: hex(@selector_balance_of <> address_word(ctx.payer))
+
+  @spec authorization_state_args(map()) :: binary()
+  defp authorization_state_args(ctx) do
+    {:ok, nonce_word} = EIP3009.encode_bytes32(ctx.nonce)
+    address_word(ctx.payer) <> nonce_word
+  end
+
+  @spec address_word(String.t()) :: binary()
+  defp address_word(address) do
+    {:ok, word} = EIP3009.encode_address(address)
+    word
+  end
+
+  @spec transfer_calldata(map(), binary()) ::
+          {:ok, binary()} | {:error, {:invalid, :invalid_signature}}
+  defp transfer_calldata(ctx, inner_signature) do
+    base = authorization_words(ctx)
+
+    case inner_signature do
+      <<r::binary-size(32), s::binary-size(32), v>> ->
+        {:ok,
+         @selector_transfer_vrs <>
+           base <> <<normalize_v(v)::unsigned-big-integer-size(256)>> <> r <> s}
+
+      signature when byte_size(signature) > 0 ->
+        {:ok,
+         @selector_transfer_bytes <>
+           base <>
+           <<7 * 32::unsigned-big-integer-size(256)>> <> encode_dynamic_bytes(signature)}
+
+      _signature ->
+        {:error, {:invalid, :invalid_signature}}
+    end
+  end
+
+  @spec authorization_words(map()) :: binary()
+  defp authorization_words(ctx) do
+    authorization = ctx.authorization
+    {:ok, from} = EIP3009.encode_address(Utils.map_value(authorization, {"from", :from}))
+    {:ok, to} = EIP3009.encode_address(Utils.map_value(authorization, {"to", :to}))
+    {:ok, value} = EIP3009.encode_uint256(ctx.value)
+
+    {:ok, valid_after} =
+      EIP3009.encode_uint256(Utils.map_value(authorization, {"validAfter", :valid_after}))
+
+    {:ok, valid_before} =
+      EIP3009.encode_uint256(Utils.map_value(authorization, {"validBefore", :valid_before}))
+
+    {:ok, nonce} = EIP3009.encode_bytes32(ctx.nonce)
+
+    from <> to <> value <> valid_after <> valid_before <> nonce
+  end
+
+  @spec normalize_v(non_neg_integer()) :: non_neg_integer()
+  defp normalize_v(v) when v in [0, 1], do: v + 27
+  defp normalize_v(v), do: v
+
+  # aggregate3(Call3[] calls) with Call3 = (address target, bool allowFailure,
+  # bytes callData). Every sub-call is encoded with allowFailure = true so the
+  # transfer leg's individual status can be inspected (mirroring the reference
+  # implementations).
+  @spec aggregate3_calldata([{String.t(), binary()}]) :: binary()
+  defp aggregate3_calldata(calls) do
+    encoded_tuples = Enum.map(calls, &encode_call3/1)
+
+    {offsets, _end} =
+      Enum.map_reduce(encoded_tuples, 32 * length(calls), fn tuple, position ->
+        {position, position + byte_size(tuple)}
+      end)
+
+    array =
+      <<length(calls)::unsigned-big-integer-size(256)>> <>
+        Enum.map_join(offsets, &<<&1::unsigned-big-integer-size(256)>>) <>
+        Enum.join(encoded_tuples)
+
+    @selector_aggregate3 <> <<32::unsigned-big-integer-size(256)>> <> array
+  end
+
+  @spec encode_call3({String.t(), binary()}) :: binary()
+  defp encode_call3({target, calldata}) do
+    address_word(target) <>
+      <<1::unsigned-big-integer-size(256)>> <>
+      <<3 * 32::unsigned-big-integer-size(256)>> <> encode_dynamic_bytes(calldata)
+  end
+
+  # -- Return-data decoding ---------------------------------------------------
+
+  @spec decode_aggregate3_return(term()) :: {:ok, [{boolean(), binary()}]} | :error
+  defp decode_aggregate3_return(return_hex) do
+    with {:ok, bytes} <- unhex(return_hex),
+         <<32::unsigned-big-integer-size(256), rest::binary>> <- bytes,
+         <<count::unsigned-big-integer-size(256), elements::binary>> when count > 0 <- rest do
+      decode_aggregate3_elements(elements, count)
+    else
+      _other -> :error
+    end
+  end
+
+  @spec decode_aggregate3_elements(binary(), pos_integer()) ::
+          {:ok, [{boolean(), binary()}]} | :error
+  defp decode_aggregate3_elements(elements, count) do
+    results =
+      Enum.map(0..(count - 1), fn index ->
+        with {:ok, offset} <- word_at(elements, index * 32),
+             {:ok, success} <- word_at(elements, offset),
+             {:ok, data_offset} <- word_at(elements, offset + 32),
+             {:ok, length} <- word_at(elements, offset + data_offset),
+             true <- offset + data_offset + 32 + length <= byte_size(elements) do
+          {:ok, {success == 1, binary_part(elements, offset + data_offset + 32, length)}}
+        else
+          _other -> :error
+        end
+      end)
+
+    case Enum.all?(results, &match?({:ok, _result}, &1)) do
+      true -> {:ok, Enum.map(results, fn {:ok, result} -> result end)}
+      false -> :error
+    end
+  end
+
+  @spec word_at(binary(), non_neg_integer()) :: {:ok, non_neg_integer()} | :error
+  defp word_at(bytes, position) when position + 32 <= byte_size(bytes) do
+    <<word::unsigned-big-integer-size(256)>> = binary_part(bytes, position, 32)
+    {:ok, word}
+  end
+
+  defp word_at(_bytes, _position), do: :error
+
+  @spec decode_uint_return(term()) :: {:ok, non_neg_integer()} | :error
+  defp decode_uint_return(return_hex) when is_binary(return_hex) do
+    case unhex(return_hex) do
+      {:ok, bytes} when byte_size(bytes) >= 32 ->
+        <<value::unsigned-big-integer-size(256), _rest::binary>> = bytes
+        {:ok, value}
+
+      _other ->
+        :error
+    end
+  end
+
+  defp decode_uint_return(_return), do: :error
+
+  @spec decode_string_return(term()) :: {:ok, String.t()} | :error
+  defp decode_string_return(return_hex) when is_binary(return_hex) do
+    with {:ok, bytes} <- unhex(return_hex),
+         {:ok, offset} <- word_at(bytes, 0),
+         {:ok, length} <- word_at(bytes, offset),
+         true <- offset + 32 + length <= byte_size(bytes) do
+      {:ok, binary_part(bytes, offset + 32, length)}
+    else
+      _other -> :error
+    end
+  end
+
+  defp decode_string_return(_return), do: :error
+
+  # Decodes a standard Error(string) revert payload (selector 0x08c379a0).
+  @spec decode_revert_string(binary()) :: String.t() | nil
+  defp decode_revert_string(<<0x08, 0xC3, 0x79, 0xA0, encoded::binary>>) do
+    case decode_string_return("0x" <> Base.encode16(encoded, case: :lower)) do
+      {:ok, reason} -> reason
+      :error -> nil
+    end
+  end
+
+  defp decode_revert_string(_bytes), do: nil
+
+  # -- Hex / padding helpers --------------------------------------------------
+
+  @spec deployed_code?(term()) :: boolean()
+  defp deployed_code?(code) when is_binary(code) do
+    case unhex(code) do
+      {:ok, bytes} -> byte_size(bytes) > 0
+      _other -> false
+    end
+  end
+
+  defp deployed_code?(_code), do: false
+
+  @spec hex(binary()) :: String.t()
+  defp hex(bytes), do: "0x" <> Base.encode16(bytes, case: :lower)
+
+  @spec unhex(term()) :: {:ok, binary()} | :error
+  defp unhex("0x" <> hex_digits), do: Base.decode16(hex_digits, case: :mixed)
+  defp unhex(_value), do: :error
+
+  @spec parse_quantity(term()) :: {:ok, non_neg_integer()} | :error
+  defp parse_quantity("0x" <> hex_digits) when hex_digits != "" do
+    case Integer.parse(hex_digits, 16) do
+      {value, ""} -> {:ok, value}
+      _parsed -> :error
+    end
+  end
+
+  defp parse_quantity(_value), do: :error
+
+  @spec encode_dynamic_bytes(binary()) :: binary()
+  defp encode_dynamic_bytes(bytes) do
+    <<byte_size(bytes)::unsigned-big-integer-size(256)>> <> pad_right(bytes)
+  end
+
+  @spec pad_right(binary()) :: binary()
+  defp pad_right(bytes) do
+    case rem(byte_size(bytes), 32) do
+      0 -> bytes
+      remainder -> bytes <> :binary.copy(<<0>>, 32 - remainder)
+    end
+  end
+end

--- a/lib/x402/verify/evm.ex
+++ b/lib/x402/verify/evm.ex
@@ -493,11 +493,17 @@ defmodule X402.Verify.EVM do
   end
 
   @spec parse_non_neg_integer(term()) :: {:ok, non_neg_integer()} | :error
-  defp parse_non_neg_integer(value) when is_integer(value) and value >= 0, do: {:ok, value}
+  # uint256 fields: values at or above 2^256 cannot be ABI-encoded and would
+  # crash word encoding downstream — reject them here.
+  @uint256_limit Integer.pow(2, 256)
+
+  defp parse_non_neg_integer(value)
+       when is_integer(value) and value >= 0 and value < @uint256_limit,
+       do: {:ok, value}
 
   defp parse_non_neg_integer(value) when is_binary(value) do
     case Integer.parse(value) do
-      {parsed, ""} when parsed >= 0 -> {:ok, parsed}
+      {parsed, ""} when parsed >= 0 and parsed < @uint256_limit -> {:ok, parsed}
       _parsed -> :error
     end
   end
@@ -796,16 +802,17 @@ defmodule X402.Verify.EVM do
   defp maybe_simulate(rpc, ctx, parsed, :erc6492_counterfactual, opts),
     do: simulate_counterfactual(rpc, ctx, parsed, opts)
 
-  defp maybe_simulate(rpc, ctx, parsed, _signature_type, opts) do
+  defp maybe_simulate(rpc, ctx, parsed, signature_type, opts) do
     case Keyword.fetch!(opts, :simulate) do
-      true -> simulate_transfer(rpc, ctx, parsed)
+      true -> simulate_transfer(rpc, ctx, parsed, signature_type)
       false -> :ok
     end
   end
 
-  @spec simulate_transfer(RPC.t(), map(), ERC6492.parsed()) :: :ok | {:error, error()}
-  defp simulate_transfer(rpc, ctx, parsed) do
-    with {:ok, calldata} <- transfer_calldata(ctx, parsed.inner_signature) do
+  @spec simulate_transfer(RPC.t(), map(), ERC6492.parsed(), signature_type()) ::
+          :ok | {:error, error()}
+  defp simulate_transfer(rpc, ctx, parsed, signature_type) do
+    with {:ok, calldata} <- transfer_calldata(ctx, parsed.inner_signature, signature_type) do
       case RPC.call(rpc, %{"to" => ctx.asset, "data" => hex(calldata)}) do
         {:ok, _return} -> :ok
         {:error, {:jsonrpc_error, error}} -> handle_simulation_revert(rpc, ctx, error)
@@ -822,7 +829,8 @@ defmodule X402.Verify.EVM do
   @spec simulate_counterfactual(RPC.t(), map(), ERC6492.parsed(), keyword()) ::
           :ok | {:error, error()}
   defp simulate_counterfactual(rpc, ctx, parsed, opts) do
-    with {:ok, transfer} <- transfer_calldata(ctx, parsed.inner_signature) do
+    with {:ok, transfer} <-
+           transfer_calldata(ctx, parsed.inner_signature, :erc6492_counterfactual) do
       calldata =
         aggregate3_calldata([
           {parsed.factory, parsed.factory_calldata},
@@ -1001,27 +1009,33 @@ defmodule X402.Verify.EVM do
     word
   end
 
-  @spec transfer_calldata(map(), binary()) ::
+  @spec transfer_calldata(map(), binary(), signature_type()) ::
           {:ok, binary()} | {:error, {:invalid, :invalid_signature}}
-  defp transfer_calldata(ctx, inner_signature) do
+  # The overload is selected by the VERIFIED signature type, never by byte
+  # length: a smart wallet's ERC-1271 signature can be exactly 65 bytes, and
+  # the (v, r, s) overload performs on-chain ECDSA, which would wrongly
+  # reject it. Only EOA signatures take the ECDSA overload; contract
+  # signatures always go through the bytes variant, whose token-side
+  # SignatureChecker routes by account code.
+  defp transfer_calldata(ctx, <<r::binary-size(32), s::binary-size(32), v>>, :eoa) do
     base = authorization_words(ctx)
 
-    case inner_signature do
-      <<r::binary-size(32), s::binary-size(32), v>> ->
-        {:ok,
-         @selector_transfer_vrs <>
-           base <> <<normalize_v(v)::unsigned-big-integer-size(256)>> <> r <> s}
-
-      signature when byte_size(signature) > 0 ->
-        {:ok,
-         @selector_transfer_bytes <>
-           base <>
-           <<7 * 32::unsigned-big-integer-size(256)>> <> encode_dynamic_bytes(signature)}
-
-      _signature ->
-        {:error, {:invalid, :invalid_signature}}
-    end
+    {:ok,
+     @selector_transfer_vrs <>
+       base <> <<normalize_v(v)::unsigned-big-integer-size(256)>> <> r <> s}
   end
+
+  defp transfer_calldata(ctx, signature, _signature_type) when byte_size(signature) > 0 do
+    base = authorization_words(ctx)
+
+    {:ok,
+     @selector_transfer_bytes <>
+       base <>
+       <<7 * 32::unsigned-big-integer-size(256)>> <> encode_dynamic_bytes(signature)}
+  end
+
+  defp transfer_calldata(_ctx, _signature, _signature_type),
+    do: {:error, {:invalid, :invalid_signature}}
 
   @spec authorization_words(map()) :: binary()
   defp authorization_words(ctx) do

--- a/mix.exs
+++ b/mix.exs
@@ -125,6 +125,7 @@ defmodule X402.MixProject do
         "guides/custom-schemes.md": [title: "Custom Payment Schemes"],
         "guides/mcp.md": [title: "Paid MCP Tools"],
         "guides/paywall.md": [title: "Browser Paywall"],
+        "guides/local-verification.md": [title: "Local Payment Verification"],
         "guides/live-smoke-tests.md": [title: "Live Smoke Tests"]
       ],
       groups_for_extras: [
@@ -171,6 +172,10 @@ defmodule X402.MixProject do
           X402.MCP,
           X402.MCP.Server,
           X402.MCP.Client
+        "Local Verification": [
+          X402.Verify.EVM,
+          X402.RPC,
+          X402.ERC6492
         ],
         Utilities: [
           X402.Wallet

--- a/mix.exs
+++ b/mix.exs
@@ -172,6 +172,7 @@ defmodule X402.MixProject do
           X402.MCP,
           X402.MCP.Server,
           X402.MCP.Client
+        ],
         "Local Verification": [
           X402.Verify.EVM,
           X402.RPC,

--- a/test/x402/erc6492_test.exs
+++ b/test/x402/erc6492_test.exs
@@ -77,7 +77,7 @@ defmodule X402.ERC6492Test do
     end
 
     test "rejects out-of-bounds calldata offsets" do
-      {:ok, factory_word} = X402.EIP3009.encode_address(@factory)
+      {:ok, factory_word} = X402.EIP712.encode_address(@factory)
 
       malformed =
         factory_word <>
@@ -89,7 +89,7 @@ defmodule X402.ERC6492Test do
     end
 
     test "rejects a declared bytes length past the end of the buffer" do
-      {:ok, factory_word} = X402.EIP3009.encode_address(@factory)
+      {:ok, factory_word} = X402.EIP712.encode_address(@factory)
 
       malformed =
         factory_word <>

--- a/test/x402/erc6492_test.exs
+++ b/test/x402/erc6492_test.exs
@@ -1,0 +1,127 @@
+defmodule X402.ERC6492Test do
+  use ExUnit.Case, async: true
+
+  alias X402.ERC6492
+
+  doctest X402.ERC6492
+
+  @factory "0x2222222222222222222222222222222222222222"
+  @zero_factory "0x0000000000000000000000000000000000000000"
+
+  describe "parse/1" do
+    test "round-trips a wrapped signature built with wrap/3" do
+      inner = :crypto.strong_rand_bytes(65)
+      calldata = :crypto.strong_rand_bytes(36)
+
+      {:ok, wrapped} = ERC6492.wrap(@factory, calldata, inner)
+      {:ok, parsed} = ERC6492.parse(wrapped)
+
+      assert parsed.wrapped?
+      assert parsed.factory == @factory
+      assert parsed.factory_calldata == calldata
+      assert parsed.inner_signature == inner
+    end
+
+    test "accepts 0x-prefixed hex input" do
+      inner = :crypto.strong_rand_bytes(65)
+      {:ok, wrapped} = ERC6492.wrap(@factory, <<0xAB>>, inner)
+      hex = "0x" <> Base.encode16(wrapped, case: :lower)
+
+      {:ok, parsed} = ERC6492.parse(hex)
+      assert parsed.inner_signature == inner
+    end
+
+    test "handles calldata and signatures at 32-byte boundaries" do
+      inner = :crypto.strong_rand_bytes(64)
+      calldata = :crypto.strong_rand_bytes(32)
+
+      {:ok, wrapped} = ERC6492.wrap(@factory, calldata, inner)
+      {:ok, parsed} = ERC6492.parse(wrapped)
+
+      assert parsed.factory_calldata == calldata
+      assert parsed.inner_signature == inner
+    end
+
+    test "a zero factory address parses as no deployment info" do
+      inner = :crypto.strong_rand_bytes(65)
+      {:ok, wrapped} = ERC6492.wrap(@zero_factory, <<0xAB>>, inner)
+
+      assert {:ok, parsed} = ERC6492.parse(wrapped)
+      assert parsed.wrapped?
+      assert parsed.factory == nil
+      assert parsed.factory_calldata == nil
+      assert parsed.inner_signature == inner
+    end
+
+    test "empty factory calldata parses as no deployment info" do
+      inner = :crypto.strong_rand_bytes(65)
+      {:ok, wrapped} = ERC6492.wrap(@factory, <<>>, inner)
+
+      assert {:ok, parsed} = ERC6492.parse(wrapped)
+      assert parsed.factory == nil
+      assert parsed.inner_signature == inner
+    end
+
+    test "an unwrapped signature passes through untouched" do
+      inner = :crypto.strong_rand_bytes(65)
+
+      assert {:ok, parsed} = ERC6492.parse(inner)
+      refute parsed.wrapped?
+      assert parsed.factory == nil
+      assert parsed.inner_signature == inner
+    end
+
+    test "rejects a magic suffix with a truncated ABI prefix" do
+      malformed = <<1, 2, 3>> <> ERC6492.magic_suffix()
+      assert ERC6492.parse(malformed) == {:error, :invalid_erc6492_wrapper}
+    end
+
+    test "rejects out-of-bounds calldata offsets" do
+      {:ok, factory_word} = X402.EIP3009.encode_address(@factory)
+
+      malformed =
+        factory_word <>
+          <<9_999::unsigned-big-integer-size(256)>> <>
+          <<96::unsigned-big-integer-size(256)>> <>
+          <<0::unsigned-big-integer-size(256)>> <> ERC6492.magic_suffix()
+
+      assert ERC6492.parse(malformed) == {:error, :invalid_erc6492_wrapper}
+    end
+
+    test "rejects a declared bytes length past the end of the buffer" do
+      {:ok, factory_word} = X402.EIP3009.encode_address(@factory)
+
+      malformed =
+        factory_word <>
+          <<96::unsigned-big-integer-size(256)>> <>
+          <<128::unsigned-big-integer-size(256)>> <>
+          <<1_000_000::unsigned-big-integer-size(256)>> <>
+          <<0::unsigned-big-integer-size(256)>> <> ERC6492.magic_suffix()
+
+      assert ERC6492.parse(malformed) == {:error, :invalid_erc6492_wrapper}
+    end
+
+    test "rejects a non-zero-padded factory word" do
+      malformed = <<0xFF>> <> :binary.copy(<<0>>, 95) <> ERC6492.magic_suffix()
+
+      assert ERC6492.parse(malformed) == {:error, :invalid_erc6492_wrapper}
+    end
+  end
+
+  describe "wrapped?/1" do
+    test "false for short binaries and unwrapped signatures" do
+      refute ERC6492.wrapped?(<<>>)
+      refute ERC6492.wrapped?(:crypto.strong_rand_bytes(65))
+      refute ERC6492.wrapped?("0x" <> String.duplicate("11", 65))
+    end
+
+    test "false for invalid hex strings" do
+      refute ERC6492.wrapped?("0xzz")
+    end
+
+    test "true for hex-encoded wrapped signatures" do
+      {:ok, wrapped} = ERC6492.wrap(@factory, <<0xAB>>, :crypto.strong_rand_bytes(65))
+      assert ERC6492.wrapped?("0x" <> Base.encode16(wrapped, case: :lower))
+    end
+  end
+end

--- a/test/x402/rpc_test.exs
+++ b/test/x402/rpc_test.exs
@@ -1,0 +1,282 @@
+defmodule X402.RPCTest do
+  use ExUnit.Case, async: false
+
+  alias X402.RPC
+
+  import X402.TestHelpers
+
+  doctest X402.RPC
+
+  setup :setup_bypass
+  setup :setup_finch
+
+  defp rpc(%{bypass: bypass, finch: finch}, opts \\ []) do
+    {:ok, rpc} =
+      RPC.new(Keyword.merge([rpc_url: "http://localhost:#{bypass.port}", finch: finch], opts))
+
+    rpc
+  end
+
+  defp respond(conn, payload) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.resp(200, Jason.encode!(payload))
+  end
+
+  describe "new/1" do
+    test "builds a config with defaults", %{finch: finch} do
+      assert {:ok, %RPC{timeout: 5_000}} =
+               RPC.new(rpc_url: "https://sepolia.base.org", finch: finch)
+    end
+
+    test "accepts pid and via-tuple finch names" do
+      assert {:ok, %RPC{}} = RPC.new(rpc_url: "https://example.com", finch: self())
+
+      assert {:ok, %RPC{}} =
+               RPC.new(rpc_url: "https://example.com", finch: {:via, Registry, {Reg, :key}})
+    end
+
+    test "rejects plain http for non-loopback hosts" do
+      assert RPC.new(rpc_url: "http://rpc.example.com", finch: MyFinch) ==
+               {:error, :insecure_rpc_url}
+
+      assert RPC.new(rpc_url: "ftp://rpc.example.com", finch: MyFinch) ==
+               {:error, :insecure_rpc_url}
+
+      assert RPC.new(rpc_url: "rpc.example.com", finch: MyFinch) == {:error, :insecure_rpc_url}
+    end
+
+    test "allows http for loopback hosts" do
+      assert {:ok, %RPC{}} = RPC.new(rpc_url: "http://localhost:8545", finch: MyFinch)
+      assert {:ok, %RPC{}} = RPC.new(rpc_url: "http://127.0.0.1:8545", finch: MyFinch)
+    end
+
+    test "raises on invalid options" do
+      assert_raise NimbleOptions.ValidationError, fn ->
+        RPC.new(rpc_url: "https://example.com", finch: "not a finch name")
+      end
+
+      assert_raise NimbleOptions.ValidationError, fn ->
+        RPC.new(finch: MyFinch)
+      end
+
+      assert_raise NimbleOptions.ValidationError, fn ->
+        RPC.new(rpc_url: "https://example.com", finch: MyFinch, timeout: 0)
+      end
+    end
+  end
+
+  describe "request/3" do
+    test "returns the decoded result", context do
+      Bypass.expect_once(context.bypass, "POST", "/", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+        assert %{
+                 "jsonrpc" => "2.0",
+                 "id" => 1,
+                 "method" => "eth_blockNumber",
+                 "params" => []
+               } = Jason.decode!(body)
+
+        respond(conn, %{"jsonrpc" => "2.0", "id" => 1, "result" => "0x10"})
+      end)
+
+      assert RPC.request(rpc(context), "eth_blockNumber", []) == {:ok, "0x10"}
+    end
+
+    test "maps node-side errors to jsonrpc_error", context do
+      Bypass.expect_once(context.bypass, "POST", "/", fn conn ->
+        respond(conn, %{
+          "jsonrpc" => "2.0",
+          "id" => 1,
+          "error" => %{"code" => 3, "message" => "execution reverted", "data" => "0x"}
+        })
+      end)
+
+      assert RPC.request(rpc(context), "eth_call", []) ==
+               {:error, {:jsonrpc_error, %{code: 3, message: "execution reverted", data: "0x"}}}
+    end
+
+    test "normalizes malformed error objects", context do
+      Bypass.expect_once(context.bypass, "POST", "/", fn conn ->
+        respond(conn, %{"jsonrpc" => "2.0", "id" => 1, "error" => %{"code" => "3"}})
+      end)
+
+      assert RPC.request(rpc(context), "eth_call", []) ==
+               {:error, {:jsonrpc_error, %{code: nil, message: nil, data: nil}}}
+    end
+
+    test "returns http_error for non-2xx statuses", context do
+      Bypass.expect_once(context.bypass, "POST", "/", fn conn ->
+        Plug.Conn.resp(conn, 502, "bad gateway")
+      end)
+
+      assert RPC.request(rpc(context), "eth_chainId", []) == {:error, {:http_error, 502}}
+    end
+
+    test "returns invalid_response for non-JSON bodies", context do
+      Bypass.expect_once(context.bypass, "POST", "/", fn conn ->
+        Plug.Conn.resp(conn, 200, "not json")
+      end)
+
+      assert {:error, {:invalid_response, %Jason.DecodeError{}}} =
+               RPC.request(rpc(context), "eth_chainId", [])
+    end
+
+    test "returns invalid_response for JSON without result or error", context do
+      Bypass.expect_once(context.bypass, "POST", "/", fn conn ->
+        respond(conn, %{"jsonrpc" => "2.0", "id" => 1})
+      end)
+
+      assert {:error, {:invalid_response, _body}} = RPC.request(rpc(context), "eth_chainId", [])
+    end
+
+    test "returns transport_error when the endpoint is down", context do
+      Bypass.down(context.bypass)
+
+      assert {:error, {:transport_error, _reason}} =
+               RPC.request(rpc(context), "eth_chainId", [])
+    end
+
+    test "emits telemetry on success and error", context do
+      ref = make_ref()
+      test_pid = self()
+
+      :telemetry.attach(
+        "rpc-test-#{inspect(ref)}",
+        [:x402, :rpc, :request],
+        fn _event, _measurements, metadata, _config -> send(test_pid, {:telemetry, metadata}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach("rpc-test-#{inspect(ref)}") end)
+
+      Bypass.expect_once(context.bypass, "POST", "/", fn conn ->
+        respond(conn, %{"jsonrpc" => "2.0", "id" => 1, "result" => "0x1"})
+      end)
+
+      assert {:ok, "0x1"} = RPC.request(rpc(context), "eth_chainId", [])
+      assert_received {:telemetry, %{status: :ok, method: "eth_chainId"}}
+
+      Bypass.down(context.bypass)
+      assert {:error, _reason} = RPC.request(rpc(context), "eth_chainId", [])
+      assert_received {:telemetry, %{status: :error, method: "eth_chainId"}}
+    end
+  end
+
+  describe "batch/2" do
+    test "returns results in request order even when responses are shuffled", context do
+      Bypass.expect_once(context.bypass, "POST", "/", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        requests = Jason.decode!(body)
+        assert Enum.map(requests, & &1["id"]) == [1, 2, 3]
+
+        respond(conn, [
+          %{"jsonrpc" => "2.0", "id" => 3, "result" => "0x3"},
+          %{"jsonrpc" => "2.0", "id" => 1, "result" => "0x1"},
+          %{"jsonrpc" => "2.0", "id" => 2, "error" => %{"code" => -32_000, "message" => "boom"}}
+        ])
+      end)
+
+      requests = [
+        {"eth_chainId", []},
+        {"eth_getCode", ["0xabc", "latest"]},
+        {"eth_blockNumber", []}
+      ]
+
+      assert RPC.batch(rpc(context), requests) ==
+               {:ok,
+                [
+                  {:ok, "0x1"},
+                  {:error, {:jsonrpc_error, %{code: -32_000, message: "boom", data: nil}}},
+                  {:ok, "0x3"}
+                ]}
+    end
+
+    test "returns {:ok, []} for an empty batch without an HTTP call", context do
+      assert RPC.batch(rpc(context), []) == {:ok, []}
+    end
+
+    test "fails the whole batch when a response id is missing", context do
+      Bypass.expect_once(context.bypass, "POST", "/", fn conn ->
+        respond(conn, [%{"jsonrpc" => "2.0", "id" => 1, "result" => "0x1"}])
+      end)
+
+      assert {:error, {:invalid_response, {:missing_response, 2}}} =
+               RPC.batch(rpc(context), [{"eth_chainId", []}, {"eth_blockNumber", []}])
+    end
+
+    test "ignores batch responses without an id", context do
+      Bypass.expect_once(context.bypass, "POST", "/", fn conn ->
+        respond(conn, [%{"jsonrpc" => "2.0", "result" => "0x1"}])
+      end)
+
+      assert {:error, {:invalid_response, {:missing_response, 1}}} =
+               RPC.batch(rpc(context), [{"eth_chainId", []}])
+    end
+
+    test "fails when the response is not a list", context do
+      Bypass.expect_once(context.bypass, "POST", "/", fn conn ->
+        respond(conn, %{"jsonrpc" => "2.0", "id" => 1, "result" => "0x1"})
+      end)
+
+      assert {:error, {:invalid_response, _body}} =
+               RPC.batch(rpc(context), [{"eth_chainId", []}])
+    end
+
+    test "propagates transport errors", context do
+      Bypass.down(context.bypass)
+
+      assert {:error, {:transport_error, _reason}} =
+               RPC.batch(rpc(context), [{"eth_chainId", []}])
+    end
+  end
+
+  describe "eth helpers" do
+    test "call/3 normalizes the call object and defaults to latest", context do
+      Bypass.expect_once(context.bypass, "POST", "/", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+        assert %{
+                 "method" => "eth_call",
+                 "params" => [%{"to" => "0xto", "data" => "0xdata", "from" => "0xfrom"}, "latest"]
+               } = Jason.decode!(body)
+
+        respond(conn, %{"jsonrpc" => "2.0", "id" => 1, "result" => "0x"})
+      end)
+
+      assert RPC.call(rpc(context), %{to: "0xto", data: "0xdata", from: "0xfrom"}) == {:ok, "0x"}
+    end
+
+    test "get_code/2 requests eth_getCode", context do
+      Bypass.expect_once(context.bypass, "POST", "/", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert %{"method" => "eth_getCode", "params" => ["0xabc", "latest"]} = Jason.decode!(body)
+        respond(conn, %{"jsonrpc" => "2.0", "id" => 1, "result" => "0x"})
+      end)
+
+      assert RPC.get_code(rpc(context), "0xabc") == {:ok, "0x"}
+    end
+
+    test "chain_id/1 requests eth_chainId", context do
+      Bypass.expect_once(context.bypass, "POST", "/", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert %{"method" => "eth_chainId", "params" => []} = Jason.decode!(body)
+        respond(conn, %{"jsonrpc" => "2.0", "id" => 1, "result" => "0x14a34"})
+      end)
+
+      assert RPC.chain_id(rpc(context)) == {:ok, "0x14a34"}
+    end
+  end
+
+  describe "validate_config/1" do
+    test "accepts an %X402.RPC{} struct", context do
+      assert {:ok, %RPC{}} = RPC.validate_config(rpc(context))
+    end
+
+    test "rejects other values" do
+      assert {:error, message} = RPC.validate_config(%{rpc_url: "https://example.com"})
+      assert message =~ "X402.RPC"
+    end
+  end
+end

--- a/test/x402/verify/evm_test.exs
+++ b/test/x402/verify/evm_test.exs
@@ -816,6 +816,42 @@ defmodule X402.Verify.EVMTest do
                        [%{"to" => @smart_wallet, "data" => "0x1626ba7e" <> _args} | _block]}
     end
 
+    test "simulates a 65-byte ERC-1271 signature through the bytes overload", context do
+      # A smart wallet's signature can be exactly 65 bytes; the (v, r, s)
+      # overload would run on-chain ECDSA and wrongly reject it. Overload
+      # selection must follow the verified signature TYPE, not byte length.
+      rpc =
+        stub_rpc(context, %{
+          code: %{String.downcase(@asset) => "0x6001", @smart_wallet => "0x6001"}
+        })
+
+      requirements = requirements()
+
+      payload =
+        unsigned_payload(requirements, @smart_wallet, "0x" <> String.duplicate("22", 65))
+
+      assert {:ok, %{signature_type: :erc1271}} =
+               EVM.verify(payload, requirements, level: :full, rpc: rpc)
+
+      assert_received {:rpc, "eth_call", [%{"data" => "0xcf092995" <> _args} | _block]}
+      refute_received {:rpc, "eth_call", [%{"data" => "0xe3ee160e" <> _args} | _block2]}
+    end
+
+    test "rejects uint256-overflowing timing values instead of crashing" do
+      requirements = requirements()
+      payload = contract_payload(requirements)
+
+      overflowing =
+        put_in(
+          payload,
+          ["payload", "authorization", "validBefore"],
+          Integer.to_string(Integer.pow(2, 256))
+        )
+
+      assert {:error, {:invalid, _reason}} =
+               EVM.verify(overflowing, requirements, level: :structural)
+    end
+
     test "rejects a wallet returning a non-magic value", context do
       rpc =
         stub_rpc(context, %{

--- a/test/x402/verify/evm_test.exs
+++ b/test/x402/verify/evm_test.exs
@@ -1,0 +1,1216 @@
+defmodule X402.Verify.EVMTest do
+  use ExUnit.Case, async: false
+
+  alias X402.EIP3009
+  alias X402.ERC6492
+  alias X402.RPC
+  alias X402.Signer.LocalKey
+  alias X402.Verify.EVM
+
+  import X402.TestHelpers
+
+  doctest X402.Verify.EVM
+
+  @private_key "0x" <> String.duplicate("11", 32)
+  @payer "0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a"
+  @pay_to "0x209693Bc6afc0C5328bA36FaF03C514EF312287C"
+  @asset "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+  @factory "0x3333333333333333333333333333333333333333"
+  @multicall3 "0xca11bde05977b3631167028862be2a173976ca11"
+  @smart_wallet "0x4444444444444444444444444444444444444444"
+
+  # -- Fixtures ---------------------------------------------------------------
+
+  defp requirements(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "scheme" => "exact",
+        "network" => "eip155:84532",
+        "amount" => "10000",
+        "asset" => @asset,
+        "payTo" => @pay_to,
+        "maxTimeoutSeconds" => 600,
+        "extra" => %{"name" => "USDC", "version" => "2"}
+      },
+      overrides
+    )
+  end
+
+  defp signer do
+    {:ok, signer} = LocalKey.new(@private_key)
+    signer
+  end
+
+  defp signed_payload(requirements) do
+    {:ok, scheme_payload} = EIP3009.sign(requirements, signer())
+    envelope(requirements, scheme_payload)
+  end
+
+  defp envelope(requirements, scheme_payload) do
+    %{"x402Version" => 2, "accepted" => requirements, "payload" => scheme_payload}
+  end
+
+  defp unsigned_payload(requirements, from, signature_hex, auth_overrides \\ %{}) do
+    now = System.system_time(:second)
+
+    authorization =
+      Map.merge(
+        %{
+          "from" => from,
+          "to" => requirements["payTo"],
+          "value" => requirements["amount"],
+          "validAfter" => Integer.to_string(now - 60),
+          "validBefore" => Integer.to_string(now + 600),
+          "nonce" => "0x" <> String.duplicate("ab", 32)
+        },
+        auth_overrides
+      )
+
+    envelope(requirements, %{"signature" => signature_hex, "authorization" => authorization})
+  end
+
+  defp put_authorization(payload, key, value) do
+    update_in(payload, ["payload", "authorization"], &Map.put(&1, key, value))
+  end
+
+  defp contract_payload(requirements) do
+    unsigned_payload(requirements, @smart_wallet, "0x" <> String.duplicate("22", 80))
+  end
+
+  defp counterfactual_payload(requirements) do
+    inner = :crypto.strong_rand_bytes(65)
+    {:ok, wrapped} = ERC6492.wrap(@factory, <<0xDE, 0xAD>>, inner)
+    wrapped_hex = "0x" <> Base.encode16(wrapped, case: :lower)
+    unsigned_payload(requirements, @smart_wallet, wrapped_hex)
+  end
+
+  defp verify_with_revert(context, overrides) do
+    rpc = stub_rpc(context, Map.merge(%{simulate: {:revert, "opaque failure"}}, overrides))
+    requirements = requirements()
+    payload = signed_payload(requirements)
+    EVM.verify(payload, requirements, level: :full, rpc: rpc)
+  end
+
+  # -- JSON-RPC stub ----------------------------------------------------------
+
+  defp stub_defaults do
+    %{
+      chain_id: 84_532,
+      code: %{String.downcase(@asset) => "0x6001"},
+      balance: 1_000_000,
+      diagnosis_balance: nil,
+      is_valid_signature: :magic,
+      simulate: :ok,
+      authorization_state: {:ok, false},
+      token_name: "USDC",
+      token_version: "2",
+      multicall: [{true, <<>>}, {true, <<>>}]
+    }
+  end
+
+  defp stub_rpc(%{bypass: bypass, finch: finch}, overrides) do
+    config = Map.merge(stub_defaults(), Map.new(overrides))
+    test_pid = self()
+
+    Bypass.expect(bypass, "POST", "/", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+      response =
+        case Jason.decode!(body) do
+          requests when is_list(requests) ->
+            diagnosis? = Enum.any?(requests, &authorization_state_request?/1)
+            Enum.map(requests, &handle_rpc(&1, config, test_pid, diagnosis?))
+
+          request ->
+            handle_rpc(request, config, test_pid, false)
+        end
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(response))
+    end)
+
+    {:ok, rpc} = RPC.new(rpc_url: "http://localhost:#{bypass.port}", finch: finch)
+    rpc
+  end
+
+  defp authorization_state_request?(%{
+         "method" => "eth_call",
+         "params" => [%{"data" => data} | _]
+       }),
+       do: String.starts_with?(data, "0xe94a0102")
+
+  defp authorization_state_request?(_request), do: false
+
+  defp handle_rpc(
+         %{"id" => id, "method" => method, "params" => params},
+         config,
+         test_pid,
+         diagnosis?
+       ) do
+    send(test_pid, {:rpc, method, params})
+
+    case rpc_result(method, params, config, diagnosis?) do
+      {:ok, result} -> %{"jsonrpc" => "2.0", "id" => id, "result" => result}
+      {:error, error} -> %{"jsonrpc" => "2.0", "id" => id, "error" => error}
+    end
+  end
+
+  defp rpc_result("eth_chainId", [], %{chain_id: :invalid}, _diagnosis?), do: {:ok, "0x"}
+
+  defp rpc_result("eth_chainId", [], config, _diagnosis?),
+    do: {:ok, "0x" <> Integer.to_string(config.chain_id, 16)}
+
+  defp rpc_result("eth_getCode", [_address, _block], %{code: :error}, _diagnosis?),
+    do: {:error, %{"code" => -32_000, "message" => "boom"}}
+
+  defp rpc_result("eth_getCode", [address, _block], config, _diagnosis?),
+    do: {:ok, Map.get(config.code, String.downcase(address), "0x")}
+
+  defp rpc_result("eth_call", [%{"data" => "0x" <> data_hex} | _rest], config, diagnosis?) do
+    dispatch_call(Base.decode16!(data_hex, case: :mixed), config, diagnosis?)
+  end
+
+  # balanceOf(address)
+  defp dispatch_call(<<0x70, 0xA0, 0x82, 0x31, _rest::binary>>, config, diagnosis?) do
+    balance =
+      case {diagnosis?, config.diagnosis_balance} do
+        {true, value} when not is_nil(value) -> value
+        _other -> config.balance
+      end
+
+    case balance do
+      :revert -> revert_error("balanceOf failed")
+      {:raw, hex} -> {:ok, hex}
+      value -> {:ok, uint_hex(value)}
+    end
+  end
+
+  # isValidSignature(bytes32,bytes)
+  defp dispatch_call(<<0x16, 0x26, 0xBA, 0x7E, args::binary>>, config, _diagnosis?) do
+    <<_digest::binary-size(32), _offset::unsigned-big-integer-size(256),
+      _length::unsigned-big-integer-size(256), _signature::binary>> = args
+
+    case config.is_valid_signature do
+      :magic -> {:ok, "0x1626ba7e" <> String.duplicate("00", 28)}
+      :wrong_value -> {:ok, "0x" <> String.duplicate("ff", 32)}
+      :revert -> revert_error("invalid signature")
+      :empty -> {:ok, "0x"}
+      :number -> {:ok, 42}
+    end
+  end
+
+  # transferWithAuthorization — (v,r,s) and bytes variants
+  defp dispatch_call(<<0xE3, 0xEE, 0x16, 0x0E, _rest::binary>>, config, _diagnosis?),
+    do: simulate_result(config)
+
+  defp dispatch_call(<<0xCF, 0x09, 0x29, 0x95, _rest::binary>>, config, _diagnosis?),
+    do: simulate_result(config)
+
+  # authorizationState(address,bytes32)
+  defp dispatch_call(<<0xE9, 0x4A, 0x01, 0x02, _rest::binary>>, config, _diagnosis?) do
+    case config.authorization_state do
+      {:ok, used?} -> {:ok, uint_hex(if(used?, do: 1, else: 0))}
+      {:raw, hex} -> {:ok, hex}
+      :revert -> revert_error("authorizationState failed")
+    end
+  end
+
+  # name()
+  defp dispatch_call(<<0x06, 0xFD, 0xDE, 0x03>>, config, _diagnosis?) do
+    case config.token_name do
+      :revert -> revert_error("name failed")
+      {:raw, hex} -> {:ok, hex}
+      name -> {:ok, string_hex(name)}
+    end
+  end
+
+  # version()
+  defp dispatch_call(<<0x54, 0xFD, 0x4D, 0x50>>, config, _diagnosis?),
+    do: {:ok, string_hex(config.token_version)}
+
+  # aggregate3((address,bool,bytes)[])
+  defp dispatch_call(<<0x82, 0xAD, 0x56, 0xCB, _rest::binary>>, config, _diagnosis?) do
+    case config.multicall do
+      :revert -> revert_error("multicall failed")
+      :empty -> {:ok, "0x"}
+      {:raw, hex} -> {:ok, hex}
+      results -> {:ok, aggregate3_hex(results)}
+    end
+  end
+
+  defp simulate_result(config) do
+    case config.simulate do
+      :ok -> {:ok, "0x"}
+      {:revert, message} -> revert_error(message)
+      {:revert_no_data, message} -> {:error, %{"code" => 3, "message" => message}}
+      {:revert_raw, error} -> {:error, error}
+    end
+  end
+
+  defp revert_error(message) do
+    {:error,
+     %{
+       "code" => 3,
+       "message" => "execution reverted: #{message}",
+       "data" => "0x08c379a0" <> strip0x(string_hex(message))
+     }}
+  end
+
+  defp strip0x("0x" <> hex), do: hex
+
+  defp uint_hex(value),
+    do: "0x" <> Base.encode16(<<value::unsigned-big-integer-size(256)>>, case: :lower)
+
+  defp string_hex(string) do
+    padded = string <> :binary.copy(<<0>>, rem(32 - rem(byte_size(string), 32), 32))
+
+    "0x" <>
+      Base.encode16(
+        <<32::unsigned-big-integer-size(256), byte_size(string)::unsigned-big-integer-size(256)>> <>
+          padded,
+        case: :lower
+      )
+  end
+
+  defp aggregate3_hex(results) do
+    tuples =
+      Enum.map(results, fn {success, data} ->
+        flag = if success, do: 1, else: 0
+        padded = data <> :binary.copy(<<0>>, rem(32 - rem(byte_size(data), 32), 32))
+
+        <<flag::unsigned-big-integer-size(256), 64::unsigned-big-integer-size(256),
+          byte_size(data)::unsigned-big-integer-size(256)>> <> padded
+      end)
+
+    {offsets, _end} =
+      Enum.map_reduce(tuples, 32 * length(tuples), fn tuple, position ->
+        {position, position + byte_size(tuple)}
+      end)
+
+    array =
+      <<length(tuples)::unsigned-big-integer-size(256)>> <>
+        Enum.map_join(offsets, &<<&1::unsigned-big-integer-size(256)>>) <> Enum.join(tuples)
+
+    "0x" <> Base.encode16(<<32::unsigned-big-integer-size(256)>> <> array, case: :lower)
+  end
+
+  # -- Structural level -------------------------------------------------------
+
+  describe "level :structural" do
+    test "accepts a well-formed payload" do
+      requirements = requirements()
+      payload = unsigned_payload(requirements, @payer, "0x" <> String.duplicate("11", 130))
+
+      assert {:ok, %{payer: @payer, level: :structural, signature_type: nil}} =
+               EVM.verify(payload, requirements, level: :structural)
+    end
+
+    test "rejects non-map payload sections" do
+      assert EVM.verify(%{"x402Version" => 2}, requirements(), level: :structural) ==
+               {:error, {:invalid, :invalid_payload}}
+
+      assert EVM.verify(
+               %{"accepted" => requirements(), "payload" => "nope"},
+               requirements(),
+               level: :structural
+             ) ==
+               {:error, {:invalid, :invalid_payload}}
+    end
+
+    test "rejects scheme mismatches on either side" do
+      requirements = requirements()
+      payload = unsigned_payload(requirements, @payer, "0x11")
+
+      upto = put_in(payload, ["accepted", "scheme"], "upto")
+
+      assert EVM.verify(upto, requirements, level: :structural) ==
+               {:error, {:invalid, :scheme_mismatch}}
+
+      assert EVM.verify(payload, requirements(%{"scheme" => "upto"}), level: :structural) ==
+               {:error, {:invalid, :scheme_mismatch}}
+    end
+
+    test "rejects network mismatches" do
+      requirements = requirements()
+      payload = unsigned_payload(requirements(%{"network" => "eip155:1"}), @payer, "0x11")
+
+      assert EVM.verify(payload, requirements, level: :structural) ==
+               {:error, {:invalid, :network_mismatch}}
+    end
+
+    test "rejects non-EVM networks" do
+      solana = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+      requirements = requirements(%{"network" => solana})
+      payload = unsigned_payload(requirements, @payer, "0x11")
+
+      assert EVM.verify(payload, requirements, level: :structural) ==
+               {:error, {:invalid, :unsupported_network}}
+    end
+
+    test "rejects a missing EIP-712 domain" do
+      requirements = requirements(%{"extra" => %{"version" => "2"}})
+      payload = unsigned_payload(requirements, @payer, "0x11")
+
+      assert EVM.verify(payload, requirements, level: :structural) ==
+               {:error, {:invalid, :missing_eip712_domain}}
+    end
+
+    test "rejects non-default asset transfer methods" do
+      requirements =
+        requirements(%{
+          "extra" => %{"name" => "USDC", "version" => "2", "assetTransferMethod" => "permit2"}
+        })
+
+      payload = unsigned_payload(requirements, @payer, "0x11")
+
+      assert EVM.verify(payload, requirements, level: :structural) ==
+               {:error, {:invalid, :unsupported_transfer_method}}
+    end
+
+    test "rejects an invalid asset address" do
+      requirements = requirements(%{"asset" => "0x123"})
+      payload = unsigned_payload(requirements, @payer, "0x11")
+
+      assert EVM.verify(payload, requirements, level: :structural) ==
+               {:error, {:invalid, :invalid_requirements}}
+    end
+
+    test "rejects missing or malformed signatures" do
+      requirements = requirements()
+
+      for signature <- ["0x", "0xzz", "not hex", nil] do
+        payload = unsigned_payload(requirements, @payer, signature)
+
+        assert EVM.verify(payload, requirements, level: :structural) ==
+                 {:error, {:invalid, :invalid_signature}},
+               "expected #{inspect(signature)} to be rejected"
+      end
+    end
+
+    test "rejects malformed authorization objects" do
+      requirements = requirements()
+      base = unsigned_payload(requirements, @payer, "0x11")
+
+      missing = update_in(base, ["payload"], &Map.delete(&1, "authorization"))
+
+      assert EVM.verify(missing, requirements, level: :structural) ==
+               {:error, {:invalid, :invalid_authorization}}
+
+      bad_from = put_authorization(base, "from", "0x123")
+
+      assert EVM.verify(bad_from, requirements, level: :structural) ==
+               {:error, {:invalid, :invalid_authorization}}
+
+      bad_nonce = put_authorization(base, "nonce", "0xabcd")
+
+      assert EVM.verify(bad_nonce, requirements, level: :structural) ==
+               {:error, {:invalid, :invalid_authorization}}
+
+      bad_value = put_authorization(base, "value", "10.5e3")
+
+      assert EVM.verify(bad_value, requirements, level: :structural) ==
+               {:error, {:invalid, :invalid_authorization}}
+
+      bad_time = put_authorization(base, "validBefore", "soon")
+
+      assert EVM.verify(bad_time, requirements, level: :structural) ==
+               {:error, {:invalid, :invalid_authorization}}
+    end
+
+    test "rejects recipients that do not match payTo" do
+      requirements = requirements()
+
+      payload =
+        unsigned_payload(requirements, @payer, "0x11", %{
+          "to" => "0x1111111111111111111111111111111111111111"
+        })
+
+      assert EVM.verify(payload, requirements, level: :structural) ==
+               {:error, {:invalid, :recipient_mismatch}}
+    end
+
+    test "accepts payTo equality case-insensitively" do
+      requirements = requirements()
+
+      payload =
+        unsigned_payload(requirements, @payer, "0x11", %{"to" => String.downcase(@pay_to)})
+
+      assert {:ok, _result} = EVM.verify(payload, requirements, level: :structural)
+    end
+
+    test "rejects amounts that do not exactly match" do
+      requirements = requirements()
+      payload = unsigned_payload(requirements, @payer, "0x11", %{"value" => "10001"})
+
+      assert EVM.verify(payload, requirements, level: :structural) ==
+               {:error, {:invalid, :value_mismatch}}
+    end
+
+    test "rejects validBefore inside the 6-second settlement buffer" do
+      now = System.system_time(:second)
+      requirements = requirements()
+
+      payload =
+        unsigned_payload(requirements, @payer, "0x11", %{
+          "validBefore" => Integer.to_string(now + 5)
+        })
+
+      assert EVM.verify(payload, requirements, level: :structural) ==
+               {:error, {:invalid, :valid_before_expired}}
+    end
+
+    test "accepts validBefore beyond the settlement buffer" do
+      now = System.system_time(:second)
+      requirements = requirements()
+
+      payload =
+        unsigned_payload(requirements, @payer, "0x11", %{
+          "validBefore" => Integer.to_string(now + 15)
+        })
+
+      assert {:ok, _result} = EVM.verify(payload, requirements, level: :structural)
+    end
+
+    test "rejects validAfter in the future" do
+      now = System.system_time(:second)
+      requirements = requirements()
+
+      payload =
+        unsigned_payload(requirements, @payer, "0x11", %{
+          "validAfter" => Integer.to_string(now + 60)
+        })
+
+      assert EVM.verify(payload, requirements, level: :structural) ==
+               {:error, {:invalid, :valid_after_in_future}}
+    end
+
+    test "accepts integer timing and amount fields" do
+      now = System.system_time(:second)
+      requirements = requirements(%{"amount" => 10_000})
+
+      payload =
+        unsigned_payload(requirements, @payer, "0x11", %{
+          "value" => 10_000,
+          "validAfter" => now - 60,
+          "validBefore" => now + 600
+        })
+
+      assert {:ok, _result} = EVM.verify(payload, requirements, level: :structural)
+    end
+
+    test "requires an explicit level" do
+      assert_raise NimbleOptions.ValidationError, fn ->
+        EVM.verify(%{}, %{}, [])
+      end
+    end
+
+    test "rejects requirements whose extra is not a map" do
+      requirements = requirements(%{"extra" => "nope"})
+      payload = unsigned_payload(requirements, @payer, "0x11")
+
+      assert EVM.verify(payload, requirements, level: :structural) ==
+               {:error, {:invalid, :invalid_requirements}}
+    end
+
+    test "rejects non-integer authorization values" do
+      requirements = requirements()
+      payload = unsigned_payload(requirements, @payer, "0x11", %{"value" => 10_000.5})
+
+      assert EVM.verify(payload, requirements, level: :structural) ==
+               {:error, {:invalid, :invalid_authorization}}
+    end
+  end
+
+  # -- Signature level --------------------------------------------------------
+
+  describe "level :signature" do
+    test "verifies a payload signed by the payer" do
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert {:ok, %{payer: @payer, level: :signature, signature_type: :eoa}} =
+               EVM.verify(payload, requirements, level: :signature)
+    end
+
+    test "rejects tampering with each signed authorization field" do
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      tampered_nonce = put_authorization(payload, "nonce", "0x" <> String.duplicate("cd", 32))
+
+      assert EVM.verify(tampered_nonce, requirements, level: :signature) ==
+               {:error, {:invalid, :invalid_signature}}
+
+      original_after = get_in(payload, ["payload", "authorization", "validAfter"])
+      shifted_after = Integer.to_string(String.to_integer(original_after) - 1)
+      tampered_after = put_authorization(payload, "validAfter", shifted_after)
+
+      assert EVM.verify(tampered_after, requirements, level: :signature) ==
+               {:error, {:invalid, :invalid_signature}}
+
+      original_before = get_in(payload, ["payload", "authorization", "validBefore"])
+      shifted_before = Integer.to_string(String.to_integer(original_before) + 1)
+      tampered_before = put_authorization(payload, "validBefore", shifted_before)
+
+      assert EVM.verify(tampered_before, requirements, level: :signature) ==
+               {:error, {:invalid, :invalid_signature}}
+
+      tampered_value = put_authorization(payload, "value", "10001")
+      tampered_requirements = requirements(%{"amount" => "10001"})
+      tampered_payload = put_in(tampered_value, ["accepted", "amount"], "10001")
+
+      assert EVM.verify(tampered_payload, tampered_requirements, level: :signature) ==
+               {:error, {:invalid, :invalid_signature}}
+    end
+
+    test "rejects a payload claiming a different payer" do
+      requirements = requirements()
+
+      payload =
+        put_authorization(
+          signed_payload(requirements),
+          "from",
+          "0x1111111111111111111111111111111111111111"
+        )
+
+      assert EVM.verify(payload, requirements, level: :signature) ==
+               {:error, {:invalid, :invalid_signature}}
+    end
+
+    test "rejects a signature over a different EIP-712 domain" do
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      other_requirements = requirements(%{"extra" => %{"name" => "USDX", "version" => "2"}})
+      other_payload = put_in(payload, ["accepted", "extra", "name"], "USDX")
+
+      assert EVM.verify(other_payload, other_requirements, level: :signature) ==
+               {:error, {:invalid, :invalid_signature}}
+    end
+
+    test "rejects garbage 65-byte signatures" do
+      requirements = requirements()
+      payload = unsigned_payload(requirements, @payer, "0x" <> String.duplicate("11", 65))
+
+      assert EVM.verify(payload, requirements, level: :signature) ==
+               {:error, {:invalid, :invalid_signature}}
+    end
+
+    test "refuses smart-wallet signatures without RPC (fail closed)" do
+      requirements = requirements()
+
+      {:ok, wrapped} = ERC6492.wrap(@factory, <<0xAB>>, :crypto.strong_rand_bytes(65))
+      wrapped_hex = "0x" <> Base.encode16(wrapped, case: :lower)
+      wrapped_payload = unsigned_payload(requirements, @smart_wallet, wrapped_hex)
+
+      assert EVM.verify(wrapped_payload, requirements, level: :signature) ==
+               {:error, {:invalid, :smart_wallet_requires_rpc}}
+
+      contract_sig =
+        unsigned_payload(requirements, @smart_wallet, "0x" <> String.duplicate("11", 33))
+
+      assert EVM.verify(contract_sig, requirements, level: :signature) ==
+               {:error, {:invalid, :smart_wallet_requires_rpc}}
+    end
+
+    test "rejects a malformed ERC-6492 wrapper" do
+      requirements = requirements()
+      malformed = <<1, 2, 3>> <> ERC6492.magic_suffix()
+      signature_hex = "0x" <> Base.encode16(malformed, case: :lower)
+      payload = unsigned_payload(requirements, @payer, signature_hex)
+
+      assert EVM.verify(payload, requirements, level: :signature) ==
+               {:error, {:invalid, :invalid_signature}}
+    end
+  end
+
+  # -- Full level -------------------------------------------------------------
+
+  describe "level :full" do
+    setup [:setup_bypass, :setup_finch]
+
+    test "requires a configured RPC endpoint" do
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert EVM.verify(payload, requirements, level: :full) == {:error, :rpc_not_configured}
+    end
+
+    test "verifies an EOA payment end to end", context do
+      rpc = stub_rpc(context, %{})
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert {:ok, %{payer: @payer, level: :full, signature_type: :eoa}} =
+               EVM.verify(payload, requirements, level: :full, rpc: rpc)
+
+      assert_received {:rpc, "eth_chainId", []}
+      assert_received {:rpc, "eth_getCode", [@payer, "latest"]}
+      assert_received {:rpc, "eth_call", [%{"data" => "0x70a08231" <> _args} | _block]}
+      assert_received {:rpc, "eth_call", [%{"data" => "0xe3ee160e" <> _args} | _block]}
+    end
+
+    test "rejects an invalid EOA signature", context do
+      rpc = stub_rpc(context, %{})
+      requirements = requirements()
+
+      payload =
+        put_authorization(
+          signed_payload(requirements),
+          "nonce",
+          "0x" <> String.duplicate("cd", 32)
+        )
+
+      assert EVM.verify(payload, requirements, level: :full, rpc: rpc) ==
+               {:error, {:invalid, :invalid_signature}}
+    end
+
+    test "rejects a chain id mismatch before any signature work", context do
+      rpc = stub_rpc(context, %{chain_id: 1})
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert EVM.verify(payload, requirements, level: :full, rpc: rpc) ==
+               {:error, {:chain_id_mismatch, 84_532, 1}}
+    end
+
+    test "skips the chain id check when disabled", context do
+      rpc = stub_rpc(context, %{chain_id: 1})
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert {:ok, _result} =
+               EVM.verify(payload, requirements, level: :full, rpc: rpc, verify_chain_id: false)
+
+      refute_received {:rpc, "eth_chainId", []}
+    end
+
+    test "rejects an asset without bytecode", context do
+      rpc = stub_rpc(context, %{code: %{}})
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert EVM.verify(payload, requirements, level: :full, rpc: rpc) ==
+               {:error, {:invalid, :asset_not_deployed_contract}}
+    end
+
+    test "rejects an underfunded payer", context do
+      rpc = stub_rpc(context, %{balance: 9_999})
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert EVM.verify(payload, requirements, level: :full, rpc: rpc) ==
+               {:error, {:invalid, :insufficient_balance}}
+    end
+
+    test "fails closed when the balance probe reverts", context do
+      rpc = stub_rpc(context, %{balance: :revert})
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert EVM.verify(payload, requirements, level: :full, rpc: rpc) ==
+               {:error, {:invalid, :balance_check_failed}}
+    end
+
+    test "skips simulation when disabled for deployed payers", context do
+      rpc = stub_rpc(context, %{simulate: {:revert, "should not run"}})
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert {:ok, _result} =
+               EVM.verify(payload, requirements, level: :full, rpc: rpc, simulate: false)
+
+      refute_received {:rpc, "eth_call", [%{"data" => "0xe3ee160e" <> _args} | _block]}
+    end
+
+    test "fails closed on transport errors", context do
+      {:ok, rpc} =
+        RPC.new(rpc_url: "http://localhost:#{context.bypass.port}", finch: context.finch)
+
+      Bypass.down(context.bypass)
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert {:error, {:rpc_error, {:transport_error, _reason}}} =
+               EVM.verify(payload, requirements, level: :full, rpc: rpc)
+    end
+
+    test "fails closed when eth_getCode errors node-side", context do
+      rpc = stub_rpc(context, %{code: :error})
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert {:error, {:rpc_error, {:jsonrpc_error, _error}}} =
+               EVM.verify(payload, requirements, level: :full, rpc: rpc)
+    end
+
+    test "fails closed on an undecodable chain id", context do
+      rpc = stub_rpc(context, %{chain_id: :invalid})
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert EVM.verify(payload, requirements, level: :full, rpc: rpc) ==
+               {:error, {:rpc_error, {:invalid_response, "0x"}}}
+    end
+
+    test "rejects an undecodable balance return", context do
+      rpc = stub_rpc(context, %{balance: {:raw, "0x12"}})
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert EVM.verify(payload, requirements, level: :full, rpc: rpc) ==
+               {:error, {:invalid, :balance_check_failed}}
+    end
+
+    test "treats undecodable payer bytecode as no code", context do
+      rpc = stub_rpc(context, %{code: %{String.downcase(@asset) => "0x6001", @payer => "zz"}})
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert {:ok, %{signature_type: :eoa}} =
+               EVM.verify(payload, requirements, level: :full, rpc: rpc)
+    end
+
+    test "accepts EOA signatures with a 0/1 recovery byte", context do
+      rpc = stub_rpc(context, %{})
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      "0x" <> signature_hex = get_in(payload, ["payload", "signature"])
+      <<compact::binary-size(64), v>> = Base.decode16!(signature_hex, case: :mixed)
+      shifted = compact <> <<v - 27>>
+      shifted_hex = "0x" <> Base.encode16(shifted, case: :lower)
+      payload = put_in(payload, ["payload", "signature"], shifted_hex)
+
+      assert {:ok, %{signature_type: :eoa}} =
+               EVM.verify(payload, requirements, level: :full, rpc: rpc)
+    end
+
+    test "rejects a non-65-byte signature from an undeployed payer", context do
+      rpc = stub_rpc(context, %{})
+      requirements = requirements()
+      payload = unsigned_payload(requirements, @smart_wallet, "0x" <> String.duplicate("22", 33))
+
+      assert EVM.verify(payload, requirements, level: :full, rpc: rpc) ==
+               {:error, {:invalid, :invalid_signature}}
+    end
+  end
+
+  describe "level :full — ERC-1271" do
+    setup [:setup_bypass, :setup_finch]
+
+    test "accepts a deployed wallet returning the magic value", context do
+      rpc =
+        stub_rpc(context, %{
+          code: %{String.downcase(@asset) => "0x6001", @smart_wallet => "0x6001"}
+        })
+
+      requirements = requirements()
+      payload = contract_payload(requirements)
+
+      assert {:ok, %{signature_type: :erc1271}} =
+               EVM.verify(payload, requirements, level: :full, rpc: rpc)
+
+      assert_received {:rpc, "eth_call",
+                       [%{"to" => @smart_wallet, "data" => "0x1626ba7e" <> _args} | _block]}
+    end
+
+    test "rejects a wallet returning a non-magic value", context do
+      rpc =
+        stub_rpc(context, %{
+          code: %{String.downcase(@asset) => "0x6001", @smart_wallet => "0x6001"},
+          is_valid_signature: :wrong_value
+        })
+
+      requirements = requirements()
+
+      assert EVM.verify(contract_payload(requirements), requirements, level: :full, rpc: rpc) ==
+               {:error, {:invalid, :invalid_signature}}
+    end
+
+    test "rejects a wallet whose isValidSignature reverts", context do
+      rpc =
+        stub_rpc(context, %{
+          code: %{String.downcase(@asset) => "0x6001", @smart_wallet => "0x6001"},
+          is_valid_signature: :revert
+        })
+
+      requirements = requirements()
+
+      assert EVM.verify(contract_payload(requirements), requirements, level: :full, rpc: rpc) ==
+               {:error, {:invalid, :invalid_signature}}
+    end
+
+    test "rejects a wallet returning a non-string result", context do
+      rpc =
+        stub_rpc(context, %{
+          code: %{String.downcase(@asset) => "0x6001", @smart_wallet => "0x6001"},
+          is_valid_signature: :number
+        })
+
+      requirements = requirements()
+
+      assert EVM.verify(contract_payload(requirements), requirements, level: :full, rpc: rpc) ==
+               {:error, {:invalid, :invalid_signature}}
+    end
+
+    test "rejects a wallet returning empty data", context do
+      rpc =
+        stub_rpc(context, %{
+          code: %{String.downcase(@asset) => "0x6001", @smart_wallet => "0x6001"},
+          is_valid_signature: :empty
+        })
+
+      requirements = requirements()
+
+      assert EVM.verify(contract_payload(requirements), requirements, level: :full, rpc: rpc) ==
+               {:error, {:invalid, :invalid_signature}}
+    end
+
+    test "unwraps ERC-6492 for a deployed wallet and passes the inner signature", context do
+      rpc =
+        stub_rpc(context, %{
+          code: %{String.downcase(@asset) => "0x6001", @smart_wallet => "0x6001"}
+        })
+
+      requirements = requirements()
+
+      inner = :crypto.strong_rand_bytes(65)
+      {:ok, wrapped} = ERC6492.wrap(@factory, <<0xAB>>, inner)
+      wrapped_hex = "0x" <> Base.encode16(wrapped, case: :lower)
+      payload = unsigned_payload(requirements, @smart_wallet, wrapped_hex)
+
+      assert {:ok, %{signature_type: :erc1271}} =
+               EVM.verify(payload, requirements, level: :full, rpc: rpc)
+
+      assert_received {:rpc, "eth_call",
+                       [%{"to" => @smart_wallet, "data" => "0x1626ba7e" <> data} | _block]}
+
+      assert String.contains?(data, Base.encode16(inner, case: :lower))
+    end
+  end
+
+  describe "level :full — ERC-6492 counterfactual" do
+    setup [:setup_bypass, :setup_finch]
+
+    test "rejects counterfactual payments by default (empty factory allowlist)", context do
+      rpc = stub_rpc(context, %{})
+      requirements = requirements()
+
+      assert EVM.verify(counterfactual_payload(requirements), requirements,
+               level: :full,
+               rpc: rpc
+             ) ==
+               {:error, {:invalid, :eip6492_factory_not_allowed}}
+    end
+
+    test "rejects counterfactual payments when simulation is disabled", context do
+      rpc = stub_rpc(context, %{})
+      requirements = requirements()
+
+      assert EVM.verify(
+               counterfactual_payload(requirements),
+               requirements,
+               level: :full,
+               rpc: rpc,
+               simulate: false,
+               eip6492_allowed_factories: [@factory]
+             ) ==
+               {:error, {:invalid, :undeployed_smart_wallet}}
+    end
+
+    test "accepts an allowlisted factory when the atomic simulation succeeds", context do
+      rpc = stub_rpc(context, %{})
+      requirements = requirements()
+
+      assert {:ok, %{signature_type: :erc6492_counterfactual}} =
+               EVM.verify(
+                 counterfactual_payload(requirements),
+                 requirements,
+                 level: :full,
+                 rpc: rpc,
+                 eip6492_allowed_factories: [String.upcase(@factory)]
+               )
+
+      assert_received {:rpc, "eth_call",
+                       [%{"to" => to, "data" => "0x82ad56cb" <> _args} | _block]}
+
+      assert String.downcase(to) == @multicall3
+    end
+
+    test "rejects when the transfer leg of the simulation fails", context do
+      revert_data =
+        <<0x08, 0xC3, 0x79, 0xA0>> <>
+          Base.decode16!(
+            String.replace_prefix(
+              string_hex("FiatTokenV2: authorization is used or canceled"),
+              "0x",
+              ""
+            ),
+            case: :lower
+          )
+
+      rpc = stub_rpc(context, %{multicall: [{true, <<>>}, {false, revert_data}]})
+      requirements = requirements()
+
+      assert EVM.verify(
+               counterfactual_payload(requirements),
+               requirements,
+               level: :full,
+               rpc: rpc,
+               eip6492_allowed_factories: [@factory]
+             ) ==
+               {:error, {:invalid, :nonce_already_used}}
+    end
+
+    test "falls back to diagnosis on an unclassifiable transfer failure", context do
+      rpc = stub_rpc(context, %{multicall: [{true, <<>>}, {false, <<>>}]})
+      requirements = requirements()
+
+      assert EVM.verify(
+               counterfactual_payload(requirements),
+               requirements,
+               level: :full,
+               rpc: rpc,
+               eip6492_allowed_factories: [@factory]
+             ) ==
+               {:error, {:invalid, :simulation_failed}}
+    end
+
+    test "treats an empty multicall return as a failed simulation", context do
+      rpc = stub_rpc(context, %{multicall: :empty})
+      requirements = requirements()
+
+      assert EVM.verify(
+               counterfactual_payload(requirements),
+               requirements,
+               level: :full,
+               rpc: rpc,
+               eip6492_allowed_factories: [@factory]
+             ) ==
+               {:error, {:invalid, :simulation_failed}}
+    end
+
+    test "diagnoses a multicall that reverts outright", context do
+      rpc = stub_rpc(context, %{multicall: :revert})
+      requirements = requirements()
+
+      assert EVM.verify(
+               counterfactual_payload(requirements),
+               requirements,
+               level: :full,
+               rpc: rpc,
+               eip6492_allowed_factories: [@factory]
+             ) ==
+               {:error, {:invalid, :simulation_failed}}
+    end
+
+    test "treats a truncated multicall return as a failed simulation", context do
+      truncated =
+        "0x" <>
+          Base.encode16(
+            <<32::unsigned-big-integer-size(256), 2::unsigned-big-integer-size(256),
+              0::unsigned-big-integer-size(256)>>,
+            case: :lower
+          )
+
+      rpc = stub_rpc(context, %{multicall: {:raw, truncated}})
+      requirements = requirements()
+
+      assert EVM.verify(
+               counterfactual_payload(requirements),
+               requirements,
+               level: :full,
+               rpc: rpc,
+               eip6492_allowed_factories: [@factory]
+             ) ==
+               {:error, {:invalid, :simulation_failed}}
+    end
+
+    test "rejects a counterfactual wrapper with an empty inner signature", context do
+      rpc = stub_rpc(context, %{})
+      requirements = requirements()
+
+      {:ok, wrapped} = ERC6492.wrap(@factory, <<0xDE, 0xAD>>, <<>>)
+      wrapped_hex = "0x" <> Base.encode16(wrapped, case: :lower)
+      payload = unsigned_payload(requirements, @smart_wallet, wrapped_hex)
+
+      assert EVM.verify(
+               payload,
+               requirements,
+               level: :full,
+               rpc: rpc,
+               eip6492_allowed_factories: [@factory]
+             ) ==
+               {:error, {:invalid, :invalid_signature}}
+    end
+  end
+
+  describe "level :full — simulation diagnosis" do
+    setup [:setup_bypass, :setup_finch]
+
+    test "classifies known revert messages without a diagnosis batch", context do
+      rpc =
+        stub_rpc(context, %{simulate: {:revert, "FiatTokenV2: authorization is used or canceled"}})
+
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert EVM.verify(payload, requirements, level: :full, rpc: rpc) ==
+               {:error, {:invalid, :nonce_already_used}}
+
+      refute_received {:rpc, "eth_call", [%{"data" => "0xe94a0102" <> _args} | _block]}
+    end
+
+    test "classifies revert reasons carried only in error data", context do
+      rpc =
+        stub_rpc(context, %{
+          simulate: {:revert, "ERC20: transfer amount exceeds balance"}
+        })
+
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert EVM.verify(payload, requirements, level: :full, rpc: rpc) ==
+               {:error, {:invalid, :insufficient_balance}}
+    end
+
+    test "diagnoses a token without EIP-3009 support", context do
+      assert verify_with_revert(context, %{authorization_state: :revert}) ==
+               {:error, {:invalid, :eip3009_not_supported}}
+    end
+
+    test "diagnoses an already-used nonce", context do
+      assert verify_with_revert(context, %{authorization_state: {:ok, true}}) ==
+               {:error, {:invalid, :nonce_already_used}}
+    end
+
+    test "diagnoses a token name mismatch", context do
+      assert verify_with_revert(context, %{token_name: "USDX"}) ==
+               {:error, {:invalid, :token_name_mismatch}}
+    end
+
+    test "diagnoses a token version mismatch", context do
+      assert verify_with_revert(context, %{token_version: "1"}) ==
+               {:error, {:invalid, :token_version_mismatch}}
+    end
+
+    test "diagnoses a balance drained between preflight and simulation", context do
+      assert verify_with_revert(context, %{diagnosis_balance: 1}) ==
+               {:error, {:invalid, :insufficient_balance}}
+    end
+
+    test "falls back to simulation_failed when nothing is conclusive", context do
+      assert verify_with_revert(context, %{}) == {:error, {:invalid, :simulation_failed}}
+    end
+
+    test "tolerates undecodable diagnosis probe results", context do
+      assert verify_with_revert(context, %{
+               authorization_state: {:raw, "0x01"},
+               token_name: :revert,
+               diagnosis_balance: {:raw, "0x01"}
+             }) ==
+               {:error, {:invalid, :simulation_failed}}
+    end
+
+    test "tolerates an undecodable token name string", context do
+      assert verify_with_revert(context, %{token_name: {:raw, "0x12"}}) ==
+               {:error, {:invalid, :simulation_failed}}
+    end
+
+    test "classifies from the message when error data is not hex", context do
+      rpc =
+        stub_rpc(context, %{
+          simulate:
+            {:revert_raw,
+             %{
+               "code" => 3,
+               "message" => "execution reverted: FiatTokenV2: authorization is expired",
+               "data" => "0xzz"
+             }}
+        })
+
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert EVM.verify(payload, requirements, level: :full, rpc: rpc) ==
+               {:error, {:invalid, :valid_before_expired}}
+    end
+
+    test "diagnoses when the revert carries only a malformed Error(string)", context do
+      rpc =
+        stub_rpc(context, %{
+          simulate: {:revert_raw, %{"code" => 3, "data" => "0x08c379a0"}}
+        })
+
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert EVM.verify(payload, requirements, level: :full, rpc: rpc) ==
+               {:error, {:invalid, :simulation_failed}}
+    end
+
+    test "handles reverts without error data", context do
+      rpc =
+        stub_rpc(context, %{
+          simulate: {:revert_no_data, "execution reverted: FiatTokenV2: authorization is expired"}
+        })
+
+      requirements = requirements()
+      payload = signed_payload(requirements)
+
+      assert EVM.verify(payload, requirements, level: :full, rpc: rpc) ==
+               {:error, {:invalid, :valid_before_expired}}
+    end
+  end
+
+  describe "ABI selectors" do
+    setup [:setup_bypass, :setup_finch]
+
+    test "hardcoded selectors match keccak256 of the canonical signatures", context do
+      rpc =
+        stub_rpc(context, %{
+          code: %{String.downcase(@asset) => "0x6001", @smart_wallet => "0x6001"}
+        })
+
+      requirements = requirements()
+      payload = unsigned_payload(requirements, @smart_wallet, "0x" <> String.duplicate("22", 80))
+
+      assert {:ok, _result} = EVM.verify(payload, requirements, level: :full, rpc: rpc)
+
+      assert_received {:rpc, "eth_call", [%{"data" => "0x70a08231" <> _b} | _block1]}
+      assert_received {:rpc, "eth_call", [%{"data" => "0x1626ba7e" <> _i} | _block2]}
+      assert_received {:rpc, "eth_call", [%{"data" => "0xcf092995" <> _t} | _block3]}
+
+      for {signature, selector} <- [
+            {"balanceOf(address)", "70a08231"},
+            {"isValidSignature(bytes32,bytes)", "1626ba7e"},
+            {"authorizationState(address,bytes32)", "e94a0102"},
+            {"transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)",
+             "e3ee160e"},
+            {"transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)",
+             "cf092995"},
+            {"name()", "06fdde03"},
+            {"version()", "54fd4d50"},
+            {"aggregate3((address,bool,bytes)[])", "82ad56cb"}
+          ] do
+        <<computed::binary-size(4), _rest::binary>> = ExKeccak.hash_256(signature)
+
+        assert Base.encode16(computed, case: :lower) == selector,
+               "selector drift for #{signature}"
+      end
+    end
+  end
+
+  describe "reason_string/1" do
+    test "maps canonical reasons and falls back to the atom name" do
+      assert EVM.reason_string(:valid_before_expired) ==
+               "invalid_exact_evm_payload_authorization_valid_before"
+
+      assert EVM.reason_string(:asset_not_deployed_contract) == "asset_not_deployed_contract"
+      assert EVM.reason_string(:smart_wallet_requires_rpc) == "invalid_exact_evm_signature"
+      assert EVM.reason_string(:invalid_authorization) == "invalid_authorization"
+    end
+  end
+end


### PR DESCRIPTION
## What

Implements full local cryptographic verification of EVM exact/eip3009 payments ([docs/ecosystem-comparison.md](https://github.com/cardotrejos/x402/blob/main/docs/ecosystem-comparison.md) §6.2, §8 P1.2 — previously this SDK performed zero local crypto; a resource server's security posture equaled its facilitator's, fully). This is also the verification core the future facilitator engine (P2.1) assembles around.

Five commits:
- **`X402.RPC`** — minimal Ethereum JSON-RPC over the user's Finch (batched requests, https enforcement mirroring the facilitator transport, structured errors, telemetry). Zero new deps.
- **`X402.ERC6492`** — pure wrapper parse/wrap per the standard.
- **`X402.Verify.EVM`** — three explicit verification levels, never silently downgraded:
  - `:structural` (pure): scheme/network/domain requirements, payload shape, payTo equality, exact amount, validAfter/validBefore with the reference 6s buffer
  - `:signature` (crypto, no RPC): EIP-712 digest recomputation + EOA ecrecover; smart-wallet signatures rejected fail-closed
  - `:full` (RPC): signature routing by payer bytecode exactly like on-chain SignatureChecker (strict ERC-1271, no ECDSA fallback), ERC-6492 with **Go's fail-closed counterfactual design** (factory allowlist defaulting to reject-all; validity proven only by atomic Multicall3 deploy+transfer simulation), asset code + balance preflight in one batch, transferWithAuthorization simulation with revert classification and the reference diagnosis probe (`nonce_already_used`, `insufficient_balance`, `token_name_mismatch`, …)
- Word encoding reuses the shared `X402.EIP712` from #65; digest/domain/recovery reuse `X402.EIP3009` — no duplicated EIP-712 logic.

## Testing

123 new tests/doctests: sign→verify round-trips against our own `X402.Signer.LocalKey`, per-field tamper rejection, ERC-1271/6492 flows over a Bypass JSON-RPC stub, counterfactual-refused-without-simulation, diagnosis mapping, a selector-drift guard. Full suite: 145 doctests + 661 tests, 0 failures; new modules 95.5–100% coverage. All gates green incl. dialyzer and --no-optional-deps.

## Notes

Gate integration is documented as the `before_verify` hook pattern (guides/local-verification.md); wiring into the gate arrives with the X402.Scheme seam (P1.1, in progress). `reason_string/1` maps rejection atoms to the canonical cross-SDK invalidReason strings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New payment-verification logic touches EIP-712, on-chain simulation, and ERC-6492 factory allowlists—bugs could accept invalid payments or reject valid ones; misconfigured RPC or allowlists have direct security impact.
> 
> **Overview**
> Adds **local payment verification** for EVM `exact`/`eip3009` payments so resource servers can run the reference facilitator verify checklist in-process instead of relying solely on a remote `/verify` verdict.
> 
> **`X402.Verify.EVM`** exposes required `:level` options that never silently downgrade: `:structural` (scheme, domain, payTo/amount/timing with the 6s buffer), `:signature` (EIP-712 + EOA recovery; smart wallets fail closed without RPC), and `:full` (batched RPC preflight, ECDSA vs strict ERC-1271 routing, ERC-6492 with factory allowlist + Multicall3 deploy-and-transfer simulation, `transferWithAuthorization` simulation, and revert/diagnosis mapped to canonical `invalidReason` via `reason_string/1`).
> 
> Supporting pieces are **`X402.RPC`** (Finch JSON-RPC: `eth_call`, `eth_getCode`, `eth_chainId`, batch; HTTPS enforcement; telemetry) and **`X402.ERC6492`** (pure wrap/parse only—validity stays in the verifier). Docs cover the new **Local Payment Verification** guide and a **`before_verify` hook** pattern for `PaymentGate`; the gate itself is not wired to the verifier yet.
> 
> Telemetry gains `[:x402, :rpc, :request]` and `[:x402, :verify, :evm]`. Large test suites exercise structural/signature/full paths, ERC-1271/6492, and simulation diagnosis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d86457a7f717797b19f7d84f421dc2f7052ca70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->