### PR TITLE
feat: offer-and-receipt extension with EIP-712 and JWS signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   signature wrappers (magic-suffix detection, bounds-checked ABI decoding of
   the factory/calldata/inner-signature tuple); classification policy lives
   in the verifier, which never treats a wrapper as proof by itself.
+- `X402.Extensions.OfferReceipt` — the
+  [offer-and-receipt extension](https://github.com/x402-foundation/x402/blob/main/specs/extensions/extension-offer-and-receipt.md):
+  servers sign the payment terms they advertise (offers under
+  `extensions["offer-receipt"].info.offers[]`) and confirm delivery after
+  settlement (a receipt under `info.receipt`); clients verify both. Supports
+  the spec's two artifact formats — EIP-712 (fixed chain-agnostic domain
+  `{name, version: "1", chainId: 1}`, canonical `Offer`/`Receipt` types,
+  signing through `X402.Signer`, verification by signer recovery) and compact
+  JWS (`ES256K`/`EdDSA` via OTP `:crypto` in
+  `X402.Extensions.OfferReceipt.JWS`, with RFC 8785 JCS payload
+  canonicalization and mandatory `alg`/`kid` headers). Includes the
+  `info`/`schema` declaration builders mirroring the spec's §6 schemas,
+  fail-closed `fetch_offers/1` / `fetch_receipt/1` extraction, structural
+  `validate_offer/1` / `validate_receipt/1`, the v1-name → CAIP-2 network
+  conversion (`to_caip2/1`), and payload builders. Boundaries: JWS
+  verification takes an explicit public key (`kid` DID URLs are never
+  resolved — no network access), and signer *authorization* (§4.5.1) remains
+  caller policy, supported via `:expected_signer`
 - **Local pre-verification checks in `X402.Plug.PaymentGate`** (option
   `local_prechecks:`, default `true`): before the facilitator round-trip, the
   gate now validates the EIP-3009-style `payload.authorization` object against

--- a/guides/plug-integration.md
+++ b/guides/plug-integration.md
@@ -253,6 +253,87 @@ response includes both
 `PAYMENT-REQUIRED` (so the client can retry) and `PAYMENT-RESPONSE` (with
 the error reason).
 
+## Signed Offers and Receipts
+
+The [offer-and-receipt extension](https://github.com/x402-foundation/x402/blob/main/specs/extensions/extension-offer-and-receipt.md)
+lets a resource server cryptographically commit to the terms it advertises
+(**signed offers**) and confirm delivery after payment (**signed
+receipts**) — evidence for disputes, audits, and reputation systems.
+`X402.Extensions.OfferReceipt` implements both artifact formats: EIP-712
+(signed through `X402.Signer`, verified by signer recovery) and compact JWS
+(`ES256K`/`EdDSA` via OTP `:crypto`).
+
+Issue offers for the terms a route advertises and attach them through the
+route's `extensions:` option (clients that ignore the extension are
+unaffected):
+
+```elixir
+alias X402.Extensions.OfferReceipt
+
+{:ok, signer} = X402.Signer.LocalKey.new(System.fetch_env!("OFFER_SIGNING_KEY"))
+
+{:ok, payload} =
+  OfferReceipt.offer_payload(
+    resource_url: "https://api.example.com/premium-data",
+    scheme: "exact",
+    network: "eip155:84532",
+    asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+    pay_to: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+    amount: "10000"
+  )
+
+{:ok, offer} = OfferReceipt.sign_offer(payload, signer, accept_index: 0)
+
+plug X402.Plug.PaymentGate,
+  routes: [
+    {"/premium-data",
+     [
+       amount: "10000",
+       pay_to: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+       network: "eip155:84532",
+       extensions: %{"offer-receipt" => OfferReceipt.build_extension([offer])}
+     ]}
+  ]
+```
+
+Because route configuration is static, offers built this way should omit
+`valid_until` (or set it generously); build the payment-required response
+yourself with `X402.PaymentRequired.encode/1` when you want short-lived,
+per-request offers.
+
+After a successful settlement, issue a receipt from your handler (the payer
+is available in the payment payload assign) and return it to the client —
+for example in the response body, or from your settlement pipeline as
+`extensions["offer-receipt"]` of a settlement response you construct:
+
+```elixir
+{:ok, receipt_payload} =
+  OfferReceipt.receipt_payload(
+    resource_url: "https://api.example.com/premium-data",
+    network: "eip155:84532",
+    payer: payer_address
+  )
+
+{:ok, receipt} = OfferReceipt.sign_receipt(receipt_payload, signer)
+extension = OfferReceipt.build_receipt_extension(receipt)
+```
+
+Clients extract and verify the artifacts — and must apply an authorization
+policy for the signer (spec §4.5.1); the simplest is requiring the offer's
+`payTo` key:
+
+```elixir
+{:ok, [offer]} = OfferReceipt.fetch_offers(payment_required)
+{:ok, payload} = OfferReceipt.extract_payload(offer)
+
+{:ok, %{signer: signer}} =
+  OfferReceipt.verify_offer(offer, expected_signer: payload["payTo"])
+```
+
+JWS verification takes the resolved public key explicitly
+(`verify_offer(offer, public_key: key)`) — the library carries the `kid`
+DID URL but never resolves it over the network.
+
 ## HTTP Status Codes
 
 The plug follows the x402 v2 HTTP transport status mapping:

--- a/lib/x402/eip712.ex
+++ b/lib/x402/eip712.ex
@@ -56,6 +56,8 @@ defmodule X402.EIP712 do
           | :invalid_word
           | {:missing_field, String.t()}
 
+  @uint256_limit Integer.pow(2, 256)
+
   @doc since: "0.6.0"
   @doc """
   Derives the EIP-712 domain from v2 payment requirements.
@@ -234,8 +236,12 @@ defmodule X402.EIP712 do
       {:error, :invalid_amount}
   """
   @spec encode_uint256(term()) :: {:ok, <<_::256>>} | {:error, :invalid_amount}
-  def encode_uint256(integer) when is_integer(integer) and integer >= 0,
-    do: {:ok, <<integer::unsigned-big-integer-size(256)>>}
+  # Values at or above 2^256 cannot be represented: bit syntax would
+  # silently truncate them to the low 256 bits, making a different value
+  # hash as if it were signed. Reject instead.
+  def encode_uint256(integer)
+      when is_integer(integer) and integer >= 0 and integer < @uint256_limit,
+      do: {:ok, <<integer::unsigned-big-integer-size(256)>>}
 
   def encode_uint256(string) when is_binary(string) do
     case Integer.parse(string) do

--- a/lib/x402/extensions/offer_receipt.ex
+++ b/lib/x402/extensions/offer_receipt.ex
@@ -520,7 +520,7 @@ defmodule X402.Extensions.OfferReceipt do
   """
   @spec verify_offer(envelope(), keyword()) :: {:ok, verification()} | {:error, verify_error()}
   def verify_offer(envelope, opts \\ []) when is_map(envelope) and is_list(opts) do
-    verify(envelope, opts, &offer_digest/1)
+    verify(envelope, opts, :offer)
   end
 
   @doc since: "0.6.0"
@@ -534,7 +534,7 @@ defmodule X402.Extensions.OfferReceipt do
   """
   @spec verify_receipt(envelope(), keyword()) :: {:ok, verification()} | {:error, verify_error()}
   def verify_receipt(envelope, opts \\ []) when is_map(envelope) and is_list(opts) do
-    verify(envelope, opts, &receipt_digest/1)
+    verify(envelope, opts, :receipt)
   end
 
   @doc since: "0.6.0"
@@ -812,18 +812,18 @@ defmodule X402.Extensions.OfferReceipt do
   # Shared verification
   # ---------------------------------------------------------------------------
 
-  @spec verify(envelope(), keyword(), (payload() -> {:ok, <<_::256>>} | {:error, term()})) ::
+  @spec verify(envelope(), keyword(), :offer | :receipt) ::
           {:ok, verification()} | {:error, verify_error()}
-  defp verify(envelope, opts, digest_fun) do
+  defp verify(envelope, opts, kind) do
     opts = NimbleOptions.validate!(opts, @verify_opts_schema)
 
     case envelope do
       %{"format" => "eip712", "payload" => payload, "signature" => signature}
       when is_map(payload) and is_binary(signature) ->
-        verify_eip712(payload, signature, opts, digest_fun)
+        verify_eip712(payload, signature, opts, kind)
 
       %{"format" => "jws", "signature" => jws} when is_binary(jws) ->
-        verify_jws(jws, opts)
+        verify_jws(jws, opts, kind)
 
       %{"format" => format} when format in ["eip712", "jws"] ->
         {:error, :invalid_envelope}
@@ -836,19 +836,47 @@ defmodule X402.Extensions.OfferReceipt do
     end
   end
 
-  @spec verify_eip712(payload(), String.t(), keyword(), fun()) ::
+  @spec kind_digest(:offer | :receipt, payload()) :: {:ok, <<_::256>>} | {:error, term()}
+  defp kind_digest(:offer, payload), do: offer_digest(payload)
+  defp kind_digest(:receipt, payload), do: receipt_digest(payload)
+
+  # Kind confusion guard: an offer payload must never verify as a receipt (or
+  # vice versa). EIP-712 is type-bound through distinct domains, but the JWS
+  # envelope signs the payload bytes with no type binding, so both branches
+  # validate the payload against the expected kind's schema before accepting.
+  @spec kind_validate(:offer | :receipt, payload()) :: :ok | {:error, term()}
+  defp kind_validate(:offer, payload), do: validate_offer_payload(payload)
+  defp kind_validate(:receipt, payload), do: validate_receipt_payload(payload)
+
+  @spec verify_eip712(payload(), String.t(), keyword(), :offer | :receipt) ::
           {:ok, verification()} | {:error, verify_error()}
-  defp verify_eip712(payload, signature, opts, digest_fun) do
+  defp verify_eip712(payload, signature, opts, kind) do
     with :ok <- ensure_payload_version(payload),
-         {:ok, digest} <- digest_fun.(payload),
+         :ok <- kind_validate(kind, payload),
+         {:ok, digest} <- kind_digest(kind, payload),
          {:ok, signer} <- EIP3009.recover_signer(digest, signature),
          :ok <- check_expected_signer(signer, Keyword.get(opts, :expected_signer)) do
-      {:ok, %{format: "eip712", signer: signer, payload: payload}}
+      # Only the canonical fields enter the struct hash — returning the
+      # transmitted map verbatim would let unsigned extra keys masquerade as
+      # signed data, so the verified payload is stripped to the signed fields.
+      {:ok, %{format: "eip712", signer: signer, payload: signed_payload(kind, payload)}}
     end
   end
 
-  @spec verify_jws(String.t(), keyword()) :: {:ok, verification()} | {:error, verify_error()}
-  defp verify_jws(jws, opts) do
+  @spec signed_payload(:offer | :receipt, payload()) :: payload()
+  defp signed_payload(kind, payload) do
+    fields =
+      case kind do
+        :offer -> offer_hash_fields()
+        :receipt -> receipt_hash_fields()
+      end
+
+    Map.take(payload, Enum.map(fields, fn {key, _kind, _default} -> key end))
+  end
+
+  @spec verify_jws(String.t(), keyword(), :offer | :receipt) ::
+          {:ok, verification()} | {:error, verify_error()}
+  defp verify_jws(jws, opts, kind) do
     case Keyword.get(opts, :public_key) do
       nil ->
         {:error, :missing_public_key}
@@ -857,7 +885,8 @@ defmodule X402.Extensions.OfferReceipt do
         with {:ok, %{header: header, payload: payload}} <-
                JWS.verify(jws, public_key, algs: Keyword.fetch!(opts, :algs)),
              :ok <- ensure_map_payload(payload),
-             :ok <- ensure_payload_version(payload) do
+             :ok <- ensure_payload_version(payload),
+             :ok <- kind_validate(kind, payload) do
           {:ok, %{format: "jws", header: header, payload: payload}}
         end
     end

--- a/lib/x402/extensions/offer_receipt.ex
+++ b/lib/x402/extensions/offer_receipt.ex
@@ -1,0 +1,1310 @@
+defmodule X402.Extensions.OfferReceipt do
+  @moduledoc """
+  Offer-and-receipt extension for x402: signed offers and signed receipts.
+
+  Implements the
+  [offer-and-receipt extension](https://github.com/x402-foundation/x402/blob/main/specs/extensions/extension-offer-and-receipt.md):
+  the resource server cryptographically commits to the payment terms it
+  advertises (a **signed offer** placed under
+  `extensions["offer-receipt"].info.offers[]` of the payment requirements)
+  and, after successful payment and delivery, confirms the transaction (a
+  **signed receipt** under `extensions["offer-receipt"].info.receipt` of the
+  settlement response). Both artifacts are portable, independently
+  verifiable, and identical for x402 v1 and v2.
+
+  Two signature formats are supported, per the specification (§3.1):
+
+    * `"eip712"` — an EIP-712 typed-data signature with the fixed domain
+      `{name: "x402 offer" | "x402 receipt", version: "1", chainId: 1}`
+      (chain-agnostic by design, §3.2) and the canonical `Offer` / `Receipt`
+      types from §4.3 and §5.3. Signing goes through the `X402.Signer`
+      behaviour; verification recovers the signer address. Requires the
+      optional `ex_keccak` (and, for verification, `ex_secp256k1`)
+      dependencies.
+    * `"jws"` — a compact JWS (`header.payload.signature`) with `ES256K` or
+      `EdDSA`, implemented with OTP `:crypto` by
+      `X402.Extensions.OfferReceipt.JWS`. The protected header carries the
+      mandatory `alg` and `kid` (a DID URL) fields (§3.3); payloads are
+      JCS-canonicalized (§10).
+
+  ## Server side: issuing offers and receipts
+
+      {:ok, signer} = X402.Signer.LocalKey.new(private_key)
+
+      {:ok, payload} =
+        X402.Extensions.OfferReceipt.offer_payload(
+          resource_url: "https://api.example.com/premium-data",
+          scheme: "exact",
+          network: "eip155:8453",
+          asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          pay_to: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+          amount: "10000",
+          valid_until: System.os_time(:second) + 300
+        )
+
+      {:ok, offer} = X402.Extensions.OfferReceipt.sign_offer(payload, signer, accept_index: 0)
+
+      extensions = %{"offer-receipt" => X402.Extensions.OfferReceipt.build_extension([offer])}
+
+  ## Client side: verifying
+
+      {:ok, [offer]} = X402.Extensions.OfferReceipt.fetch_offers(payment_required)
+
+      {:ok, %{signer: signer_address, payload: payload}} =
+        X402.Extensions.OfferReceipt.verify_offer(offer)
+
+  A valid signature only proves *which key* signed — it does not prove the
+  key was **authorized** for the offered resource. Verifiers must apply an
+  authorization policy (§4.5.1); the simplest is checking the recovered
+  signer against the offer's `payTo` address, which `verify_offer/2` supports
+  through the `:expected_signer` option.
+
+  ## Boundaries
+
+    * JWS verification takes an explicit `:public_key` — this library never
+      resolves `kid` DID URLs (no network access); resolve the key yourself
+      and check its authorization per §4.5.1.
+    * The JWS algorithms are limited to what OTP `:crypto` provides:
+      `ES256K` and `EdDSA` (both spec-named algorithms are covered).
+  """
+
+  alias X402.EIP3009
+  alias X402.EIP712
+  alias X402.Extensions.OfferReceipt.JWS
+  alias X402.Signer
+  alias X402.Utils
+
+  @extension_key "offer-receipt"
+  @payload_version 1
+  @schema_uri "https://json-schema.org/draft/2020-12/schema"
+
+  # EIP-712 constants (§3.2, §4.3, §5.3). The domain deliberately hardcodes
+  # chainId 1: EIP-712 is used as an off-chain signing format and the payment
+  # network is identified by the payload's `network` field.
+  @domain_type "EIP712Domain(string name,string version,uint256 chainId)"
+  @offer_type "Offer(uint256 version,string resourceUrl,string scheme,string network," <>
+                "string asset,string payTo,string amount,uint256 validUntil)"
+  @receipt_type "Receipt(uint256 version,string network,string resourceUrl,string payer," <>
+                  "uint256 issuedAt,string transaction)"
+
+  @offer_domain_name "x402 offer"
+  @receipt_domain_name "x402 receipt"
+
+  @domain_fields [
+    %{"name" => "name", "type" => "string"},
+    %{"name" => "version", "type" => "string"},
+    %{"name" => "chainId", "type" => "uint256"}
+  ]
+
+  @offer_fields [
+    %{"name" => "version", "type" => "uint256"},
+    %{"name" => "resourceUrl", "type" => "string"},
+    %{"name" => "scheme", "type" => "string"},
+    %{"name" => "network", "type" => "string"},
+    %{"name" => "asset", "type" => "string"},
+    %{"name" => "payTo", "type" => "string"},
+    %{"name" => "amount", "type" => "string"},
+    %{"name" => "validUntil", "type" => "uint256"}
+  ]
+
+  @receipt_fields [
+    %{"name" => "version", "type" => "uint256"},
+    %{"name" => "network", "type" => "string"},
+    %{"name" => "resourceUrl", "type" => "string"},
+    %{"name" => "payer", "type" => "string"},
+    %{"name" => "issuedAt", "type" => "uint256"},
+    %{"name" => "transaction", "type" => "string"}
+  ]
+
+  # x402 v1 human-readable network identifiers → CAIP-2, per the reference
+  # implementation. Offer and receipt payloads MUST use CAIP-2 (§4.2, §5.2).
+  @v1_evm_networks %{
+    "ethereum" => 1,
+    "sepolia" => 11_155_111,
+    "abstract" => 2741,
+    "abstract-testnet" => 11_124,
+    "base" => 8453,
+    "base-sepolia" => 84_532,
+    "avalanche" => 43_114,
+    "avalanche-fuji" => 43_113,
+    "iotex" => 4689,
+    "sei" => 1329,
+    "sei-testnet" => 1328,
+    "polygon" => 137,
+    "polygon-amoy" => 80_002,
+    "peaq" => 3338,
+    "story" => 1514,
+    "educhain" => 41_923,
+    "skale-base-sepolia" => 324_705_682
+  }
+
+  @v1_solana_networks %{
+    "solana" => "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+    "solana-devnet" => "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+    "solana-testnet" => "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z"
+  }
+
+  @offer_payload_schema [
+    resource_url: [type: :string, required: true, doc: "The paid resource URL."],
+    scheme: [type: :string, required: true, doc: "Payment scheme identifier (e.g. `\"exact\"`)."],
+    network: [
+      type: :string,
+      required: true,
+      doc: "Network identifier — CAIP-2 or an x402 v1 name (converted via `to_caip2/1`)."
+    ],
+    asset: [type: :string, required: true, doc: "Token contract address or `\"native\"`."],
+    pay_to: [type: :string, required: true, doc: "Recipient wallet address."],
+    amount: [
+      type: {:or, [:string, :non_neg_integer]},
+      required: true,
+      doc: "Required payment amount in atomic units (encoded as a string)."
+    ],
+    valid_until: [
+      type: :non_neg_integer,
+      doc: "Unix timestamp (seconds) when the offer expires. Omit for no expiry."
+    ]
+  ]
+
+  @receipt_payload_schema [
+    resource_url: [type: :string, required: true, doc: "The paid resource URL."],
+    network: [
+      type: :string,
+      required: true,
+      doc: "Network identifier — CAIP-2 or an x402 v1 name (converted via `to_caip2/1`)."
+    ],
+    payer: [type: :string, required: true, doc: "Payer identifier (commonly a wallet address)."],
+    issued_at: [
+      type: :non_neg_integer,
+      doc: "Unix timestamp (seconds) the receipt was issued. Defaults to the current time."
+    ],
+    transaction: [
+      type: :string,
+      doc: """
+      Blockchain transaction hash. Optional — receipts are privacy-minimal
+      by default; include it when verifiability matters more than privacy.
+      """
+    ]
+  ]
+
+  @sign_opts_schema [
+    accept_index: [
+      type: :non_neg_integer,
+      doc: """
+      Index into `accepts[]` this offer corresponds to. An unsigned
+      convenience field (§4.1.1) — clients match offers by payload fields.
+      """
+    ]
+  ]
+
+  @verify_opts_schema [
+    expected_signer: [
+      type: :string,
+      doc: """
+      EIP-712 only: EVM address the recovered signer must equal
+      (case-insensitive), e.g. the offer's `payTo`. When the recovered signer
+      differs, verification fails with `{:error, :unauthorized_signer}`.
+      """
+    ],
+    public_key: [
+      type: :string,
+      doc: """
+      JWS only (required for `"jws"` artifacts): raw public key bytes — a
+      32-byte Ed25519 key for `EdDSA`, a SEC1 secp256k1 point for `ES256K`.
+      """
+    ],
+    algs: [
+      type: {:list, {:in, ["ES256K", "EdDSA"]}},
+      default: ["ES256K", "EdDSA"],
+      doc: "JWS only: accepted algorithms."
+    ]
+  ]
+
+  @typedoc "A signed offer or receipt envelope in wire shape (string keys)."
+  @type envelope :: %{optional(String.t()) => term()}
+
+  @typedoc "An offer or receipt payload in wire shape (string keys)."
+  @type payload :: %{optional(String.t()) => term()}
+
+  @typedoc "A built `extensions[\"offer-receipt\"]` value (`info` + `schema`)."
+  @type t :: %{optional(String.t()) => map()}
+
+  @typedoc "The result of a successful verification."
+  @type verification :: %{
+          optional(:signer) => String.t(),
+          optional(:header) => map(),
+          format: String.t(),
+          payload: payload()
+        }
+
+  @type payload_error ::
+          {:missing_field, String.t()}
+          | {:invalid_field, String.t()}
+          | {:unsupported_payload_version, term()}
+          | {:unknown_network, String.t()}
+
+  @type verify_error ::
+          payload_error()
+          | JWS.verify_error()
+          | {:unsupported_format, term()}
+          | :invalid_envelope
+          | :missing_public_key
+          | :unauthorized_signer
+          | :missing_dependency
+          | :invalid_signature
+
+  # ---------------------------------------------------------------------------
+  # Payload construction (server side)
+  # ---------------------------------------------------------------------------
+
+  @doc since: "0.6.0"
+  @doc group: :offers
+  @doc """
+  Builds an offer payload (§4.2) in wire shape.
+
+  The `:network` is normalized to CAIP-2 with `to_caip2/1`, as the
+  specification requires for offer payloads. `version` is always the current
+  payload schema version (`1`).
+
+  ## Options
+
+  #{NimbleOptions.docs(@offer_payload_schema)}
+
+  ## Examples
+
+      iex> X402.Extensions.OfferReceipt.offer_payload(
+      ...>   resource_url: "https://api.example.com/premium-data",
+      ...>   scheme: "exact",
+      ...>   network: "base",
+      ...>   asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      ...>   pay_to: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      ...>   amount: 10_000,
+      ...>   valid_until: 1_703_123_516
+      ...> )
+      {:ok,
+       %{
+         "version" => 1,
+         "resourceUrl" => "https://api.example.com/premium-data",
+         "scheme" => "exact",
+         "network" => "eip155:8453",
+         "asset" => "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+         "payTo" => "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+         "amount" => "10000",
+         "validUntil" => 1703123516
+       }}
+
+      iex> X402.Extensions.OfferReceipt.offer_payload(
+      ...>   resource_url: "https://a.example",
+      ...>   scheme: "exact",
+      ...>   network: "unknown-net",
+      ...>   asset: "native",
+      ...>   pay_to: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      ...>   amount: "1"
+      ...> )
+      {:error, {:unknown_network, "unknown-net"}}
+  """
+  @spec offer_payload(keyword()) :: {:ok, payload()} | {:error, {:unknown_network, String.t()}}
+  def offer_payload(opts) when is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @offer_payload_schema)
+
+    with {:ok, network} <- to_caip2(Keyword.fetch!(opts, :network)) do
+      payload = %{
+        "version" => @payload_version,
+        "resourceUrl" => Keyword.fetch!(opts, :resource_url),
+        "scheme" => Keyword.fetch!(opts, :scheme),
+        "network" => network,
+        "asset" => Keyword.fetch!(opts, :asset),
+        "payTo" => Keyword.fetch!(opts, :pay_to),
+        "amount" => to_amount_string(Keyword.fetch!(opts, :amount))
+      }
+
+      {:ok, maybe_put(payload, "validUntil", Keyword.get(opts, :valid_until))}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc group: :receipts
+  @doc """
+  Builds a receipt payload (§5.2) in wire shape.
+
+  Receipts are privacy-minimal by default: `transaction` is only included
+  when passed. `:issued_at` defaults to the current Unix time.
+
+  ## Options
+
+  #{NimbleOptions.docs(@receipt_payload_schema)}
+
+  ## Examples
+
+      iex> X402.Extensions.OfferReceipt.receipt_payload(
+      ...>   resource_url: "https://api.example.com/premium-data",
+      ...>   network: "eip155:8453",
+      ...>   payer: "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+      ...>   issued_at: 1_703_123_456
+      ...> )
+      {:ok,
+       %{
+         "version" => 1,
+         "network" => "eip155:8453",
+         "resourceUrl" => "https://api.example.com/premium-data",
+         "payer" => "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+         "issuedAt" => 1703123456
+       }}
+  """
+  @spec receipt_payload(keyword()) :: {:ok, payload()} | {:error, {:unknown_network, String.t()}}
+  def receipt_payload(opts) when is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @receipt_payload_schema)
+
+    with {:ok, network} <- to_caip2(Keyword.fetch!(opts, :network)) do
+      payload = %{
+        "version" => @payload_version,
+        "network" => network,
+        "resourceUrl" => Keyword.fetch!(opts, :resource_url),
+        "payer" => Keyword.fetch!(opts, :payer),
+        "issuedAt" => Keyword.get_lazy(opts, :issued_at, fn -> System.os_time(:second) end)
+      }
+
+      {:ok, maybe_put(payload, "transaction", Keyword.get(opts, :transaction))}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # EIP-712 signing (server side)
+  # ---------------------------------------------------------------------------
+
+  @doc since: "0.6.0"
+  @doc group: :offers
+  @doc """
+  Signs an offer payload as an EIP-712 artifact through an `X402.Signer`.
+
+  Computes the EIP-712 digest with the fixed offer domain
+  (`name: "x402 offer"`, `version: "1"`, `chainId: 1`, §3.2) and the
+  canonical `Offer` type (§4.3), signs it through `signer`, and returns the
+  transmitted envelope
+
+      %{"format" => "eip712", "payload" => payload, "signature" => "0x..."}
+
+  Per §4.3, an absent `validUntil` is signed **and transmitted** as `0`.
+  Requires the optional `ex_keccak` dependency (`{:error,
+  :missing_dependency}` without it).
+
+  ## Options
+
+  #{NimbleOptions.docs(@sign_opts_schema)}
+  """
+  @spec sign_offer(payload(), Signer.t(), keyword()) ::
+          {:ok, envelope()} | {:error, verify_error() | term()}
+  def sign_offer(payload, signer, opts \\ []) when is_map(payload) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @sign_opts_schema)
+    payload = normalize_offer_payload(payload)
+
+    with {:ok, digest} <- offer_digest(payload),
+         typed_data = typed_data("Offer", @offer_domain_name, @offer_fields, payload),
+         {:ok, signature} <- Signer.sign_eip712(signer, digest, typed_data) do
+      envelope = %{
+        "format" => "eip712",
+        "payload" => payload,
+        "signature" => "0x" <> Base.encode16(signature, case: :lower)
+      }
+
+      {:ok, maybe_put(envelope, "acceptIndex", Keyword.get(opts, :accept_index))}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc group: :receipts
+  @doc """
+  Signs a receipt payload as an EIP-712 artifact through an `X402.Signer`.
+
+  Uses the fixed receipt domain (`name: "x402 receipt"`, `version: "1"`,
+  `chainId: 1`, §3.2) and the canonical `Receipt` type (§5.3). Per §5.3, an
+  absent `transaction` is signed **and transmitted** as `""`.
+  """
+  @spec sign_receipt(payload(), Signer.t()) :: {:ok, envelope()} | {:error, term()}
+  def sign_receipt(payload, signer) when is_map(payload) do
+    payload = normalize_receipt_payload(payload)
+
+    with {:ok, digest} <- receipt_digest(payload),
+         typed_data = typed_data("Receipt", @receipt_domain_name, @receipt_fields, payload),
+         {:ok, signature} <- Signer.sign_eip712(signer, digest, typed_data) do
+      {:ok,
+       %{
+         "format" => "eip712",
+         "payload" => payload,
+         "signature" => "0x" <> Base.encode16(signature, case: :lower)
+       }}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # JWS signing (server side)
+  # ---------------------------------------------------------------------------
+
+  @doc since: "0.6.0"
+  @doc group: :offers
+  @doc """
+  Signs an offer payload as a compact JWS artifact.
+
+  The payload travels inside the JWS, so the envelope omits `payload`
+  (§3.1.1). Optional payload fields stay omitted (no zero-filling — that
+  rule is EIP-712 specific).
+
+  `key_opts` are the `X402.Extensions.OfferReceipt.JWS.sign/2` options
+  (`:alg`, `:kid`, `:key`) plus the `:accept_index` envelope option.
+
+  ## Examples
+
+      {:ok, offer} =
+        X402.Extensions.OfferReceipt.sign_offer_jws(payload,
+          alg: "EdDSA",
+          kid: "did:web:api.example.com#key-1",
+          key: ed25519_seed,
+          accept_index: 0
+        )
+  """
+  @spec sign_offer_jws(payload(), keyword()) ::
+          {:ok, envelope()} | {:error, JWS.sign_error() | payload_error()}
+  def sign_offer_jws(payload, key_opts) when is_map(payload) and is_list(key_opts) do
+    {opts, key_opts} = Keyword.split(key_opts, [:accept_index])
+
+    with :ok <- validate_offer_payload(payload),
+         {:ok, jws} <- JWS.sign(payload, key_opts) do
+      envelope = %{"format" => "jws", "signature" => jws}
+      {:ok, maybe_put(envelope, "acceptIndex", Keyword.get(opts, :accept_index))}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc group: :receipts
+  @doc """
+  Signs a receipt payload as a compact JWS artifact.
+
+  See `sign_offer_jws/2`; `key_opts` are `:alg`, `:kid`, and `:key`.
+  """
+  @spec sign_receipt_jws(payload(), keyword()) ::
+          {:ok, envelope()} | {:error, JWS.sign_error() | payload_error()}
+  def sign_receipt_jws(payload, key_opts) when is_map(payload) and is_list(key_opts) do
+    with :ok <- validate_receipt_payload(payload),
+         {:ok, jws} <- JWS.sign(payload, key_opts) do
+      {:ok, %{"format" => "jws", "signature" => jws}}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Verification (client side)
+  # ---------------------------------------------------------------------------
+
+  @doc since: "0.6.0"
+  @doc group: :offers
+  @doc """
+  Verifies a signed offer envelope (§4.5).
+
+  For `"eip712"` artifacts, recomputes the EIP-712 digest from the payload
+  **exactly as transmitted** and recovers the signer address (requires the
+  optional `ex_secp256k1` / `ex_keccak` dependencies). For `"jws"`
+  artifacts, verifies the compact JWS against the `:public_key` option.
+
+  Returns `{:ok, %{format: ..., payload: ...}}` with `:signer` (EIP-712, the
+  recovered address) or `:header` (JWS, the protected header with `alg` and
+  `kid`).
+
+  > #### Signature validity is not authorization {: .warning}
+  >
+  > A valid signature proves which key signed, not that the key was
+  > authorized for `payload.resourceUrl` (§4.5.1). Check the signer against
+  > your authorization policy — for the common `payTo`-signs deployment,
+  > pass `expected_signer: payload["payTo"]`.
+
+  ## Options
+
+  #{NimbleOptions.docs(@verify_opts_schema)}
+  """
+  @spec verify_offer(envelope(), keyword()) :: {:ok, verification()} | {:error, verify_error()}
+  def verify_offer(envelope, opts \\ []) when is_map(envelope) and is_list(opts) do
+    verify(envelope, opts, &offer_digest/1)
+  end
+
+  @doc since: "0.6.0"
+  @doc group: :receipts
+  @doc """
+  Verifies a signed receipt envelope (§5.5).
+
+  Same contract as `verify_offer/2`, with the receipt domain and types.
+  `issuedAt` policy checks (freshness) and on-chain `transaction` checks are
+  the caller's responsibility.
+  """
+  @spec verify_receipt(envelope(), keyword()) :: {:ok, verification()} | {:error, verify_error()}
+  def verify_receipt(envelope, opts \\ []) when is_map(envelope) and is_list(opts) do
+    verify(envelope, opts, &receipt_digest/1)
+  end
+
+  @doc since: "0.6.0"
+  @doc group: :offers
+  @doc """
+  Extracts the payload from a signed envelope **without verifying it**.
+
+  For `"eip712"` the transmitted `payload` is returned; for `"jws"` the JWS
+  payload segment is decoded. Use `verify_offer/2` / `verify_receipt/2` for
+  verified reads.
+
+  ## Examples
+
+      iex> X402.Extensions.OfferReceipt.extract_payload(%{
+      ...>   "format" => "eip712",
+      ...>   "payload" => %{"version" => 1},
+      ...>   "signature" => "0xsig"
+      ...> })
+      {:ok, %{"version" => 1}}
+
+      iex> X402.Extensions.OfferReceipt.extract_payload(%{"format" => "carrier-pigeon"})
+      {:error, {:unsupported_format, "carrier-pigeon"}}
+  """
+  @spec extract_payload(envelope()) :: {:ok, payload()} | {:error, verify_error()}
+  def extract_payload(%{"format" => "eip712", "payload" => payload}) when is_map(payload),
+    do: {:ok, payload}
+
+  def extract_payload(%{"format" => "eip712"}), do: {:error, {:missing_field, "payload"}}
+
+  def extract_payload(%{"format" => "jws", "signature" => jws}) when is_binary(jws),
+    do: JWS.peek_payload(jws)
+
+  def extract_payload(%{"format" => "jws"}), do: {:error, {:missing_field, "signature"}}
+  def extract_payload(%{"format" => format}), do: {:error, {:unsupported_format, format}}
+  def extract_payload(_envelope), do: {:error, :invalid_envelope}
+
+  # ---------------------------------------------------------------------------
+  # EIP-712 digests
+  # ---------------------------------------------------------------------------
+
+  @doc since: "0.6.0"
+  @doc group: :offers
+  @doc """
+  Computes the EIP-712 digest of an offer payload (§4.3).
+
+  Returns `keccak256(0x19 0x01 || domainSeparator || structHash)` where the
+  domain is `{name: "x402 offer", version: "1", chainId: 1}`. An absent
+  `validUntil` is hashed as `0`. Requires the optional `ex_keccak`
+  dependency.
+  """
+  @spec offer_digest(payload()) ::
+          {:ok, <<_::256>>} | {:error, payload_error() | :missing_dependency}
+  def offer_digest(payload) when is_map(payload) do
+    digest(payload, @offer_domain_name, @offer_type, offer_hash_fields())
+  end
+
+  @doc since: "0.6.0"
+  @doc group: :receipts
+  @doc """
+  Computes the EIP-712 digest of a receipt payload (§5.3).
+
+  The domain is `{name: "x402 receipt", version: "1", chainId: 1}`; an
+  absent `transaction` is hashed as `""`. Requires the optional `ex_keccak`
+  dependency.
+  """
+  @spec receipt_digest(payload()) ::
+          {:ok, <<_::256>>} | {:error, payload_error() | :missing_dependency}
+  def receipt_digest(payload) when is_map(payload) do
+    digest(payload, @receipt_domain_name, @receipt_type, receipt_hash_fields())
+  end
+
+  # ---------------------------------------------------------------------------
+  # Extension envelope (declaration)
+  # ---------------------------------------------------------------------------
+
+  @doc since: "0.6.0"
+  @doc group: :declaration
+  @doc """
+  Builds the `extensions["offer-receipt"]` value for payment requirements.
+
+  Takes the signed offer envelopes for the response's `accepts[]` entries
+  and returns the `%{"info" => %{"offers" => offers}, "schema" => schema}`
+  declaration (§4.1, §6.1/§6.3). All offers must share one signature format
+  — the specification's schemas are format-specific and servers use one
+  format consistently (§6). Raises `ArgumentError` for empty, mixed-format,
+  or structurally invalid offers (programmer errors).
+  """
+  @spec build_extension([envelope()]) :: t()
+  def build_extension(offers) when is_list(offers) and offers != [] do
+    format = uniform_format!(offers)
+
+    Enum.each(offers, fn offer ->
+      case validate_offer(offer) do
+        :ok -> :ok
+        {:error, reason} -> raise ArgumentError, "invalid signed offer: #{inspect(reason)}"
+      end
+    end)
+
+    %{
+      "info" => %{"offers" => offers},
+      "schema" => offers_schema(format)
+    }
+  end
+
+  def build_extension(other) do
+    raise ArgumentError, "expected a non-empty list of signed offers, got: #{inspect(other)}"
+  end
+
+  @doc since: "0.6.0"
+  @doc group: :declaration
+  @doc """
+  Builds the `extensions["offer-receipt"]` value for a settlement response.
+
+  Takes the signed receipt envelope and returns the
+  `%{"info" => %{"receipt" => receipt}, "schema" => schema}` declaration
+  (§5.1, §6.5/§6.7). Raises `ArgumentError` for a structurally invalid
+  receipt (programmer error).
+  """
+  @spec build_receipt_extension(envelope()) :: t()
+  def build_receipt_extension(receipt) when is_map(receipt) do
+    case validate_receipt(receipt) do
+      :ok -> :ok
+      {:error, reason} -> raise ArgumentError, "invalid signed receipt: #{inspect(reason)}"
+    end
+
+    %{
+      "info" => %{"receipt" => receipt},
+      "schema" => receipt_schema(Map.fetch!(receipt, "format"))
+    }
+  end
+
+  def build_receipt_extension(other) do
+    raise ArgumentError, "expected a signed receipt map, got: #{inspect(other)}"
+  end
+
+  @doc since: "0.6.0"
+  @doc group: :declaration
+  @doc """
+  Fetches and validates the signed offers from a payment-required map.
+
+  Accepts either the full decoded `PAYMENT-REQUIRED` map (looks under
+  `"extensions"`) or the extensions map itself. Validation is fail-closed:
+  every offer envelope must be structurally valid per §3.1.1
+  (`"eip712"` offers carry a payload and a 65-byte hex signature; `"jws"`
+  offers carry a three-part compact JWS and **no** payload).
+
+  ## Examples
+
+      iex> X402.Extensions.OfferReceipt.fetch_offers(%{"accepts" => []})
+      {:error, :extension_not_present}
+  """
+  @spec fetch_offers(map()) ::
+          {:ok, [envelope()]}
+          | {:error, :extension_not_present | {:invalid_extension, term()}}
+  def fetch_offers(map) when is_map(map) do
+    with {:ok, info} <- fetch_info(map) do
+      case Map.get(info, "offers") do
+        offers when is_list(offers) and offers != [] -> validate_offers(offers)
+        _missing -> {:error, {:invalid_extension, {:missing_field, "offers"}}}
+      end
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc group: :declaration
+  @doc """
+  Fetches and validates the signed receipt from a settlement response map.
+
+  Accepts either the full decoded settlement response (looks under
+  `"extensions"`) or the extensions map itself.
+  """
+  @spec fetch_receipt(map()) ::
+          {:ok, envelope()}
+          | {:error, :extension_not_present | {:invalid_extension, term()}}
+  def fetch_receipt(map) when is_map(map) do
+    with {:ok, info} <- fetch_info(map) do
+      validate_fetched_receipt(Map.get(info, "receipt"))
+    end
+  end
+
+  @spec validate_fetched_receipt(term()) ::
+          {:ok, envelope()} | {:error, {:invalid_extension, term()}}
+  defp validate_fetched_receipt(%{} = receipt) do
+    case validate_receipt(receipt) do
+      :ok -> {:ok, receipt}
+      {:error, reason} -> {:error, {:invalid_extension, reason}}
+    end
+  end
+
+  defp validate_fetched_receipt(_missing),
+    do: {:error, {:invalid_extension, {:missing_field, "receipt"}}}
+
+  @doc since: "0.6.0"
+  @doc group: :declaration
+  @doc """
+  Validates the structure of a signed offer envelope (§3.1.1, §4.2).
+
+  ## Examples
+
+      iex> X402.Extensions.OfferReceipt.validate_offer(%{
+      ...>   "format" => "jws",
+      ...>   "signature" => "eyJhbGciOiJFUzI1NksiLCJraWQiOiJrIn0.eyJ2ZXJzaW9uIjoxfQ.c2ln"
+      ...> })
+      :ok
+
+      iex> X402.Extensions.OfferReceipt.validate_offer(%{
+      ...>   "format" => "jws",
+      ...>   "payload" => %{"version" => 1},
+      ...>   "signature" => "a.b.c"
+      ...> })
+      {:error, {:invalid_field, "payload"}}
+  """
+  @spec validate_offer(envelope()) :: :ok | {:error, verify_error()}
+  def validate_offer(envelope) when is_map(envelope) do
+    with :ok <- validate_accept_index(envelope) do
+      validate_envelope(envelope, &validate_offer_payload/1)
+    end
+  end
+
+  def validate_offer(_envelope), do: {:error, :invalid_envelope}
+
+  @doc since: "0.6.0"
+  @doc group: :declaration
+  @doc """
+  Validates the structure of a signed receipt envelope (§3.1.1, §5.2).
+  """
+  @spec validate_receipt(envelope()) :: :ok | {:error, verify_error()}
+  def validate_receipt(envelope) when is_map(envelope) do
+    validate_envelope(envelope, &validate_receipt_payload/1)
+  end
+
+  def validate_receipt(_envelope), do: {:error, :invalid_envelope}
+
+  # ---------------------------------------------------------------------------
+  # Network conversion
+  # ---------------------------------------------------------------------------
+
+  @doc since: "0.6.0"
+  @doc """
+  Converts a network identifier to CAIP-2 format.
+
+  Offer and receipt payloads must carry CAIP-2 identifiers even in x402 v1
+  flows (§4.2, §5.2). Strings that already contain a `:` are passed through;
+  x402 v1 names are mapped (`"base"` → `"eip155:8453"`, `"solana"` → its
+  CAIP-2 chain reference); anything else is `{:error, {:unknown_network,
+  network}}`.
+
+  ## Examples
+
+      iex> X402.Extensions.OfferReceipt.to_caip2("eip155:8453")
+      {:ok, "eip155:8453"}
+
+      iex> X402.Extensions.OfferReceipt.to_caip2("base-sepolia")
+      {:ok, "eip155:84532"}
+
+      iex> X402.Extensions.OfferReceipt.to_caip2("solana")
+      {:ok, "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"}
+
+      iex> X402.Extensions.OfferReceipt.to_caip2("mystery-chain")
+      {:error, {:unknown_network, "mystery-chain"}}
+  """
+  @spec to_caip2(String.t()) :: {:ok, String.t()} | {:error, {:unknown_network, String.t()}}
+  def to_caip2(network) when is_binary(network) do
+    normalized = String.downcase(network)
+
+    cond do
+      String.contains?(network, ":") -> {:ok, network}
+      is_map_key(@v1_evm_networks, normalized) -> {:ok, "eip155:#{@v1_evm_networks[normalized]}"}
+      is_map_key(@v1_solana_networks, normalized) -> {:ok, @v1_solana_networks[normalized]}
+      true -> {:error, {:unknown_network, network}}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Shared verification
+  # ---------------------------------------------------------------------------
+
+  @spec verify(envelope(), keyword(), (payload() -> {:ok, <<_::256>>} | {:error, term()})) ::
+          {:ok, verification()} | {:error, verify_error()}
+  defp verify(envelope, opts, digest_fun) do
+    opts = NimbleOptions.validate!(opts, @verify_opts_schema)
+
+    case envelope do
+      %{"format" => "eip712", "payload" => payload, "signature" => signature}
+      when is_map(payload) and is_binary(signature) ->
+        verify_eip712(payload, signature, opts, digest_fun)
+
+      %{"format" => "jws", "signature" => jws} when is_binary(jws) ->
+        verify_jws(jws, opts)
+
+      %{"format" => format} when format in ["eip712", "jws"] ->
+        {:error, :invalid_envelope}
+
+      %{"format" => format} ->
+        {:error, {:unsupported_format, format}}
+
+      _envelope ->
+        {:error, :invalid_envelope}
+    end
+  end
+
+  @spec verify_eip712(payload(), String.t(), keyword(), fun()) ::
+          {:ok, verification()} | {:error, verify_error()}
+  defp verify_eip712(payload, signature, opts, digest_fun) do
+    with :ok <- ensure_payload_version(payload),
+         {:ok, digest} <- digest_fun.(payload),
+         {:ok, signer} <- EIP3009.recover_signer(digest, signature),
+         :ok <- check_expected_signer(signer, Keyword.get(opts, :expected_signer)) do
+      {:ok, %{format: "eip712", signer: signer, payload: payload}}
+    end
+  end
+
+  @spec verify_jws(String.t(), keyword()) :: {:ok, verification()} | {:error, verify_error()}
+  defp verify_jws(jws, opts) do
+    case Keyword.get(opts, :public_key) do
+      nil ->
+        {:error, :missing_public_key}
+
+      public_key ->
+        with {:ok, %{header: header, payload: payload}} <-
+               JWS.verify(jws, public_key, algs: Keyword.fetch!(opts, :algs)),
+             :ok <- ensure_map_payload(payload),
+             :ok <- ensure_payload_version(payload) do
+          {:ok, %{format: "jws", header: header, payload: payload}}
+        end
+    end
+  end
+
+  @spec ensure_map_payload(term()) :: :ok | {:error, :invalid_envelope}
+  defp ensure_map_payload(payload) when is_map(payload), do: :ok
+  defp ensure_map_payload(_payload), do: {:error, :invalid_envelope}
+
+  @spec ensure_payload_version(payload()) ::
+          :ok | {:error, {:unsupported_payload_version, term()}}
+  defp ensure_payload_version(payload) do
+    case Utils.map_value(payload, {"version", :version}) do
+      @payload_version -> :ok
+      version -> {:error, {:unsupported_payload_version, version}}
+    end
+  end
+
+  @spec check_expected_signer(String.t(), String.t() | nil) ::
+          :ok | {:error, :unauthorized_signer}
+  defp check_expected_signer(_signer, nil), do: :ok
+
+  defp check_expected_signer(signer, expected) do
+    case String.downcase(signer) == String.downcase(expected) do
+      true -> :ok
+      false -> {:error, :unauthorized_signer}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # EIP-712 hashing
+  # ---------------------------------------------------------------------------
+
+  # {wire key, kind, default} — `kind` selects string-hash vs uint256 word,
+  # `default` fills the spec's zero-value for optional fields (§4.3, §5.3).
+  @spec offer_hash_fields() :: [{String.t(), :string | :uint256, term()}]
+  defp offer_hash_fields do
+    [
+      {"version", :uint256, nil},
+      {"resourceUrl", :string, nil},
+      {"scheme", :string, nil},
+      {"network", :string, nil},
+      {"asset", :string, nil},
+      {"payTo", :string, nil},
+      {"amount", :string, nil},
+      {"validUntil", :uint256, 0}
+    ]
+  end
+
+  @spec receipt_hash_fields() :: [{String.t(), :string | :uint256, term()}]
+  defp receipt_hash_fields do
+    [
+      {"version", :uint256, nil},
+      {"network", :string, nil},
+      {"resourceUrl", :string, nil},
+      {"payer", :string, nil},
+      {"issuedAt", :uint256, nil},
+      {"transaction", :string, ""}
+    ]
+  end
+
+  # The struct hashing is built on the shared X402.EIP712 primitives. Only the
+  # domain separator is computed locally: the offer-receipt domain has three
+  # fields (name, version, chainId — no verifyingContract, §3.2), while
+  # X402.EIP712.domain_separator/1 covers the common four-field x402 shape.
+  @spec digest(payload(), String.t(), String.t(), [{String.t(), atom(), term()}]) ::
+          {:ok, <<_::256>>} | {:error, payload_error() | :missing_dependency}
+  defp digest(payload, domain_name, type_string, fields) do
+    with {:ok, keccak} <- EIP712.keccak_module(),
+         {:ok, words} <- field_words(payload, fields, keccak),
+         {:ok, struct_hash} <- EIP712.hash_struct(type_string, words),
+         {:ok, domain_separator} <- domain_separator(domain_name, keccak) do
+      {:ok, keccak.hash_256(<<0x19, 0x01>> <> domain_separator <> struct_hash)}
+    end
+  end
+
+  @spec domain_separator(String.t(), module()) ::
+          {:ok, <<_::256>>} | {:error, :missing_dependency | :invalid_word}
+  defp domain_separator(domain_name, keccak) do
+    EIP712.hash_struct(@domain_type, [
+      keccak.hash_256(domain_name),
+      keccak.hash_256("1"),
+      <<1::unsigned-big-integer-size(256)>>
+    ])
+  end
+
+  @spec field_words(payload(), [{String.t(), atom(), term()}], module()) ::
+          {:ok, [<<_::256>>]} | {:error, payload_error()}
+  defp field_words(payload, fields, keccak) do
+    fields
+    |> Enum.reduce_while({:ok, []}, fn field, {:ok, acc} ->
+      case field_word(payload, field, keccak) do
+        {:ok, word} -> {:cont, {:ok, [word | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, words} -> {:ok, Enum.reverse(words)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec field_word(payload(), {String.t(), atom(), term()}, module()) ::
+          {:ok, binary()} | {:error, payload_error()}
+  defp field_word(payload, {key, kind, default}, keccak) do
+    case fetch_hash_value(payload, key, default) do
+      {:ok, value} -> encode_word(kind, key, value, keccak)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec fetch_hash_value(payload(), String.t(), term()) ::
+          {:ok, term()} | {:error, {:missing_field, String.t()}}
+  defp fetch_hash_value(payload, key, default) do
+    case Utils.map_value(payload, {key, String.to_atom(key)}) do
+      nil when is_nil(default) -> {:error, {:missing_field, key}}
+      nil -> {:ok, default}
+      value -> {:ok, value}
+    end
+  end
+
+  @spec encode_word(:string | :uint256, String.t(), term(), module()) ::
+          {:ok, binary()} | {:error, {:invalid_field, String.t()}}
+  defp encode_word(:string, _key, value, keccak) when is_binary(value),
+    do: {:ok, keccak.hash_256(value)}
+
+  defp encode_word(:uint256, key, value, _keccak) do
+    case EIP712.encode_uint256(value) do
+      {:ok, word} -> {:ok, word}
+      {:error, _reason} -> {:error, {:invalid_field, key}}
+    end
+  end
+
+  defp encode_word(_kind, key, _value, _keccak), do: {:error, {:invalid_field, key}}
+
+  @spec typed_data(String.t(), String.t(), [map()], payload()) :: Signer.typed_data()
+  defp typed_data(primary_type, domain_name, fields, payload) do
+    %{
+      "types" => %{"EIP712Domain" => @domain_fields, primary_type => fields},
+      "primaryType" => primary_type,
+      "domain" => %{"name" => domain_name, "version" => "1", "chainId" => 1},
+      "message" => payload
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Payload normalization and validation
+  # ---------------------------------------------------------------------------
+
+  @spec normalize_offer_payload(payload()) :: payload()
+  defp normalize_offer_payload(payload),
+    do: Map.put_new(payload, "validUntil", 0)
+
+  @spec normalize_receipt_payload(payload()) :: payload()
+  defp normalize_receipt_payload(payload),
+    do: Map.put_new(payload, "transaction", "")
+
+  @spec validate_offer_payload(term()) :: :ok | {:error, payload_error()}
+  defp validate_offer_payload(payload) when is_map(payload) do
+    with :ok <- ensure_payload_version(payload),
+         :ok <- require_strings(payload, ~w(resourceUrl scheme network asset payTo amount)) do
+      optional_integer(payload, "validUntil")
+    end
+  end
+
+  defp validate_offer_payload(_payload), do: {:error, {:invalid_field, "payload"}}
+
+  @spec validate_receipt_payload(term()) :: :ok | {:error, payload_error()}
+  defp validate_receipt_payload(payload) when is_map(payload) do
+    with :ok <- ensure_payload_version(payload),
+         :ok <- require_strings(payload, ~w(network resourceUrl payer)),
+         :ok <- require_integer(payload, "issuedAt") do
+      optional_string(payload, "transaction")
+    end
+  end
+
+  defp validate_receipt_payload(_payload), do: {:error, {:invalid_field, "payload"}}
+
+  @spec require_strings(payload(), [String.t()]) :: :ok | {:error, payload_error()}
+  defp require_strings(payload, keys) do
+    Enum.reduce_while(keys, :ok, fn key, :ok ->
+      case Map.get(payload, key) do
+        value when is_binary(value) and value != "" -> {:cont, :ok}
+        nil -> {:halt, {:error, {:missing_field, key}}}
+        _invalid -> {:halt, {:error, {:invalid_field, key}}}
+      end
+    end)
+  end
+
+  @spec require_integer(payload(), String.t()) :: :ok | {:error, payload_error()}
+  defp require_integer(payload, key) do
+    case Map.get(payload, key) do
+      value when is_integer(value) and value >= 0 -> :ok
+      nil -> {:error, {:missing_field, key}}
+      _invalid -> {:error, {:invalid_field, key}}
+    end
+  end
+
+  @spec optional_integer(payload(), String.t()) :: :ok | {:error, payload_error()}
+  defp optional_integer(payload, key) do
+    case Map.get(payload, key) do
+      nil -> :ok
+      value when is_integer(value) and value >= 0 -> :ok
+      _invalid -> {:error, {:invalid_field, key}}
+    end
+  end
+
+  @spec optional_string(payload(), String.t()) :: :ok | {:error, payload_error()}
+  defp optional_string(payload, key) do
+    case Map.get(payload, key) do
+      nil -> :ok
+      value when is_binary(value) -> :ok
+      _invalid -> {:error, {:invalid_field, key}}
+    end
+  end
+
+  @spec validate_envelope(envelope(), (term() -> :ok | {:error, term()})) ::
+          :ok | {:error, verify_error()}
+  defp validate_envelope(%{"format" => "eip712"} = envelope, payload_validator) do
+    with {:ok, payload} <- fetch_map(envelope, "payload"),
+         :ok <- payload_validator.(payload) do
+      validate_hex_signature(Map.get(envelope, "signature"))
+    end
+  end
+
+  defp validate_envelope(%{"format" => "jws"} = envelope, _payload_validator) do
+    with :ok <- ensure_no_payload(envelope) do
+      validate_compact_jws(Map.get(envelope, "signature"))
+    end
+  end
+
+  defp validate_envelope(%{"format" => format}, _payload_validator),
+    do: {:error, {:unsupported_format, format}}
+
+  defp validate_envelope(_envelope, _payload_validator),
+    do: {:error, {:missing_field, "format"}}
+
+  @spec fetch_map(envelope(), String.t()) :: {:ok, map()} | {:error, payload_error()}
+  defp fetch_map(envelope, key) do
+    case Map.get(envelope, key) do
+      %{} = value -> {:ok, value}
+      nil -> {:error, {:missing_field, key}}
+      _invalid -> {:error, {:invalid_field, key}}
+    end
+  end
+
+  # §3.1.1: for JWS the payload MUST be omitted — the JWS already carries it.
+  @spec ensure_no_payload(envelope()) :: :ok | {:error, {:invalid_field, String.t()}}
+  defp ensure_no_payload(envelope) do
+    case Map.has_key?(envelope, "payload") do
+      false -> :ok
+      true -> {:error, {:invalid_field, "payload"}}
+    end
+  end
+
+  @spec validate_hex_signature(term()) :: :ok | {:error, :invalid_signature}
+  defp validate_hex_signature("0x" <> hex) when byte_size(hex) == 130 do
+    case Base.decode16(hex, case: :mixed) do
+      {:ok, _bytes} -> :ok
+      :error -> {:error, :invalid_signature}
+    end
+  end
+
+  defp validate_hex_signature(_signature), do: {:error, :invalid_signature}
+
+  @spec validate_compact_jws(term()) :: :ok | {:error, :invalid_jws}
+  defp validate_compact_jws(jws) when is_binary(jws) do
+    case String.split(jws, ".") do
+      [_header, _payload, _signature] -> :ok
+      _parts -> {:error, :invalid_jws}
+    end
+  end
+
+  defp validate_compact_jws(_jws), do: {:error, :invalid_jws}
+
+  @spec validate_accept_index(envelope()) :: :ok | {:error, {:invalid_field, String.t()}}
+  defp validate_accept_index(envelope) do
+    case Map.get(envelope, "acceptIndex") do
+      nil -> :ok
+      index when is_integer(index) and index >= 0 -> :ok
+      _invalid -> {:error, {:invalid_field, "acceptIndex"}}
+    end
+  end
+
+  @spec validate_offers([term()]) ::
+          {:ok, [envelope()]} | {:error, {:invalid_extension, term()}}
+  defp validate_offers(offers) do
+    offers
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, offers}, fn {offer, index}, acc ->
+      case is_map(offer) && validate_offer(offer) do
+        :ok ->
+          {:cont, acc}
+
+        false ->
+          {:halt, {:error, {:invalid_extension, {:invalid_offer, index, :invalid_envelope}}}}
+
+        {:error, reason} ->
+          {:halt, {:error, {:invalid_extension, {:invalid_offer, index, reason}}}}
+      end
+    end)
+  end
+
+  @spec fetch_info(map()) :: {:ok, map()} | {:error, term()}
+  defp fetch_info(map) do
+    extensions =
+      case Utils.map_value(map, {"extensions", :extensions}) do
+        %{} = nested -> nested
+        _other -> map
+      end
+
+    case Map.get(extensions, @extension_key) do
+      %{"info" => %{} = info} -> {:ok, info}
+      %{} -> {:error, {:invalid_extension, {:missing_field, "info"}}}
+      nil -> {:error, :extension_not_present}
+      _invalid -> {:error, {:invalid_extension, :not_a_map}}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Declaration schemas (§6)
+  # ---------------------------------------------------------------------------
+
+  @spec uniform_format!([envelope()]) :: String.t()
+  defp uniform_format!(offers) do
+    formats = offers |> Enum.map(&(is_map(&1) && Map.get(&1, "format"))) |> Enum.uniq()
+
+    case formats do
+      [format] when format in ["eip712", "jws"] ->
+        format
+
+      _mixed ->
+        raise ArgumentError,
+              ~s{all offers must share one signature format ("eip712" or "jws"), } <>
+                "got: #{inspect(formats)}"
+    end
+  end
+
+  @spec offers_schema(String.t()) :: map()
+  defp offers_schema(format) do
+    %{
+      "$schema" => @schema_uri,
+      "type" => "object",
+      "properties" => %{
+        "offers" => %{
+          "type" => "array",
+          "items" => envelope_schema(format, :offer)
+        }
+      },
+      "required" => ["offers"]
+    }
+  end
+
+  @spec receipt_schema(String.t()) :: map()
+  defp receipt_schema(format) do
+    %{
+      "$schema" => @schema_uri,
+      "type" => "object",
+      "properties" => %{"receipt" => envelope_schema(format, :receipt)},
+      "required" => ["receipt"]
+    }
+  end
+
+  @spec envelope_schema(String.t(), :offer | :receipt) :: map()
+  defp envelope_schema("eip712", artifact) do
+    properties = %{
+      "format" => %{"type" => "string", "const" => "eip712"},
+      "payload" => payload_schema(artifact),
+      "signature" => %{"type" => "string"}
+    }
+
+    %{
+      "type" => "object",
+      "properties" => maybe_accept_index(properties, artifact),
+      "required" => ["format", "payload", "signature"]
+    }
+  end
+
+  defp envelope_schema("jws", artifact) do
+    properties = %{
+      "format" => %{"type" => "string", "const" => "jws"},
+      "signature" => %{
+        "type" => "string",
+        "description" =>
+          "JWS compact serialization containing the #{artifact_name(artifact)} payload"
+      }
+    }
+
+    %{
+      "type" => "object",
+      "properties" => maybe_accept_index(properties, artifact),
+      "required" => ["format", "signature"]
+    }
+  end
+
+  @spec maybe_accept_index(map(), :offer | :receipt) :: map()
+  defp maybe_accept_index(properties, :offer),
+    do: Map.put(properties, "acceptIndex", %{"type" => "integer"})
+
+  defp maybe_accept_index(properties, :receipt), do: properties
+
+  @spec artifact_name(:offer | :receipt) :: String.t()
+  defp artifact_name(:offer), do: "offer"
+  defp artifact_name(:receipt), do: "receipt"
+
+  @spec payload_schema(:offer | :receipt) :: map()
+  defp payload_schema(:offer) do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "version" => %{"type" => "integer"},
+        "resourceUrl" => %{"type" => "string"},
+        "scheme" => %{"type" => "string"},
+        "network" => %{"type" => "string"},
+        "asset" => %{"type" => "string"},
+        "payTo" => %{"type" => "string"},
+        "amount" => %{"type" => "string"},
+        "validUntil" => %{"type" => "integer"}
+      },
+      "required" => ["version", "resourceUrl", "scheme", "network", "asset", "payTo", "amount"]
+    }
+  end
+
+  defp payload_schema(:receipt) do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "version" => %{"type" => "integer"},
+        "network" => %{"type" => "string"},
+        "resourceUrl" => %{"type" => "string"},
+        "payer" => %{"type" => "string"},
+        "issuedAt" => %{"type" => "integer"},
+        "transaction" => %{"type" => "string"}
+      },
+      "required" => ["version", "network", "resourceUrl", "payer", "issuedAt"]
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Small helpers
+  # ---------------------------------------------------------------------------
+
+  @spec to_amount_string(String.t() | non_neg_integer()) :: String.t()
+  defp to_amount_string(amount) when is_binary(amount), do: amount
+  defp to_amount_string(amount) when is_integer(amount), do: Integer.to_string(amount)
+
+  @spec maybe_put(map(), String.t(), term()) :: map()
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/lib/x402/extensions/offer_receipt/jws.ex
+++ b/lib/x402/extensions/offer_receipt/jws.ex
@@ -1,0 +1,472 @@
+defmodule X402.Extensions.OfferReceipt.JWS do
+  @moduledoc """
+  Compact JWS signing and verification for the offer-receipt extension.
+
+  Implements the JWS Compact Serialization (`header.payload.signature`,
+  RFC 7515) used by the x402 offer-and-receipt extension with the two
+  algorithms the extension names (§3.3):
+
+    * `"ES256K"` — ECDSA over secp256k1 with SHA-256 (RFC 8812), with the
+      64-byte `R || S` JOSE signature encoding
+    * `"EdDSA"` — Ed25519 (RFC 8037)
+
+  Both are implemented with OTP's `:crypto` application — no additional
+  dependencies. Payloads are canonicalized with the JSON Canonicalization
+  Scheme (JCS, RFC 8785) before signing, as required by the extension's
+  security considerations (§10).
+
+  ## Keys
+
+  Keys are raw binaries, not JWKs:
+
+    * `"ES256K"` — a 32-byte secp256k1 private key; the public key is a
+      SEC1 point (65-byte uncompressed, 33-byte compressed, or the bare
+      64-byte X || Y coordinates)
+    * `"EdDSA"` — a 32-byte Ed25519 seed; the public key is the 32-byte
+      Ed25519 public key
+
+  ## Boundaries
+
+    * Key discovery is out of scope: the `kid` header (a DID URL per the
+      extension spec) is carried and returned verbatim, but this module never
+      resolves it — callers supply the public key for verification and are
+      responsible for checking the key is authorized for the resource
+      (spec §4.5.1).
+    * `canonicalize/1` supports the JSON values that appear in offer and
+      receipt payloads (objects, arrays, strings, integers, booleans, null).
+      Floats are rejected with `{:error, {:unsupported_json_value, value}}`
+      rather than risking a non-canonical number serialization.
+    * ECDSA over secp256k1 requires OTP's `:crypto` to be linked against an
+      OpenSSL with secp256k1 support (the common case); otherwise `"ES256K"`
+      operations return `{:error, {:unsupported_algorithm, "ES256K"}}`.
+  """
+
+  @algorithms ["ES256K", "EdDSA"]
+
+  # secp256k1 group order, for low-S normalization of ES256K signatures.
+  @secp256k1_n 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+  @sign_opts_schema [
+    alg: [
+      type: {:in, @algorithms},
+      required: true,
+      doc: "JWS algorithm: `ES256K` or `EdDSA`."
+    ],
+    kid: [
+      type: :string,
+      required: true,
+      doc: "Key identifier placed in the protected header (a DID URL)."
+    ],
+    key: [
+      type: :string,
+      required: true,
+      doc: """
+      Raw private key: a 32-byte secp256k1 private key for `"ES256K"`, a
+      32-byte Ed25519 seed for `"EdDSA"`.
+      """
+    ]
+  ]
+
+  @verify_opts_schema [
+    algs: [
+      type: {:list, {:in, @algorithms}},
+      default: @algorithms,
+      doc: "Algorithms accepted during verification (allowlist)."
+    ]
+  ]
+
+  @typedoc "A JWS Compact Serialization string (`header.payload.signature`)."
+  @type compact :: String.t()
+
+  @typedoc "A decoded protected header with at least `alg` and `kid`."
+  @type header :: %{optional(String.t()) => term()}
+
+  @type sign_error ::
+          {:unsupported_algorithm, String.t()}
+          | {:invalid_key, String.t()}
+          | {:unsupported_json_value, term()}
+
+  @type verify_error ::
+          :invalid_jws
+          | :signature_mismatch
+          | {:unsupported_algorithm, term()}
+          | {:invalid_key, String.t()}
+          | {:missing_header, String.t()}
+
+  @doc since: "0.6.0"
+  @doc """
+  Signs a JSON payload into a JWS Compact Serialization string.
+
+  The protected header is `{"alg": alg, "kid": kid}`; the payload is
+  JCS-canonicalized before base64url encoding, so signing the same payload
+  twice produces the same JWS (for a deterministic algorithm like EdDSA).
+
+  ## Options
+
+  #{NimbleOptions.docs(@sign_opts_schema)}
+
+  ## Examples
+
+      {:ok, jws} =
+        X402.Extensions.OfferReceipt.JWS.sign(
+          %{"version" => 1, "resourceUrl" => "https://api.example.com/data"},
+          alg: "EdDSA",
+          kid: "did:web:api.example.com#key-1",
+          key: ed25519_seed
+        )
+  """
+  @spec sign(map(), keyword()) :: {:ok, compact()} | {:error, sign_error()}
+  def sign(payload, opts) when is_map(payload) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @sign_opts_schema)
+    alg = Keyword.fetch!(opts, :alg)
+
+    with {:ok, header_json} <- canonicalize(%{"alg" => alg, "kid" => Keyword.fetch!(opts, :kid)}),
+         {:ok, payload_json} <- canonicalize(payload) do
+      signing_input = base64url(header_json) <> "." <> base64url(payload_json)
+
+      with {:ok, signature} <- sign_bytes(alg, signing_input, Keyword.fetch!(opts, :key)) do
+        {:ok, signing_input <> "." <> base64url(signature)}
+      end
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Verifies a JWS Compact Serialization string against a public key.
+
+  Returns the decoded header and payload on success. The header must carry
+  `"alg"` (one of the allowed `:algs`) and `"kid"` (required by the
+  extension, §3.3). Key authorization for the signed resource is the
+  caller's responsibility (spec §4.5.1).
+
+  ## Options
+
+  #{NimbleOptions.docs(@verify_opts_schema)}
+  """
+  @spec verify(compact(), binary(), keyword()) ::
+          {:ok, %{header: header(), payload: term()}} | {:error, verify_error()}
+  def verify(compact, public_key, opts \\ [])
+      when is_binary(compact) and is_binary(public_key) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @verify_opts_schema)
+
+    with {:ok, header_b64, payload_b64, signature_b64} <- split(compact),
+         {:ok, header} <- decode_json_segment(header_b64),
+         {:ok, alg} <- fetch_alg(header, Keyword.fetch!(opts, :algs)),
+         :ok <- ensure_kid(header),
+         {:ok, signature} <- decode_base64url(signature_b64),
+         :ok <- verify_bytes(alg, header_b64 <> "." <> payload_b64, signature, public_key),
+         {:ok, payload} <- decode_json_segment(payload_b64) do
+      {:ok, %{header: header, payload: payload}}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Decodes the protected header of a JWS without verifying the signature.
+
+  Useful for extracting the `kid` in order to resolve the verification key.
+
+  ## Examples
+
+      iex> X402.Extensions.OfferReceipt.JWS.peek_header(
+      ...>   "eyJhbGciOiJFUzI1NksiLCJraWQiOiJkaWQ6d2ViOmFwaS5leGFtcGxlLmNvbSNrZXktMSJ9.e30.c2ln"
+      ...> )
+      {:ok, %{"alg" => "ES256K", "kid" => "did:web:api.example.com#key-1"}}
+
+      iex> X402.Extensions.OfferReceipt.JWS.peek_header("not a jws")
+      {:error, :invalid_jws}
+  """
+  @spec peek_header(compact()) :: {:ok, header()} | {:error, :invalid_jws}
+  def peek_header(compact) when is_binary(compact) do
+    with {:ok, header_b64, _payload_b64, _signature_b64} <- split(compact) do
+      decode_json_segment(header_b64)
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Decodes the payload of a JWS **without verifying the signature**.
+
+  Only use the result for display or matching; verified reads must go
+  through `verify/3`.
+
+  ## Examples
+
+      iex> X402.Extensions.OfferReceipt.JWS.peek_payload("eyJhbGciOiJFUzI1NksiLCJraWQiOiJrIn0.eyJ2ZXJzaW9uIjoxfQ.c2ln")
+      {:ok, %{"version" => 1}}
+  """
+  @spec peek_payload(compact()) :: {:ok, term()} | {:error, :invalid_jws}
+  def peek_payload(compact) when is_binary(compact) do
+    with {:ok, _header_b64, payload_b64, _signature_b64} <- split(compact) do
+      decode_json_segment(payload_b64)
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Serializes a JSON-representable term with the JSON Canonicalization Scheme.
+
+  Implements RFC 8785 for the value domain used by offer and receipt
+  payloads: object keys are sorted by UTF-16 code units, no insignificant
+  whitespace is emitted, and strings use ECMAScript's minimal escaping.
+  Atom keys and values are serialized as their string form (as `Jason`
+  does); floats are rejected as unsupported.
+
+  ## Examples
+
+      iex> X402.Extensions.OfferReceipt.JWS.canonicalize(%{"b" => 1, "a" => [true, nil, "x"]})
+      {:ok, ~s({"a":[true,null,"x"],"b":1})}
+
+      iex> X402.Extensions.OfferReceipt.JWS.canonicalize(%{"bad" => 1.5})
+      {:error, {:unsupported_json_value, 1.5}}
+  """
+  @spec canonicalize(term()) :: {:ok, String.t()} | {:error, {:unsupported_json_value, term()}}
+  def canonicalize(value) do
+    {:ok, serialize(value)}
+  catch
+    {:unsupported_json_value, unsupported} ->
+      {:error, {:unsupported_json_value, unsupported}}
+  end
+
+  # -- Signing primitives -----------------------------------------------------
+
+  @spec sign_bytes(String.t(), binary(), binary()) :: {:ok, binary()} | {:error, sign_error()}
+  defp sign_bytes("EdDSA", message, key) do
+    case byte_size(key) do
+      32 -> {:ok, :crypto.sign(:eddsa, :none, message, [key, :ed25519])}
+      _size -> {:error, {:invalid_key, "expected a 32-byte Ed25519 seed"}}
+    end
+  end
+
+  defp sign_bytes("ES256K", message, key) do
+    with :ok <- ensure_secp256k1(),
+         :ok <- ensure_key_size(key, 32, "expected a 32-byte secp256k1 private key") do
+      der = :crypto.sign(:ecdsa, :sha256, message, [key, :secp256k1])
+
+      with {:ok, {r, s}} <- der_to_integers(der) do
+        {:ok, integers_to_raw(r, normalize_s(s))}
+      end
+    end
+  end
+
+  @spec verify_bytes(String.t(), binary(), binary(), binary()) ::
+          :ok | {:error, verify_error()}
+  defp verify_bytes("EdDSA", message, signature, public_key) do
+    with :ok <- ensure_key_size(public_key, 32, "expected a 32-byte Ed25519 public key") do
+      case byte_size(signature) == 64 and
+             :crypto.verify(:eddsa, :none, message, signature, [public_key, :ed25519]) do
+        true -> :ok
+        false -> {:error, :signature_mismatch}
+      end
+    end
+  end
+
+  defp verify_bytes("ES256K", message, signature, public_key) do
+    with :ok <- ensure_secp256k1(),
+         {:ok, point} <- sec1_point(public_key),
+         {:ok, der} <- raw_to_der(signature) do
+      case :crypto.verify(:ecdsa, :sha256, message, der, [point, :secp256k1]) do
+        true -> :ok
+        false -> {:error, :signature_mismatch}
+      end
+    end
+  end
+
+  @spec ensure_secp256k1() :: :ok | {:error, {:unsupported_algorithm, String.t()}}
+  defp ensure_secp256k1 do
+    case :secp256k1 in :crypto.supports(:curves) do
+      true -> :ok
+      false -> {:error, {:unsupported_algorithm, "ES256K"}}
+    end
+  end
+
+  @spec ensure_key_size(binary(), pos_integer(), String.t()) ::
+          :ok | {:error, {:invalid_key, String.t()}}
+  defp ensure_key_size(key, size, message) do
+    case byte_size(key) == size do
+      true -> :ok
+      false -> {:error, {:invalid_key, message}}
+    end
+  end
+
+  @spec sec1_point(binary()) :: {:ok, binary()} | {:error, {:invalid_key, String.t()}}
+  defp sec1_point(<<4, _coordinates::binary-size(64)>> = point), do: {:ok, point}
+  defp sec1_point(<<prefix, _x::binary-size(32)>> = point) when prefix in [2, 3], do: {:ok, point}
+  defp sec1_point(<<coordinates::binary-size(64)>>), do: {:ok, <<4>> <> coordinates}
+
+  defp sec1_point(_key),
+    do: {:error, {:invalid_key, "expected a SEC1 secp256k1 point (33, 64, or 65 bytes)"}}
+
+  # ECDSA signatures leave :crypto DER-encoded; JOSE uses the raw 64-byte
+  # R || S concatenation. The DER form is small enough that lengths always
+  # use the short form.
+
+  @spec der_to_integers(binary()) ::
+          {:ok, {non_neg_integer(), non_neg_integer()}} | {:error, :signature_mismatch}
+  defp der_to_integers(<<0x30, _length, 0x02, r_length, rest::binary>>) do
+    case rest do
+      <<r::binary-size(r_length), 0x02, s_length, s::binary-size(s_length)>> ->
+        {:ok, {:binary.decode_unsigned(r), :binary.decode_unsigned(s)}}
+
+      _other ->
+        {:error, :signature_mismatch}
+    end
+  end
+
+  defp der_to_integers(_der), do: {:error, :signature_mismatch}
+
+  @spec integers_to_raw(non_neg_integer(), non_neg_integer()) :: <<_::512>>
+  defp integers_to_raw(r, s),
+    do: <<r::unsigned-big-integer-size(256), s::unsigned-big-integer-size(256)>>
+
+  @spec raw_to_der(binary()) :: {:ok, binary()} | {:error, :signature_mismatch}
+  defp raw_to_der(<<r::unsigned-big-integer-size(256), s::unsigned-big-integer-size(256)>>) do
+    r_der = der_integer(r)
+    s_der = der_integer(s)
+    body = <<0x02, byte_size(r_der)>> <> r_der <> <<0x02, byte_size(s_der)>> <> s_der
+    {:ok, <<0x30, byte_size(body)>> <> body}
+  end
+
+  defp raw_to_der(_signature), do: {:error, :signature_mismatch}
+
+  @spec der_integer(non_neg_integer()) :: binary()
+  defp der_integer(integer) do
+    bytes = :binary.encode_unsigned(integer)
+
+    case bytes do
+      <<high, _rest::binary>> when high >= 0x80 -> <<0>> <> bytes
+      _bytes -> bytes
+    end
+  end
+
+  # Normalizes ECDSA `s` to the lower half of the group order. RFC 8812 does
+  # not require it, but the wider secp256k1 ecosystem rejects high-S
+  # signatures, and emitting the canonical form keeps signatures stable.
+  @spec normalize_s(non_neg_integer()) :: non_neg_integer()
+  defp normalize_s(s) when s > div(@secp256k1_n, 2), do: @secp256k1_n - s
+  defp normalize_s(s), do: s
+
+  # -- Compact serialization helpers ------------------------------------------
+
+  @spec split(binary()) :: {:ok, binary(), binary(), binary()} | {:error, :invalid_jws}
+  defp split(compact) do
+    case String.split(compact, ".") do
+      [header, payload, signature] -> {:ok, header, payload, signature}
+      _parts -> {:error, :invalid_jws}
+    end
+  end
+
+  @spec decode_json_segment(binary()) :: {:ok, term()} | {:error, :invalid_jws}
+  defp decode_json_segment(segment) do
+    with {:ok, json} <- decode_base64url(segment),
+         {:ok, decoded} <- Jason.decode(json) do
+      {:ok, decoded}
+    else
+      _error -> {:error, :invalid_jws}
+    end
+  end
+
+  @spec decode_base64url(binary()) :: {:ok, binary()} | {:error, :invalid_jws}
+  defp decode_base64url(segment) do
+    case Base.url_decode64(segment, padding: false) do
+      {:ok, decoded} -> {:ok, decoded}
+      :error -> {:error, :invalid_jws}
+    end
+  end
+
+  @spec base64url(binary()) :: binary()
+  defp base64url(bytes), do: Base.url_encode64(bytes, padding: false)
+
+  @spec fetch_alg(map(), [String.t()]) ::
+          {:ok, String.t()}
+          | {:error, {:unsupported_algorithm, term()} | {:missing_header, String.t()}}
+  defp fetch_alg(header, allowed) when is_map(header) do
+    case Map.fetch(header, "alg") do
+      {:ok, alg} when is_binary(alg) ->
+        if alg in allowed, do: {:ok, alg}, else: {:error, {:unsupported_algorithm, alg}}
+
+      {:ok, alg} ->
+        {:error, {:unsupported_algorithm, alg}}
+
+      :error ->
+        {:error, {:missing_header, "alg"}}
+    end
+  end
+
+  defp fetch_alg(_header, _allowed), do: {:error, {:missing_header, "alg"}}
+
+  @spec ensure_kid(map()) :: :ok | {:error, {:missing_header, String.t()}}
+  defp ensure_kid(header) do
+    case Map.get(header, "kid") do
+      kid when is_binary(kid) and kid != "" -> :ok
+      _missing -> {:error, {:missing_header, "kid"}}
+    end
+  end
+
+  # -- JCS (RFC 8785) ---------------------------------------------------------
+
+  @spec serialize(term()) :: binary()
+  defp serialize(nil), do: "null"
+  defp serialize(true), do: "true"
+  defp serialize(false), do: "false"
+  defp serialize(value) when is_integer(value), do: Integer.to_string(value)
+  defp serialize(value) when is_binary(value), do: serialize_string(value)
+  defp serialize(value) when is_atom(value), do: serialize_string(Atom.to_string(value))
+
+  defp serialize(value) when is_list(value),
+    do: "[" <> Enum.map_join(value, ",", &serialize/1) <> "]"
+
+  defp serialize(value) when is_map(value) and not is_struct(value) do
+    pairs =
+      value
+      |> Enum.map(fn {key, entry} -> {serialize_key(key), entry} end)
+      |> Enum.sort_by(fn {key, _entry} -> utf16_units(key) end)
+      |> Enum.map_join(",", fn {key, entry} ->
+        serialize_string(key) <> ":" <> serialize(entry)
+      end)
+
+    "{" <> pairs <> "}"
+  end
+
+  defp serialize(value), do: throw({:unsupported_json_value, value})
+
+  @spec serialize_key(term()) :: binary()
+  defp serialize_key(key) when is_binary(key), do: key
+  defp serialize_key(key) when is_atom(key) and not is_nil(key), do: Atom.to_string(key)
+  defp serialize_key(key), do: throw({:unsupported_json_value, key})
+
+  # RFC 8785 sorts object keys by their UTF-16 code units.
+  @spec utf16_units(binary()) :: binary()
+  defp utf16_units(key) do
+    case :unicode.characters_to_binary(key, :utf8, {:utf16, :big}) do
+      encoded when is_binary(encoded) -> encoded
+      _error -> throw({:unsupported_json_value, key})
+    end
+  end
+
+  @spec serialize_string(binary()) :: binary()
+  defp serialize_string(value) do
+    escaped =
+      value
+      |> String.to_charlist()
+      |> Enum.map_join("", &escape_char/1)
+
+    "\"" <> escaped <> "\""
+  end
+
+  @spec escape_char(char()) :: binary()
+  defp escape_char(?"), do: "\\\""
+  defp escape_char(?\\), do: "\\\\"
+  defp escape_char(?\b), do: "\\b"
+  defp escape_char(?\t), do: "\\t"
+  defp escape_char(?\n), do: "\\n"
+  defp escape_char(?\f), do: "\\f"
+  defp escape_char(?\r), do: "\\r"
+
+  defp escape_char(char) when char < 0x20 do
+    hex = char |> Integer.to_string(16) |> String.downcase() |> String.pad_leading(4, "0")
+    "\\u" <> hex
+  end
+
+  defp escape_char(char), do: <<char::utf8>>
+end

--- a/mix.exs
+++ b/mix.exs
@@ -190,6 +190,8 @@ defmodule X402.MixProject do
           X402.Extensions.PaymentIdentifier.ETSCache,
           X402.Extensions.PaymentIdentifier.RedisCache,
           X402.Extensions.PaymentIdentifier.RedisCache.Command,
+          X402.Extensions.OfferReceipt,
+          X402.Extensions.OfferReceipt.JWS,
           X402.Extensions.SIWX,
           X402.Extensions.SIWX.Verifier,
           X402.Extensions.SIWX.Verifier.Default,
@@ -201,7 +203,10 @@ defmodule X402.MixProject do
         "Header Encoding": &(&1[:group] == :headers),
         "Payment Verification": &(&1[:group] == :verification),
         "Payment Settlement": &(&1[:group] == :settlement),
-        "Facilitator Discovery": &(&1[:group] == :discovery)
+        "Facilitator Discovery": &(&1[:group] == :discovery),
+        "Signed Offers": &(&1[:group] == :offers),
+        "Signed Receipts": &(&1[:group] == :receipts),
+        "Extension Declaration": &(&1[:group] == :declaration)
       ]
     ]
   end

--- a/test/x402/extensions/offer_receipt/jws_test.exs
+++ b/test/x402/extensions/offer_receipt/jws_test.exs
@@ -1,0 +1,210 @@
+defmodule X402.Extensions.OfferReceipt.JWSTest do
+  use ExUnit.Case, async: true
+
+  alias X402.Extensions.OfferReceipt.JWS
+
+  doctest X402.Extensions.OfferReceipt.JWS
+
+  @kid "did:web:api.example.com#key-1"
+
+  defp ed25519_pair, do: :crypto.generate_key(:eddsa, :ed25519)
+  defp secp256k1_pair, do: :crypto.generate_key(:ecdh, :secp256k1)
+
+  describe "canonicalize/1 (JCS, RFC 8785)" do
+    test "sorts object keys and emits no whitespace" do
+      assert {:ok, ~s({"a":1,"b":[2,3],"c":{"x":null}})} =
+               JWS.canonicalize(%{"c" => %{"x" => nil}, "a" => 1, "b" => [2, 3]})
+    end
+
+    test "sorts keys by UTF-16 code units, not UTF-8 bytes" do
+      # U+1D11E (surrogate pair D834 DD1E) sorts before U+FB04 in UTF-16,
+      # but after it in UTF-8 byte order — RFC 8785 requires UTF-16 order.
+      assert {:ok, ~s({"𝄞":2,"ﬄ":1})} = JWS.canonicalize(%{"ﬄ" => 1, "𝄞" => 2})
+    end
+
+    test "escapes strings minimally, per ECMAScript JSON.stringify" do
+      assert {:ok, ~s({"s":"a\\"b\\\\c\\n\\t\\u0000"})} =
+               JWS.canonicalize(%{"s" => "a\"b\\c\n\t" <> <<0>>})
+    end
+
+    test "serializes literals and integers" do
+      assert {:ok, "[null,true,false,0,-42]"} = JWS.canonicalize([nil, true, false, 0, -42])
+    end
+
+    test "accepts atom keys and values as strings" do
+      assert {:ok, ~s({"key":"value"})} = JWS.canonicalize(%{key: :value})
+    end
+
+    test "rejects floats as unsupported" do
+      assert {:error, {:unsupported_json_value, 1.5}} = JWS.canonicalize(%{"x" => 1.5})
+    end
+
+    test "rejects non-JSON values" do
+      assert {:error, {:unsupported_json_value, {:a, :b}}} = JWS.canonicalize(%{"x" => {:a, :b}})
+    end
+  end
+
+  describe "sign/2 with EdDSA" do
+    test "produces a three-part compact JWS with the spec header fields" do
+      {_public, seed} = ed25519_pair()
+
+      assert {:ok, jws} =
+               JWS.sign(%{"version" => 1}, alg: "EdDSA", kid: @kid, key: seed)
+
+      assert [header_b64, payload_b64, signature_b64] = String.split(jws, ".")
+
+      assert {:ok, %{"alg" => "EdDSA", "kid" => @kid}} = JWS.peek_header(jws)
+      assert Base.url_decode64!(header_b64, padding: false) == ~s({"alg":"EdDSA","kid":"#{@kid}"})
+      assert Base.url_decode64!(payload_b64, padding: false) == ~s({"version":1})
+      assert byte_size(Base.url_decode64!(signature_b64, padding: false)) == 64
+    end
+
+    test "round-trips through verify/3" do
+      {public, seed} = ed25519_pair()
+      payload = %{"version" => 1, "resourceUrl" => "https://api.example.com/data"}
+
+      assert {:ok, jws} = JWS.sign(payload, alg: "EdDSA", kid: @kid, key: seed)
+
+      assert {:ok, %{header: %{"alg" => "EdDSA", "kid" => @kid}, payload: ^payload}} =
+               JWS.verify(jws, public)
+    end
+
+    test "rejects a wrong key" do
+      {_public, seed} = ed25519_pair()
+      {other_public, _other_seed} = ed25519_pair()
+
+      assert {:ok, jws} = JWS.sign(%{"version" => 1}, alg: "EdDSA", kid: @kid, key: seed)
+      assert {:error, :signature_mismatch} = JWS.verify(jws, other_public)
+    end
+
+    test "rejects an invalid seed size" do
+      assert {:error, {:invalid_key, _message}} =
+               JWS.sign(%{"version" => 1}, alg: "EdDSA", kid: @kid, key: <<1::128>>)
+    end
+  end
+
+  describe "sign/2 with ES256K" do
+    test "signs the JCS-canonicalized payload with a 64-byte low-S signature" do
+      {public, private} = secp256k1_pair()
+
+      assert {:ok, jws} =
+               JWS.sign(%{"b" => 2, "a" => 1}, alg: "ES256K", kid: @kid, key: private)
+
+      [_header, payload_b64, signature_b64] = String.split(jws, ".")
+      assert Base.url_decode64!(payload_b64, padding: false) == ~s({"a":1,"b":2})
+
+      # Low-S normalization: s must be in the lower half of the group order.
+      n =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+      assert <<_r::unsigned-big-integer-size(256), s::unsigned-big-integer-size(256)>> =
+               Base.url_decode64!(signature_b64, padding: false)
+
+      assert s <= div(n, 2)
+      assert {:ok, %{payload: %{"a" => 1, "b" => 2}}} = JWS.verify(jws, public)
+    end
+
+    test "accepts compressed and bare 64-byte public keys for verification" do
+      {public, private} = secp256k1_pair()
+      assert {:ok, jws} = JWS.sign(%{"version" => 1}, alg: "ES256K", kid: @kid, key: private)
+
+      <<4, bare::binary-size(64)>> = public
+      assert {:ok, _verified} = JWS.verify(jws, bare)
+
+      compressed = compress_point(public)
+      assert {:ok, _verified} = JWS.verify(jws, compressed)
+    end
+
+    test "rejects a tampered payload" do
+      {public, private} = secp256k1_pair()
+
+      assert {:ok, jws} =
+               JWS.sign(%{"amount" => "10000", "version" => 1},
+                 alg: "ES256K",
+                 kid: @kid,
+                 key: private
+               )
+
+      [header, _payload, signature] = String.split(jws, ".")
+      forged_payload = Base.url_encode64(~s({"amount":"20000","version":1}), padding: false)
+      forged = Enum.join([header, forged_payload, signature], ".")
+
+      assert {:error, :signature_mismatch} = JWS.verify(forged, public)
+    end
+
+    test "rejects an invalid public key" do
+      {_public, private} = secp256k1_pair()
+      assert {:ok, jws} = JWS.sign(%{"version" => 1}, alg: "ES256K", kid: @kid, key: private)
+      assert {:error, {:invalid_key, _message}} = JWS.verify(jws, <<1, 2, 3>>)
+    end
+
+    test "rejects an invalid private key size" do
+      assert {:error, {:invalid_key, _message}} =
+               JWS.sign(%{"version" => 1}, alg: "ES256K", kid: @kid, key: <<1::128>>)
+    end
+  end
+
+  describe "verify/3 header requirements" do
+    test "enforces the :algs allowlist" do
+      {public, private} = secp256k1_pair()
+      assert {:ok, jws} = JWS.sign(%{"version" => 1}, alg: "ES256K", kid: @kid, key: private)
+
+      assert {:error, {:unsupported_algorithm, "ES256K"}} =
+               JWS.verify(jws, public, algs: ["EdDSA"])
+    end
+
+    test "rejects a header without kid (§3.3)" do
+      header = Base.url_encode64(~s({"alg":"EdDSA"}), padding: false)
+      payload = Base.url_encode64(~s({"version":1}), padding: false)
+      signature = Base.url_encode64(:crypto.strong_rand_bytes(64), padding: false)
+
+      assert {:error, {:missing_header, "kid"}} =
+               JWS.verify(Enum.join([header, payload, signature], "."), <<0::256>>)
+    end
+
+    test "rejects a header without alg" do
+      header = Base.url_encode64(~s({"kid":"did:web:x"}), padding: false)
+      payload = Base.url_encode64(~s({"version":1}), padding: false)
+      signature = Base.url_encode64(<<0::512>>, padding: false)
+
+      assert {:error, {:missing_header, "alg"}} =
+               JWS.verify(Enum.join([header, payload, signature], "."), <<0::256>>)
+    end
+
+    test "rejects unknown algorithms in the header" do
+      header = Base.url_encode64(~s({"alg":"none","kid":"did:web:x"}), padding: false)
+      payload = Base.url_encode64(~s({"version":1}), padding: false)
+      signature = Base.url_encode64(<<0::512>>, padding: false)
+
+      assert {:error, {:unsupported_algorithm, "none"}} =
+               JWS.verify(Enum.join([header, payload, signature], "."), <<0::256>>)
+    end
+
+    test "rejects malformed compact serializations" do
+      assert {:error, :invalid_jws} = JWS.verify("only.two", <<0::256>>)
+      assert {:error, :invalid_jws} = JWS.verify("a.b.c.d", <<0::256>>)
+      assert {:error, :invalid_jws} = JWS.verify("!not-base64!.b.c", <<0::256>>)
+    end
+  end
+
+  describe "peek_payload/1" do
+    test "decodes the payload without verification" do
+      {_public, seed} = ed25519_pair()
+      payload = %{"version" => 1, "amount" => "10000"}
+
+      assert {:ok, jws} = JWS.sign(payload, alg: "EdDSA", kid: @kid, key: seed)
+      assert {:ok, ^payload} = JWS.peek_payload(jws)
+    end
+
+    test "rejects malformed input" do
+      assert {:error, :invalid_jws} = JWS.peek_payload("nope")
+      assert {:error, :invalid_jws} = JWS.peek_payload("a.!bad-base64!.c")
+    end
+  end
+
+  # SEC1 point compression: prefix 02 for even Y, 03 for odd Y.
+  defp compress_point(<<4, x::binary-size(32), y::unsigned-big-integer-size(256)>>) do
+    prefix = if rem(y, 2) == 0, do: 2, else: 3
+    <<prefix, x::binary>>
+  end
+end

--- a/test/x402/extensions/offer_receipt_test.exs
+++ b/test/x402/extensions/offer_receipt_test.exs
@@ -214,6 +214,17 @@ defmodule X402.Extensions.OfferReceiptTest do
       assert String.match?(offer["signature"], ~r/^0x[0-9a-f]{130}$/)
     end
 
+    test "verified payloads strip unsigned extra keys" do
+      # Only the canonical fields enter the struct hash — an extra key added
+      # after signing must not come back looking signed.
+      assert {:ok, offer} = OfferReceipt.sign_offer(offer_payload(), signer())
+
+      inflated = put_in(offer, ["payload", "unsignedNote"], "added in transit")
+
+      assert {:ok, %{payload: verified}} = OfferReceipt.verify_offer(inflated)
+      refute Map.has_key?(verified, "unsignedNote")
+    end
+
     test "an absent validUntil is signed and transmitted as 0 (§4.3)" do
       payload = Map.delete(offer_payload(), "validUntil")
       assert {:ok, offer} = OfferReceipt.sign_offer(payload, signer())
@@ -370,6 +381,25 @@ defmodule X402.Extensions.OfferReceiptTest do
                OfferReceipt.verify_receipt(receipt, public_key: public)
 
       assert verified == payload
+    end
+
+    test "a signed offer JWS never verifies as a receipt (kind confusion)", %{ed: {public, seed}} do
+      # A public offer JWS is signed by the same key that signs receipts — if
+      # verify_receipt accepted it, an attacker could present the published
+      # offer as forged settlement evidence.
+      assert {:ok, offer} =
+               OfferReceipt.sign_offer_jws(offer_payload(), alg: "EdDSA", kid: @kid, key: seed)
+
+      assert {:error, _kind_mismatch} = OfferReceipt.verify_receipt(offer, public_key: public)
+
+      assert {:ok, receipt} =
+               OfferReceipt.sign_receipt_jws(receipt_payload(),
+                 alg: "EdDSA",
+                 kid: @kid,
+                 key: seed
+               )
+
+      assert {:error, _kind_mismatch2} = OfferReceipt.verify_offer(receipt, public_key: public)
     end
 
     test "optional fields stay omitted in JWS payloads", %{ed: {public, seed}} do

--- a/test/x402/extensions/offer_receipt_test.exs
+++ b/test/x402/extensions/offer_receipt_test.exs
@@ -1,0 +1,742 @@
+defmodule X402.Extensions.OfferReceiptTest do
+  use ExUnit.Case, async: true
+
+  alias X402.Extensions.OfferReceipt
+  alias X402.Extensions.OfferReceipt.JWS
+  alias X402.Signer.LocalKey
+
+  doctest X402.Extensions.OfferReceipt
+
+  # Deterministic test key (same key used across the client test suite).
+  @private_key "0x" <> String.duplicate("11", 32)
+
+  @resource_url "https://api.example.com/premium-data"
+  @asset "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+  @pay_to "0x209693Bc6afc0C5328bA36FaF03C514EF312287C"
+  @payer "0x857b06519E91e3A54538791bDbb0E22373e36b66"
+  @kid "did:web:api.example.com#key-1"
+
+  # Spec §4.4: base64url of {"alg":"ES256K","kid":"did:web:api.example.com#key-1"}
+  @spec_jws_header "eyJhbGciOiJFUzI1NksiLCJraWQiOiJkaWQ6d2ViOmFwaS5leGFtcGxlLmNvbSNrZXktMSJ9"
+
+  defp signer do
+    {:ok, signer} = LocalKey.new(@private_key)
+    signer
+  end
+
+  defp offer_payload(overrides \\ []) do
+    {:ok, payload} =
+      OfferReceipt.offer_payload(
+        Keyword.merge(
+          [
+            resource_url: @resource_url,
+            scheme: "exact",
+            network: "eip155:8453",
+            asset: @asset,
+            pay_to: @pay_to,
+            amount: "10000",
+            valid_until: 1_703_123_516
+          ],
+          overrides
+        )
+      )
+
+    payload
+  end
+
+  defp receipt_payload(overrides \\ []) do
+    {:ok, payload} =
+      OfferReceipt.receipt_payload(
+        Keyword.merge(
+          [
+            resource_url: @resource_url,
+            network: "eip155:8453",
+            payer: @payer,
+            issued_at: 1_703_123_456
+          ],
+          overrides
+        )
+      )
+
+    payload
+  end
+
+  # Independent digest compositions straight from the specification text
+  # (§3.2 domain, §4.3 / §5.3 types), so a regression in the module's hashing
+  # cannot cancel itself out.
+
+  @domain_type "EIP712Domain(string name,string version,uint256 chainId)"
+  @offer_type "Offer(uint256 version,string resourceUrl,string scheme,string network," <>
+                "string asset,string payTo,string amount,uint256 validUntil)"
+  @receipt_type "Receipt(uint256 version,string network,string resourceUrl,string payer," <>
+                  "uint256 issuedAt,string transaction)"
+
+  defp manual_domain_separator(name) do
+    ExKeccak.hash_256(
+      ExKeccak.hash_256(@domain_type) <>
+        ExKeccak.hash_256(name) <>
+        ExKeccak.hash_256("1") <>
+        <<1::unsigned-big-integer-size(256)>>
+    )
+  end
+
+  defp manual_offer_digest(payload) do
+    struct_hash =
+      ExKeccak.hash_256(
+        ExKeccak.hash_256(@offer_type) <>
+          <<payload["version"]::unsigned-big-integer-size(256)>> <>
+          ExKeccak.hash_256(payload["resourceUrl"]) <>
+          ExKeccak.hash_256(payload["scheme"]) <>
+          ExKeccak.hash_256(payload["network"]) <>
+          ExKeccak.hash_256(payload["asset"]) <>
+          ExKeccak.hash_256(payload["payTo"]) <>
+          ExKeccak.hash_256(payload["amount"]) <>
+          <<Map.get(payload, "validUntil", 0)::unsigned-big-integer-size(256)>>
+      )
+
+    ExKeccak.hash_256(<<0x19, 0x01>> <> manual_domain_separator("x402 offer") <> struct_hash)
+  end
+
+  defp manual_receipt_digest(payload) do
+    struct_hash =
+      ExKeccak.hash_256(
+        ExKeccak.hash_256(@receipt_type) <>
+          <<payload["version"]::unsigned-big-integer-size(256)>> <>
+          ExKeccak.hash_256(payload["network"]) <>
+          ExKeccak.hash_256(payload["resourceUrl"]) <>
+          ExKeccak.hash_256(payload["payer"]) <>
+          <<payload["issuedAt"]::unsigned-big-integer-size(256)>> <>
+          ExKeccak.hash_256(Map.get(payload, "transaction", ""))
+      )
+
+    ExKeccak.hash_256(<<0x19, 0x01>> <> manual_domain_separator("x402 receipt") <> struct_hash)
+  end
+
+  describe "offer_payload/1" do
+    test "converts integer amounts to strings (EIP-712 amount is a string)" do
+      assert offer_payload(amount: 10_000)["amount"] == "10000"
+    end
+
+    test "omits validUntil when not given" do
+      {:ok, payload} =
+        OfferReceipt.offer_payload(
+          resource_url: @resource_url,
+          scheme: "exact",
+          network: "eip155:8453",
+          asset: @asset,
+          pay_to: @pay_to,
+          amount: "10000"
+        )
+
+      refute Map.has_key?(payload, "validUntil")
+    end
+
+    test "raises on missing required options (programmer error)" do
+      assert_raise NimbleOptions.ValidationError, fn ->
+        OfferReceipt.offer_payload(resource_url: @resource_url)
+      end
+    end
+  end
+
+  describe "receipt_payload/1" do
+    test "defaults issuedAt to the current time" do
+      before = System.os_time(:second)
+
+      {:ok, payload} =
+        OfferReceipt.receipt_payload(
+          resource_url: @resource_url,
+          network: "eip155:8453",
+          payer: @payer
+        )
+
+      assert payload["issuedAt"] >= before
+      assert payload["issuedAt"] <= System.os_time(:second)
+    end
+
+    test "includes transaction only when given" do
+      refute Map.has_key?(receipt_payload(), "transaction")
+      assert receipt_payload(transaction: "0xabc")["transaction"] == "0xabc"
+    end
+  end
+
+  describe "EIP-712 digests (spec §3.2, §4.3, §5.3)" do
+    test "offer digest matches an independent composition of the spec formula" do
+      payload = offer_payload()
+      assert {:ok, digest} = OfferReceipt.offer_digest(payload)
+      assert digest == manual_offer_digest(payload)
+    end
+
+    test "receipt digest matches an independent composition of the spec formula" do
+      payload = receipt_payload(transaction: "0x" <> String.duplicate("ab", 32))
+      assert {:ok, digest} = OfferReceipt.receipt_digest(payload)
+      assert digest == manual_receipt_digest(payload)
+    end
+
+    test "absent validUntil hashes as zero and equals an explicit zero (§4.3)" do
+      without = Map.delete(offer_payload(), "validUntil")
+      with_zero = Map.put(without, "validUntil", 0)
+
+      assert OfferReceipt.offer_digest(without) == OfferReceipt.offer_digest(with_zero)
+    end
+
+    test "absent transaction hashes as the empty string (§5.3)" do
+      without = receipt_payload()
+      with_empty = Map.put(without, "transaction", "")
+
+      assert OfferReceipt.receipt_digest(without) == OfferReceipt.receipt_digest(with_empty)
+    end
+
+    test "missing required payload fields are structured errors" do
+      assert {:error, {:missing_field, "amount"}} =
+               offer_payload() |> Map.delete("amount") |> OfferReceipt.offer_digest()
+
+      assert {:error, {:missing_field, "payer"}} =
+               receipt_payload() |> Map.delete("payer") |> OfferReceipt.receipt_digest()
+    end
+
+    test "mistyped fields are structured errors" do
+      assert {:error, {:invalid_field, "resourceUrl"}} =
+               offer_payload() |> Map.put("resourceUrl", 42) |> OfferReceipt.offer_digest()
+
+      assert {:error, {:invalid_field, "issuedAt"}} =
+               receipt_payload() |> Map.put("issuedAt", "soon") |> OfferReceipt.receipt_digest()
+    end
+  end
+
+  describe "sign_offer/3 and verify_offer/2 (EIP-712)" do
+    test "produces the transmitted envelope shape from §3.1 / §4.4" do
+      assert {:ok, offer} = OfferReceipt.sign_offer(offer_payload(), signer(), accept_index: 0)
+
+      assert Map.keys(offer) |> Enum.sort() == ["acceptIndex", "format", "payload", "signature"]
+      assert offer["format"] == "eip712"
+      assert offer["acceptIndex"] == 0
+      assert offer["payload"] == offer_payload()
+      assert String.match?(offer["signature"], ~r/^0x[0-9a-f]{130}$/)
+    end
+
+    test "an absent validUntil is signed and transmitted as 0 (§4.3)" do
+      payload = Map.delete(offer_payload(), "validUntil")
+      assert {:ok, offer} = OfferReceipt.sign_offer(payload, signer())
+      assert offer["payload"]["validUntil"] == 0
+      refute Map.has_key?(offer, "acceptIndex")
+    end
+
+    test "round-trips: verification recovers the signing address" do
+      signer = signer()
+      assert {:ok, offer} = OfferReceipt.sign_offer(offer_payload(), signer)
+
+      assert {:ok, %{format: "eip712", signer: recovered, payload: payload}} =
+               OfferReceipt.verify_offer(offer)
+
+      assert recovered == signer.address
+      assert payload == offer["payload"]
+    end
+
+    test "accepts a matching :expected_signer case-insensitively" do
+      signer = signer()
+      assert {:ok, offer} = OfferReceipt.sign_offer(offer_payload(), signer)
+
+      upcased = "0x" <> String.upcase(String.trim_leading(signer.address, "0x"))
+      assert {:ok, _verified} = OfferReceipt.verify_offer(offer, expected_signer: upcased)
+    end
+
+    test "rejects a non-matching :expected_signer (§4.5.1 authorization)" do
+      assert {:ok, offer} = OfferReceipt.sign_offer(offer_payload(), signer())
+
+      assert {:error, :unauthorized_signer} =
+               OfferReceipt.verify_offer(offer, expected_signer: @pay_to)
+    end
+
+    test "a tampered payload no longer recovers the signing address" do
+      signer = signer()
+      assert {:ok, offer} = OfferReceipt.sign_offer(offer_payload(), signer)
+
+      tampered = put_in(offer, ["payload", "amount"], "1")
+      assert {:ok, %{signer: recovered}} = OfferReceipt.verify_offer(tampered)
+      assert recovered != signer.address
+
+      assert {:error, :unauthorized_signer} =
+               OfferReceipt.verify_offer(tampered, expected_signer: signer.address)
+    end
+
+    test "rejects unknown payload versions (§4.5)" do
+      assert {:ok, offer} = OfferReceipt.sign_offer(offer_payload(), signer())
+      unversioned = put_in(offer, ["payload", "version"], 2)
+
+      assert {:error, {:unsupported_payload_version, 2}} =
+               OfferReceipt.verify_offer(unversioned)
+    end
+
+    test "rejects malformed envelopes" do
+      assert {:error, :invalid_envelope} = OfferReceipt.verify_offer(%{"format" => "eip712"})
+      assert {:error, :invalid_envelope} = OfferReceipt.verify_offer(%{})
+
+      assert {:error, {:unsupported_format, "pgp"}} =
+               OfferReceipt.verify_offer(%{"format" => "pgp", "signature" => "sig"})
+    end
+  end
+
+  describe "sign_receipt/2 and verify_receipt/2 (EIP-712)" do
+    test "an absent transaction is signed and transmitted as \"\" (§5.3)" do
+      assert {:ok, receipt} = OfferReceipt.sign_receipt(receipt_payload(), signer())
+      assert receipt["payload"]["transaction"] == ""
+      assert Map.keys(receipt) |> Enum.sort() == ["format", "payload", "signature"]
+    end
+
+    test "round-trips with and without a transaction hash" do
+      signer = signer()
+
+      for overrides <- [[], [transaction: "0x" <> String.duplicate("ab", 32)]] do
+        payload = receipt_payload(overrides)
+        assert {:ok, receipt} = OfferReceipt.sign_receipt(payload, signer)
+
+        assert {:ok, %{format: "eip712", signer: recovered}} =
+                 OfferReceipt.verify_receipt(receipt, expected_signer: signer.address)
+
+        assert recovered == signer.address
+      end
+    end
+
+    test "a tampered payer fails the expected-signer check" do
+      signer = signer()
+      assert {:ok, receipt} = OfferReceipt.sign_receipt(receipt_payload(), signer)
+
+      tampered = put_in(receipt, ["payload", "payer"], @pay_to)
+
+      assert {:error, :unauthorized_signer} =
+               OfferReceipt.verify_receipt(tampered, expected_signer: signer.address)
+    end
+  end
+
+  describe "JWS artifacts" do
+    setup do
+      {public, seed} = :crypto.generate_key(:eddsa, :ed25519)
+      {secp_public, secp_private} = :crypto.generate_key(:ecdh, :secp256k1)
+      %{ed: {public, seed}, secp: {secp_public, secp_private}}
+    end
+
+    test "sign_offer_jws/2 omits the payload from the envelope (§3.1.1)", %{ed: {_pub, seed}} do
+      assert {:ok, offer} =
+               OfferReceipt.sign_offer_jws(offer_payload(),
+                 alg: "EdDSA",
+                 kid: @kid,
+                 key: seed,
+                 accept_index: 0
+               )
+
+      assert Map.keys(offer) |> Enum.sort() == ["acceptIndex", "format", "signature"]
+      assert offer["format"] == "jws"
+      refute Map.has_key?(offer, "payload")
+    end
+
+    test "the protected header matches the spec's §4.4 example encoding", %{secp: {_pub, priv}} do
+      assert {:ok, offer} =
+               OfferReceipt.sign_offer_jws(offer_payload(), alg: "ES256K", kid: @kid, key: priv)
+
+      assert [@spec_jws_header, _payload, _signature] = String.split(offer["signature"], ".")
+    end
+
+    test "the JWS payload segment is JCS-canonicalized (§10)", %{ed: {_pub, seed}} do
+      payload = offer_payload()
+
+      assert {:ok, offer} =
+               OfferReceipt.sign_offer_jws(payload, alg: "EdDSA", kid: @kid, key: seed)
+
+      [_header, payload_b64, _signature] = String.split(offer["signature"], ".")
+      assert {:ok, canonical} = JWS.canonicalize(payload)
+      assert Base.url_decode64!(payload_b64, padding: false) == canonical
+    end
+
+    test "offer round-trips through verify_offer/2", %{ed: {public, seed}} do
+      payload = offer_payload()
+
+      assert {:ok, offer} =
+               OfferReceipt.sign_offer_jws(payload, alg: "EdDSA", kid: @kid, key: seed)
+
+      assert {:ok, %{format: "jws", header: header, payload: verified}} =
+               OfferReceipt.verify_offer(offer, public_key: public)
+
+      assert header == %{"alg" => "EdDSA", "kid" => @kid}
+      assert verified == payload
+    end
+
+    test "receipt round-trips through verify_receipt/2 with ES256K", %{secp: {public, priv}} do
+      payload = receipt_payload()
+
+      assert {:ok, receipt} =
+               OfferReceipt.sign_receipt_jws(payload, alg: "ES256K", kid: @kid, key: priv)
+
+      assert {:ok, %{format: "jws", payload: verified}} =
+               OfferReceipt.verify_receipt(receipt, public_key: public)
+
+      assert verified == payload
+    end
+
+    test "optional fields stay omitted in JWS payloads", %{ed: {public, seed}} do
+      payload = Map.delete(offer_payload(), "validUntil")
+
+      assert {:ok, offer} =
+               OfferReceipt.sign_offer_jws(payload, alg: "EdDSA", kid: @kid, key: seed)
+
+      assert {:ok, %{payload: verified}} = OfferReceipt.verify_offer(offer, public_key: public)
+      refute Map.has_key?(verified, "validUntil")
+    end
+
+    test "verification requires a public key", %{ed: {_public, seed}} do
+      assert {:ok, offer} =
+               OfferReceipt.sign_offer_jws(offer_payload(), alg: "EdDSA", kid: @kid, key: seed)
+
+      assert {:error, :missing_public_key} = OfferReceipt.verify_offer(offer)
+    end
+
+    test "a tampered JWS payload is rejected", %{ed: {public, seed}} do
+      assert {:ok, offer} =
+               OfferReceipt.sign_offer_jws(offer_payload(), alg: "EdDSA", kid: @kid, key: seed)
+
+      [header, payload_b64, signature] = String.split(offer["signature"], ".")
+
+      forged_payload =
+        payload_b64
+        |> Base.url_decode64!(padding: false)
+        |> String.replace("10000", "20000")
+        |> Base.url_encode64(padding: false)
+
+      forged = %{offer | "signature" => Enum.join([header, forged_payload, signature], ".")}
+
+      assert {:error, :signature_mismatch} = OfferReceipt.verify_offer(forged, public_key: public)
+    end
+
+    test "the :algs allowlist is enforced", %{secp: {public, priv}} do
+      assert {:ok, offer} =
+               OfferReceipt.sign_offer_jws(offer_payload(), alg: "ES256K", kid: @kid, key: priv)
+
+      assert {:error, {:unsupported_algorithm, "ES256K"}} =
+               OfferReceipt.verify_offer(offer, public_key: public, algs: ["EdDSA"])
+    end
+
+    test "signing validates the payload first", %{ed: {_public, seed}} do
+      assert {:error, {:missing_field, "amount"}} =
+               offer_payload()
+               |> Map.delete("amount")
+               |> OfferReceipt.sign_offer_jws(alg: "EdDSA", kid: @kid, key: seed)
+
+      assert {:error, {:missing_field, "payer"}} =
+               receipt_payload()
+               |> Map.delete("payer")
+               |> OfferReceipt.sign_receipt_jws(alg: "EdDSA", kid: @kid, key: seed)
+    end
+  end
+
+  describe "validate_offer/1 and validate_receipt/1" do
+    test "accepts valid EIP-712 and JWS envelopes" do
+      assert {:ok, eip712} = OfferReceipt.sign_offer(offer_payload(), signer(), accept_index: 1)
+      assert :ok = OfferReceipt.validate_offer(eip712)
+
+      {_public, seed} = :crypto.generate_key(:eddsa, :ed25519)
+
+      assert {:ok, jws} =
+               OfferReceipt.sign_offer_jws(offer_payload(), alg: "EdDSA", kid: @kid, key: seed)
+
+      assert :ok = OfferReceipt.validate_offer(jws)
+    end
+
+    test "rejects EIP-712 envelopes without a payload" do
+      assert {:error, {:missing_field, "payload"}} =
+               OfferReceipt.validate_offer(%{"format" => "eip712", "signature" => "0x00"})
+    end
+
+    test "rejects EIP-712 envelopes with malformed signatures" do
+      {:ok, offer} = OfferReceipt.sign_offer(offer_payload(), signer())
+
+      assert {:error, :invalid_signature} =
+               OfferReceipt.validate_offer(Map.put(offer, "signature", "0xdead"))
+
+      assert {:error, :invalid_signature} =
+               OfferReceipt.validate_offer(
+                 Map.put(offer, "signature", "0x" <> String.duplicate("zz", 65))
+               )
+    end
+
+    test "rejects JWS envelopes that carry a payload (§3.1.1)" do
+      assert {:error, {:invalid_field, "payload"}} =
+               OfferReceipt.validate_offer(%{
+                 "format" => "jws",
+                 "payload" => %{"version" => 1},
+                 "signature" => "a.b.c"
+               })
+    end
+
+    test "rejects JWS envelopes without a compact serialization" do
+      assert {:error, :invalid_jws} =
+               OfferReceipt.validate_offer(%{"format" => "jws", "signature" => "onlyonepart"})
+    end
+
+    test "rejects unknown formats and missing formats" do
+      assert {:error, {:unsupported_format, "pgp"}} =
+               OfferReceipt.validate_offer(%{"format" => "pgp", "signature" => "sig"})
+
+      assert {:error, {:missing_field, "format"}} = OfferReceipt.validate_offer(%{})
+    end
+
+    test "rejects non-integer acceptIndex values" do
+      {:ok, offer} = OfferReceipt.sign_offer(offer_payload(), signer())
+
+      assert {:error, {:invalid_field, "acceptIndex"}} =
+               OfferReceipt.validate_offer(Map.put(offer, "acceptIndex", "first"))
+    end
+
+    test "validates receipt payload fields" do
+      {:ok, receipt} = OfferReceipt.sign_receipt(receipt_payload(), signer())
+      assert :ok = OfferReceipt.validate_receipt(receipt)
+
+      missing = update_in(receipt, ["payload"], &Map.delete(&1, "issuedAt"))
+      assert {:error, {:missing_field, "issuedAt"}} = OfferReceipt.validate_receipt(missing)
+
+      mistyped = put_in(receipt, ["payload", "transaction"], 7)
+      assert {:error, {:invalid_field, "transaction"}} = OfferReceipt.validate_receipt(mistyped)
+    end
+  end
+
+  describe "build_extension/1" do
+    test "wraps offers in the info/schema declaration with the §6.1 schema" do
+      {:ok, offer} = OfferReceipt.sign_offer(offer_payload(), signer(), accept_index: 0)
+      extension = OfferReceipt.build_extension([offer])
+
+      assert extension["info"] == %{"offers" => [offer]}
+
+      assert extension["schema"] == %{
+               "$schema" => "https://json-schema.org/draft/2020-12/schema",
+               "type" => "object",
+               "properties" => %{
+                 "offers" => %{
+                   "type" => "array",
+                   "items" => %{
+                     "type" => "object",
+                     "properties" => %{
+                       "format" => %{"type" => "string", "const" => "eip712"},
+                       "acceptIndex" => %{"type" => "integer"},
+                       "payload" => %{
+                         "type" => "object",
+                         "properties" => %{
+                           "version" => %{"type" => "integer"},
+                           "resourceUrl" => %{"type" => "string"},
+                           "scheme" => %{"type" => "string"},
+                           "network" => %{"type" => "string"},
+                           "asset" => %{"type" => "string"},
+                           "payTo" => %{"type" => "string"},
+                           "amount" => %{"type" => "string"},
+                           "validUntil" => %{"type" => "integer"}
+                         },
+                         "required" => [
+                           "version",
+                           "resourceUrl",
+                           "scheme",
+                           "network",
+                           "asset",
+                           "payTo",
+                           "amount"
+                         ]
+                       },
+                       "signature" => %{"type" => "string"}
+                     },
+                     "required" => ["format", "payload", "signature"]
+                   }
+                 }
+               },
+               "required" => ["offers"]
+             }
+    end
+
+    test "builds the §6.3 schema for JWS offers" do
+      {_public, seed} = :crypto.generate_key(:eddsa, :ed25519)
+
+      {:ok, offer} =
+        OfferReceipt.sign_offer_jws(offer_payload(), alg: "EdDSA", kid: @kid, key: seed)
+
+      extension = OfferReceipt.build_extension([offer])
+
+      assert extension["schema"]["properties"]["offers"]["items"] == %{
+               "type" => "object",
+               "properties" => %{
+                 "format" => %{"type" => "string", "const" => "jws"},
+                 "acceptIndex" => %{"type" => "integer"},
+                 "signature" => %{
+                   "type" => "string",
+                   "description" => "JWS compact serialization containing the offer payload"
+                 }
+               },
+               "required" => ["format", "signature"]
+             }
+    end
+
+    test "raises on empty lists, mixed formats, and invalid offers" do
+      {:ok, eip712} = OfferReceipt.sign_offer(offer_payload(), signer())
+      {_public, seed} = :crypto.generate_key(:eddsa, :ed25519)
+
+      {:ok, jws} =
+        OfferReceipt.sign_offer_jws(offer_payload(), alg: "EdDSA", kid: @kid, key: seed)
+
+      assert_raise ArgumentError, fn -> OfferReceipt.build_extension([]) end
+      assert_raise ArgumentError, fn -> OfferReceipt.build_extension([eip712, jws]) end
+
+      assert_raise ArgumentError, fn ->
+        OfferReceipt.build_extension([Map.delete(eip712, "payload")])
+      end
+    end
+  end
+
+  describe "build_receipt_extension/1" do
+    test "wraps the receipt with the §6.5 schema (EIP-712)" do
+      {:ok, receipt} = OfferReceipt.sign_receipt(receipt_payload(), signer())
+      extension = OfferReceipt.build_receipt_extension(receipt)
+
+      assert extension["info"] == %{"receipt" => receipt}
+
+      assert extension["schema"] == %{
+               "$schema" => "https://json-schema.org/draft/2020-12/schema",
+               "type" => "object",
+               "properties" => %{
+                 "receipt" => %{
+                   "type" => "object",
+                   "properties" => %{
+                     "format" => %{"type" => "string", "const" => "eip712"},
+                     "payload" => %{
+                       "type" => "object",
+                       "properties" => %{
+                         "version" => %{"type" => "integer"},
+                         "network" => %{"type" => "string"},
+                         "resourceUrl" => %{"type" => "string"},
+                         "payer" => %{"type" => "string"},
+                         "issuedAt" => %{"type" => "integer"},
+                         "transaction" => %{"type" => "string"}
+                       },
+                       "required" => ["version", "network", "resourceUrl", "payer", "issuedAt"]
+                     },
+                     "signature" => %{"type" => "string"}
+                   },
+                   "required" => ["format", "payload", "signature"]
+                 }
+               },
+               "required" => ["receipt"]
+             }
+    end
+
+    test "builds the §6.7 schema for JWS receipts" do
+      {_public, seed} = :crypto.generate_key(:eddsa, :ed25519)
+
+      {:ok, receipt} =
+        OfferReceipt.sign_receipt_jws(receipt_payload(), alg: "EdDSA", kid: @kid, key: seed)
+
+      extension = OfferReceipt.build_receipt_extension(receipt)
+
+      assert extension["schema"]["properties"]["receipt"] == %{
+               "type" => "object",
+               "properties" => %{
+                 "format" => %{"type" => "string", "const" => "jws"},
+                 "signature" => %{
+                   "type" => "string",
+                   "description" => "JWS compact serialization containing the receipt payload"
+                 }
+               },
+               "required" => ["format", "signature"]
+             }
+    end
+
+    test "raises on invalid receipts" do
+      assert_raise ArgumentError, fn ->
+        OfferReceipt.build_receipt_extension(%{"format" => "eip712"})
+      end
+
+      assert_raise ArgumentError, fn -> OfferReceipt.build_receipt_extension("receipt") end
+    end
+  end
+
+  describe "fetch_offers/1 and fetch_receipt/1" do
+    setup do
+      {:ok, offer} = OfferReceipt.sign_offer(offer_payload(), signer(), accept_index: 0)
+      {:ok, receipt} = OfferReceipt.sign_receipt(receipt_payload(), signer())
+      %{offer: offer, receipt: receipt}
+    end
+
+    test "reads offers from a full payment-required map", %{offer: offer} do
+      payment_required = %{
+        "x402Version" => 2,
+        "accepts" => [],
+        "extensions" => %{"offer-receipt" => OfferReceipt.build_extension([offer])}
+      }
+
+      assert {:ok, [^offer]} = OfferReceipt.fetch_offers(payment_required)
+    end
+
+    test "reads offers from a bare extensions map", %{offer: offer} do
+      extensions = %{"offer-receipt" => OfferReceipt.build_extension([offer])}
+      assert {:ok, [^offer]} = OfferReceipt.fetch_offers(extensions)
+    end
+
+    test "reports absence and malformed declarations" do
+      assert {:error, :extension_not_present} = OfferReceipt.fetch_offers(%{"accepts" => []})
+
+      assert {:error, {:invalid_extension, {:missing_field, "info"}}} =
+               OfferReceipt.fetch_offers(%{"offer-receipt" => %{"schema" => %{}}})
+
+      assert {:error, {:invalid_extension, {:missing_field, "offers"}}} =
+               OfferReceipt.fetch_offers(%{"offer-receipt" => %{"info" => %{}}})
+
+      assert {:error, {:invalid_extension, :not_a_map}} =
+               OfferReceipt.fetch_offers(%{"offer-receipt" => "yes"})
+    end
+
+    test "is fail-closed on a structurally invalid offer", %{offer: offer} do
+      broken = Map.delete(offer, "signature")
+
+      extensions = %{"offer-receipt" => %{"info" => %{"offers" => [offer, broken]}}}
+
+      assert {:error, {:invalid_extension, {:invalid_offer, 1, :invalid_signature}}} =
+               OfferReceipt.fetch_offers(extensions)
+
+      assert {:error, {:invalid_extension, {:invalid_offer, 0, :invalid_envelope}}} =
+               OfferReceipt.fetch_offers(%{"offer-receipt" => %{"info" => %{"offers" => ["x"]}}})
+    end
+
+    test "reads and validates the settlement receipt", %{receipt: receipt} do
+      settlement = %{
+        "success" => true,
+        "extensions" => %{"offer-receipt" => OfferReceipt.build_receipt_extension(receipt)}
+      }
+
+      assert {:ok, ^receipt} = OfferReceipt.fetch_receipt(settlement)
+
+      assert {:error, :extension_not_present} = OfferReceipt.fetch_receipt(%{"success" => true})
+
+      assert {:error, {:invalid_extension, {:missing_field, "receipt"}}} =
+               OfferReceipt.fetch_receipt(%{"offer-receipt" => %{"info" => %{}}})
+
+      broken = update_in(receipt, ["payload"], &Map.delete(&1, "network"))
+
+      assert {:error, {:invalid_extension, {:missing_field, "network"}}} =
+               OfferReceipt.fetch_receipt(%{
+                 "offer-receipt" => %{"info" => %{"receipt" => broken}}
+               })
+    end
+  end
+
+  describe "extract_payload/1" do
+    test "decodes the JWS payload without verification" do
+      {_public, seed} = :crypto.generate_key(:eddsa, :ed25519)
+      payload = offer_payload()
+
+      {:ok, offer} = OfferReceipt.sign_offer_jws(payload, alg: "EdDSA", kid: @kid, key: seed)
+      assert {:ok, ^payload} = OfferReceipt.extract_payload(offer)
+    end
+
+    test "rejects malformed envelopes" do
+      assert {:error, {:missing_field, "signature"}} =
+               OfferReceipt.extract_payload(%{"format" => "jws"})
+
+      assert {:error, {:missing_field, "payload"}} =
+               OfferReceipt.extract_payload(%{"format" => "eip712", "payload" => "nope"})
+
+      assert {:error, :invalid_envelope} = OfferReceipt.extract_payload(%{})
+    end
+  end
+end

--- a/test/x402/extensions/offer_receipt_test.exs
+++ b/test/x402/extensions/offer_receipt_test.exs
@@ -194,6 +194,16 @@ defmodule X402.Extensions.OfferReceiptTest do
                receipt_payload() |> Map.delete("payer") |> OfferReceipt.receipt_digest()
     end
 
+    test "uint256-overflowing fields fail closed instead of truncating" do
+      huge = Integer.pow(2, 256)
+
+      assert {:error, {:invalid_field, "validUntil"}} =
+               offer_payload() |> Map.put("validUntil", huge) |> OfferReceipt.offer_digest()
+
+      assert {:error, {:invalid_field, "issuedAt"}} =
+               receipt_payload() |> Map.put("issuedAt", huge) |> OfferReceipt.receipt_digest()
+    end
+
     test "mistyped fields are structured errors" do
       assert {:error, {:invalid_field, "resourceUrl"}} =
                offer_payload() |> Map.put("resourceUrl", 42) |> OfferReceipt.offer_digest()

--- a/test/x402/test_payments_test.exs
+++ b/test/x402/test_payments_test.exs
@@ -137,7 +137,9 @@ defmodule X402.TestPaymentsTest do
       valid_before = String.to_integer(authorization["validBefore"])
       now = System.os_time(:second)
       assert valid_after <= now
-      assert valid_before == now + config.max_timeout
+      # `now` is sampled after the payload was built, so a second may have
+      # ticked between the two readings — allow it (was a CI flake).
+      assert_in_delta valid_before, now + config.max_timeout, 1
 
       signature = payload["payload"]["signature"]
       assert String.starts_with?(signature, "0x")


### PR DESCRIPTION
## What

Implements the offer-and-receipt extension ([docs/ecosystem-comparison.md](https://github.com/cardotrejos/x402/blob/main/docs/ecosystem-comparison.md) §8 P2.4 — previously TS-only in the entire ecosystem; this makes Elixir the second SDK to ship it). Per spec v0.6: server-signed **offers** (commitment to advertised terms in `extensions["offer-receipt"].info.offers[]`) and **receipts** (delivery confirmation in the settlement response), client-verified.

- **Both spec formats**: EIP-712 (fixed chain-agnostic domain `{name, version: "1", chainId: 1}`, no verifyingContract, `payTo` as string per the v0.6 change, 65-byte signatures, spec zero-filling) and **compact JWS** (ES256K + EdDSA implemented on pure OTP `:crypto` — DER↔raw conversion, low-S normalization — with RFC 8785 JCS canonicalization incl. UTF-16 key ordering, detached payload per spec). Zero new deps.
- Sign/verify both artifact kinds through the existing `X402.Signer` behaviour with signer recovery and explicit `:expected_signer` authorization (spec §4.5.1: signature validity ≠ signer authorization). EIP-712 hashing reuses the shared `X402.EIP712`.
- Fail-closed extraction/validation, §6-exact declaration envelopes, reference v1→CAIP-2 network tables.

## Honest boundaries (documented)

`kid` DID URLs are never resolved — verification takes an explicit `:public_key` (offline did:key parsing would need multibase deps); JCS rejects floats (spec payloads are integers/strings only); offer freshness and on-chain tx checks stay caller policy per the spec's MAY.

## Testing

76 tests + 17 doctests: independent digest recomposition from the spec formulas, §6 schema literals, the §4.4 base64 vector, sign→verify round-trips with address recovery, tamper rejection, alg-allowlist, JCS ordering cases. Full suite 162 doctests + 711 tests, 0 failures. All gates green incl. dialyzer and --no-optional-deps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New cryptographic signing/verification surface and a behavior change to shared uint256 encoding; mistakes in verification or authorization policy could accept forged terms, though the API is fail-closed and heavily tested.
> 
> **Overview**
> Adds **`X402.Extensions.OfferReceipt`** (and **`JWS`**) so resource servers can sign advertised payment terms and post-settlement receipts per the x402 offer-and-receipt extension. Callers build payloads, sign via **EIP-712** (`X402.Signer`) or **compact JWS** (ES256K/EdDSA on OTP `:crypto` with RFC 8785 JCS), attach **`extensions["offer-receipt"]`** on payment-required and settlement responses, and clients verify with optional **`expected_signer`** / explicit **`public_key`** (no `kid` DID resolution). Includes fail-closed **`fetch_offers/1`** / **`fetch_receipt/1`**, structural validation, v1→CAIP-2 **`to_caip2/1`**, and §6 JSON Schema builders; verified EIP-712 payloads are stripped to signed fields only, and JWS verification rejects offer/receipt kind confusion.
> 
> **`X402.EIP712.encode_uint256/1`** now rejects integers ≥ 2²⁵⁶ instead of silently truncating, which affects all EIP-712 hashing paths (including offer/receipt uint fields).
> 
> Docs: **CHANGELOG**, **`guides/plug-integration.md`** (signed offers/receipts examples), and **mix.exs** doc groups. Tests cover digests, round-trips, tampering, and schemas; **`test_payments_test.exs`** uses **`assert_in_delta`** for a timing flake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3a7f89c342c4f93874054aefc95820bdafc0d90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->