### PR TITLE
feat: X402.Scheme behaviour — pluggable payment schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cannot inject markup. A renderer returning `{:error, reason}` logs a
   warning and falls back to the JSON body. See the new "Browser Paywall"
   guide.
+- **`X402.Scheme` behaviour — pluggable payment schemes** (ecosystem report
+  §5.3.1/§8 P1.1): everything scheme-specific now dispatches through one
+  behaviour, so adding a chain or scheme means writing one module and
+  passing it as an option instead of editing core modules. Callbacks:
+  `scheme/0` and `networks/0` (metadata — CAIP-2 patterns with trailing-`*`
+  wildcards), `sign/3` and the optional `signable?/1` (client side),
+  `validate_payload/3` and `precheck/3` (server side). Resolution lives in
+  `X402.Scheme.Registry` (exact CAIP-2 match beats wildcard, longest
+  wildcard prefix wins, user modules beat built-ins) and is seeded with
+  `X402.Scheme.ExactEVM` (`exact` on `eip155:*`, EIP-3009 signing plus the
+  existing local pre-checks) and `X402.Scheme.UptoEVM` (`upto` on
+  `eip155:*`, the existing ceiling validation) — extracted from
+  `X402.Client`, `X402.Plug.PaymentGate`, and `X402.PaymentSignature`
+  with unchanged external behavior. Custom schemes register via the new
+  `schemes:` option on `X402.Plug.PaymentGate` (routes may then use the
+  registered scheme names), `X402.Client.build_payment/3` /
+  `select_requirements/2`, `X402.Client.Finch.request/3`, and the new
+  `X402.PaymentSignature.validate/3` / `decode_and_validate/3` — no
+  application environment, no global registration. Kinds with no
+  registered module keep their historical behavior: validation passes
+  through, the gate skips pre-checks, and the client returns
+  `{:error, {:unsupported_kind, scheme, network}}`. Scheme
+  `validate_payload/3` failures shaped `{:invalid_scheme_payment, reason}`
+  are answered with HTTP 400 by the gate. Shared EVM authorization
+  pre-checks are reusable via `X402.Scheme.EVM.authorization_precheck/3`.
+  See the new Custom Payment Schemes guide
 - **Local pre-verification checks in `X402.Plug.PaymentGate`** (option
   `local_prechecks:`, default `true`): before the facilitator round-trip, the
   gate now validates the EIP-3009-style `payload.authorization` object against

--- a/guides/custom-schemes.md
+++ b/guides/custom-schemes.md
@@ -1,0 +1,90 @@
+# Custom Payment Schemes
+
+Everything scheme-specific in this library — client signing, incoming
+payload validation, and the payment gate's local pre-checks — dispatches
+through the `X402.Scheme` behaviour. Supporting a new chain or payment
+scheme means writing **one module** and passing it as an option; no core
+module needs to change.
+
+The built-ins cover `exact` (`X402.Scheme.ExactEVM`) and `upto`
+(`X402.Scheme.UptoEVM`) on EVM (`eip155:*`) networks. Resolution — exact
+CAIP-2 matches beating wildcards, user modules beating built-ins — is
+handled by `X402.Scheme.Registry`.
+
+## Writing a scheme module
+
+Implement `X402.Scheme`. Only `c:X402.Scheme.scheme/0` and
+`c:X402.Scheme.networks/0` are required; implement the callbacks for the
+roles your scheme plays:
+
+```elixir
+defmodule MyApp.SolanaExact do
+  @behaviour X402.Scheme
+
+  @impl X402.Scheme
+  def scheme, do: "exact"
+
+  @impl X402.Scheme
+  def networks, do: ["solana:*"]
+
+  # Client role: build the scheme payload carried as PaymentPayload.payload.
+  @impl X402.Scheme
+  def sign(requirements, signer, _opts) do
+    with {:ok, transaction} <- build_and_sign_transaction(requirements, signer) do
+      {:ok, %{"transaction" => transaction}}
+    end
+  end
+
+  # Server role: structural validation of incoming PAYMENT-SIGNATURE payloads.
+  @impl X402.Scheme
+  def validate_payload(payload, _requirements, _opts) do
+    case get_in(payload, ["payload", "transaction"]) do
+      transaction when is_binary(transaction) -> :ok
+      _missing -> {:error, {:invalid_scheme_payment, :missing_transaction}}
+    end
+  end
+
+  # Server role: cheap local pre-checks before the facilitator round-trip.
+  @impl X402.Scheme
+  def precheck(_payload, _requirements, _opts), do: :ok
+
+  defp build_and_sign_transaction(_requirements, _signer), do: {:error, :not_implemented}
+end
+```
+
+## Registering it
+
+There is no global registry and no application environment — scheme modules
+are passed explicitly wherever you use the SDK, so two gates (or two
+clients) in the same VM can support different scheme sets:
+
+```elixir
+# Resource server: routes may now use the scheme on its networks.
+plug X402.Plug.PaymentGate,
+  schemes: [MyApp.SolanaExact],
+  routes: [
+    %{
+      method: :get,
+      path: "/api/*",
+      scheme: "exact",
+      price: "10000",
+      network: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      asset: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      pay_to: "CKPKJWNdJEqa81x7CkZ14BVPiY6y16Sxs7owznqtWYp5"
+    }
+  ]
+
+# Payer client (also available on X402.Client.Finch.request/3).
+X402.Client.build_payment(payment_required, signer, schemes: [MyApp.SolanaExact])
+
+# Standalone header validation.
+X402.PaymentSignature.validate(payload, requirements, schemes: [MyApp.SolanaExact])
+```
+
+Kinds with no registered module keep their historical neutral behavior:
+validation passes through with `:ok`, the gate skips pre-checks (the
+facilitator remains the authority), and the client returns
+`{:error, {:unsupported_kind, scheme, network}}`.
+
+See the `X402.Scheme` module documentation for the full callback reference
+and error conventions.

--- a/guides/plug-integration.md
+++ b/guides/plug-integration.md
@@ -45,7 +45,7 @@ plug X402.Plug.PaymentGate,
 | `:method` | `atom()` | **yes** | HTTP method (`:get`, `:post`, `:put`, `:delete`, `:patch`, `:head`, `:options`, `:trace`, or `:any` for all) |
 | `:path` | `String.t()` | **yes** | Route path. Exact matches (`/api/data`) or glob patterns (`/api/*`) |
 | `:accepts` | `[map()]` | no | Multiple payment options (see "Multiple Accepts" below) |
-| `:scheme` | `String.t()` | no | `"exact"` (default) or `"upto"` |
+| `:scheme` | `String.t()` | no | `"exact"` (default), `"upto"`, or the scheme name of a module passed in the plug's `:schemes` option — see the [Custom Payment Schemes](custom-schemes.md) guide |
 | `:price` | `String.t()` | conditionally | Payment amount in atomic token units. Required when `:accepts` is empty |
 | `:network` | `String.t()` | conditionally | CAIP-2 network identifier (e.g. `"eip155:8453"`) |
 | `:asset` | `String.t()` | conditionally | Token contract address |

--- a/lib/x402/client.ex
+++ b/lib/x402/client.ex
@@ -9,9 +9,11 @@ defmodule X402.Client do
   own HTTP client, or use `X402.Client.Finch` for a ready-made
   402 → sign → retry flow.
 
-  This release signs the `exact` scheme on EVM (`eip155:*`) networks via
-  EIP-3009 (`X402.EIP3009`); other scheme/network combinations return
-  `{:error, {:unsupported_kind, scheme, network}}`.
+  Signing dispatches through `X402.Scheme.Registry`: out of the box this
+  client signs the `exact` scheme on EVM (`eip155:*`) networks via EIP-3009
+  (`X402.Scheme.ExactEVM`); other scheme/network combinations return
+  `{:error, {:unsupported_kind, scheme, network}}` unless a matching
+  `X402.Scheme` module is passed with the `:schemes` option.
 
   ## Example
 
@@ -26,6 +28,7 @@ defmodule X402.Client do
 
   alias X402.EIP3009
   alias X402.PaymentRequirements
+  alias X402.Scheme
   alias X402.Signer
   alias X402.Telemetry
   alias X402.Utils
@@ -51,6 +54,15 @@ defmodule X402.Client do
       doc: """
       Only select requirements whose `amount` (in atomic units) does not
       exceed this value — the budget guard for automated payers.
+      """
+    ],
+    schemes: [
+      type: {:list, {:custom, Scheme, :validate_module, []}},
+      default: [],
+      doc: """
+      Additional `X402.Scheme` modules consulted (before the built-ins) when
+      deciding which requirements this client can sign and how to sign
+      them — see `X402.Scheme.Registry`.
       """
     ]
   ]
@@ -85,7 +97,8 @@ defmodule X402.Client do
           network: String.t(),
           scheme: String.t(),
           asset: String.t(),
-          max_amount: String.t() | non_neg_integer()
+          max_amount: String.t() | non_neg_integer(),
+          schemes: [module()]
         ]
 
   @type select_error :: :no_acceptable_requirements | :invalid_payment_required
@@ -103,10 +116,12 @@ defmodule X402.Client do
 
   Accepts a decoded `PaymentRequired` map (its `accepts` list is used) or a
   bare list of requirements maps. Returns the first entry that passes the
-  option filters **and** that this client can sign: `exact` scheme on an
-  `eip155:*` network, structurally valid per
-  `X402.PaymentRequirements.validate/1`, with the EIP-712 domain fields
-  (`extra.name` / `extra.version`) present.
+  option filters **and** that this client can sign: structurally valid per
+  `X402.PaymentRequirements.validate/1` and resolved by
+  `X402.Scheme.Registry` to a scheme module with a sign callback — by
+  default `exact` on an `eip155:*` network via `X402.Scheme.ExactEVM`,
+  which additionally requires the EIP-712 domain fields (`extra.name` /
+  `extra.version`). Pass additional schemes with the `:schemes` option.
 
   The selected entry is returned exactly as the server sent it, so it can be
   echoed verbatim as the payload's `accepted` value.
@@ -138,11 +153,12 @@ defmodule X402.Client do
           {:ok, map()} | {:error, select_error()}
   def select_requirements(payment_required, opts \\ []) do
     opts = NimbleOptions.validate!(opts, @select_opts_schema)
+    schemes = Keyword.fetch!(opts, :schemes)
 
     with {:ok, accepts} <- fetch_accepts(payment_required) do
       accepts
       |> Enum.filter(&(is_map(&1) and matches_filters?(&1, opts)))
-      |> Enum.find(&supported?/1)
+      |> Enum.find(&supported?(&1, schemes))
       |> case do
         nil ->
           Telemetry.emit(:client, :select, :error, %{reason: :no_acceptable_requirements})
@@ -176,9 +192,13 @@ defmodule X402.Client do
   example `X402.Extensions.EIP2612GasSponsoring.enricher/2` for
   gas-sponsored Permit2 approvals.
 
-  Signing dispatches on the scheme and network of the chosen requirements;
-  this release supports `exact` on `eip155:*` networks (EIP-3009). Other
-  combinations return `{:error, {:unsupported_kind, scheme, network}}`.
+  Signing dispatches on the scheme and network of the chosen requirements
+  through `X402.Scheme.Registry`; out of the box this supports `exact` on
+  `eip155:*` networks (EIP-3009). Other combinations return
+  `{:error, {:unsupported_kind, scheme, network}}` unless a matching
+  module is passed with the `:schemes` option. Scheme modules receive the
+  validated build options, so options like `:valid_after_buffer` reach
+  `c:X402.Scheme.sign/3`.
 
   ## Options
 
@@ -296,19 +316,23 @@ defmodule X402.Client do
     end
   end
 
-  @spec supported?(map()) :: boolean()
-  defp supported?(requirements) do
+  @spec supported?(map(), [module()]) :: boolean()
+  defp supported?(requirements, schemes) do
     PaymentRequirements.validate(requirements) == :ok and
-      supported_kind?(
-        Utils.map_value(requirements, {"scheme", :scheme}),
-        Utils.map_value(requirements, {"network", :network})
-      ) and
-      match?({:ok, _domain}, EIP3009.domain(requirements))
+      case resolve_scheme(requirements, schemes) do
+        {:ok, module} -> Scheme.signs?(module) and Scheme.signable?(module, requirements)
+        :error -> false
+      end
   end
 
-  @spec supported_kind?(term(), term()) :: boolean()
-  defp supported_kind?("exact", "eip155:" <> _chain_id), do: true
-  defp supported_kind?(_scheme, _network), do: false
+  @spec resolve_scheme(map(), [module()]) :: {:ok, module()} | :error
+  defp resolve_scheme(requirements, schemes) do
+    Scheme.Registry.resolve(
+      schemes,
+      Utils.map_value(requirements, {"scheme", :scheme}),
+      Utils.map_value(requirements, {"network", :network})
+    )
+  end
 
   # -- Payload assembly -------------------------------------------------------
 
@@ -346,9 +370,10 @@ defmodule X402.Client do
     scheme = Utils.map_value(requirements, {"scheme", :scheme})
     network = Utils.map_value(requirements, {"network", :network})
 
-    if supported_kind?(scheme, network) do
-      case EIP3009.sign(requirements, signer, valid_after_buffer: opts[:valid_after_buffer]) do
-        {:ok, scheme_payload} ->
+    with {:ok, module} <- resolve_scheme(requirements, Keyword.fetch!(opts, :schemes)),
+         true <- Scheme.signs?(module) do
+      case module.sign(requirements, signer, opts) do
+        {:ok, scheme_payload} when is_map(scheme_payload) ->
           Telemetry.emit(:client, :sign, :ok, %{scheme: scheme, network: network})
           {:ok, scheme_payload}
 
@@ -360,15 +385,27 @@ defmodule X402.Client do
           })
 
           error
+
+        other ->
+          reason = {:invalid_scheme_payload, other}
+
+          Telemetry.emit(:client, :sign, :error, %{
+            reason: reason,
+            scheme: scheme,
+            network: network
+          })
+
+          {:error, reason}
       end
     else
-      Telemetry.emit(:client, :sign, :error, %{
-        reason: :unsupported_kind,
-        scheme: scheme,
-        network: network
-      })
+      _unsupported ->
+        Telemetry.emit(:client, :sign, :error, %{
+          reason: :unsupported_kind,
+          scheme: scheme,
+          network: network
+        })
 
-      {:error, {:unsupported_kind, scheme, network}}
+        {:error, {:unsupported_kind, scheme, network}}
     end
   end
 

--- a/lib/x402/client/finch.ex
+++ b/lib/x402/client/finch.ex
@@ -100,6 +100,14 @@ defmodule X402.Client.Finch do
       `X402.Client.build_payment/3` — see its `:extensions` option.
       """
     ],
+    schemes: [
+      type: {:list, {:custom, X402.Scheme, :validate_module, []}},
+      default: [],
+      doc: """
+      Additional `X402.Scheme` modules forwarded to
+      `X402.Client.build_payment/3` — see its `:schemes` option.
+      """
+    ],
     on_payment_required: [
       type: {:or, [{:fun, 1}, nil]},
       default: nil,
@@ -302,7 +310,8 @@ defmodule X402.Client.Finch do
         :asset,
         :max_amount,
         :valid_after_buffer,
-        :extensions
+        :extensions,
+        :schemes
       ])
 
   @spec finalize(map()) :: response()

--- a/lib/x402/payment_signature.ex
+++ b/lib/x402/payment_signature.ex
@@ -14,22 +14,37 @@ defmodule X402.PaymentSignature do
   v1 wire format (v1 payments arrive in the `X-PAYMENT` header, which
   `X402.Plug.PaymentGate` never reads); rejecting explicitly is safer than the
   false interop of validating a shape no facilitator settles.
+
+  Scheme-specific structural validation (for example the `upto` ceiling
+  check) dispatches through `X402.Scheme.Registry`; pass additional
+  `X402.Scheme` modules with the `:schemes` option of `validate/3` or
+  `decode_and_validate/3`. Kinds with no registered scheme module pass
+  through with `:ok` — the facilitator remains the authority.
   """
 
   alias X402.PaymentRequirements
+  alias X402.Scheme
   alias X402.Telemetry
   alias X402.Utils
 
   # Single source of truth for the 8 KB decode guard — see X402.Header.
   @max_header_bytes X402.Header.max_header_bytes()
 
+  @validate_opts_schema [
+    schemes: [
+      type: {:list, {:custom, Scheme, :validate_module, []}},
+      default: [],
+      doc: """
+      Additional `X402.Scheme` modules consulted (before the built-ins) for
+      scheme-specific payload validation — see `X402.Scheme.Registry`.
+      """
+    ]
+  ]
+
   @type decode_error :: :invalid_base64 | :invalid_json | :payload_too_large
-  @type upto_validation_error ::
-          :missing_max_price
-          | :missing_payment_value
-          | :invalid_max_price
-          | :invalid_payment_value
-          | :payment_value_exceeds_max_price
+
+  @typedoc "See `t:X402.Scheme.UptoEVM.validation_error/0`."
+  @type upto_validation_error :: X402.Scheme.UptoEVM.validation_error()
 
   @type validate_error ::
           :invalid_payload
@@ -158,7 +173,7 @@ defmodule X402.PaymentSignature do
       {:error, :invalid_payload}
   """
   @spec validate(map()) :: {:ok, map()} | {:error, validate_error()}
-  def validate(payload) when is_map(payload), do: do_validate(payload, %{})
+  def validate(payload) when is_map(payload), do: do_validate(payload, %{}, [])
 
   def validate(_payload) do
     Telemetry.emit(:payment_signature, :validate, :error, %{reason: :invalid_payload})
@@ -174,7 +189,7 @@ defmodule X402.PaymentSignature do
   """
   @spec validate(map(), map()) :: {:ok, map()} | {:error, validate_error()}
   def validate(payload, requirements) when is_map(payload) and is_map(requirements) do
-    do_validate(payload, requirements)
+    do_validate(payload, requirements, [])
   end
 
   def validate(_payload, _requirements) do
@@ -182,17 +197,44 @@ defmodule X402.PaymentSignature do
     {:error, :invalid_payload}
   end
 
-  @spec do_validate(map(), map()) :: {:ok, map()} | {:error, validate_error()}
-  defp do_validate(payload, requirements) do
+  @doc since: "0.6.0", group: :verification
+  @doc """
+  Validates a decoded `PAYMENT-SIGNATURE` payload with custom schemes.
+
+  Behaves like `validate/2`, additionally consulting the given
+  `X402.Scheme` modules (before the built-ins) for scheme-specific payload
+  validation — see `X402.Scheme.Registry` for the resolution rules.
+
+  ## Options
+
+  #{NimbleOptions.docs(@validate_opts_schema)}
+  """
+  @spec validate(map(), map(), keyword()) ::
+          {:ok, map()} | {:error, validate_error() | term()}
+  def validate(payload, requirements, opts)
+      when is_map(payload) and is_map(requirements) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @validate_opts_schema)
+    do_validate(payload, requirements, Keyword.fetch!(opts, :schemes))
+  end
+
+  def validate(_payload, _requirements, _opts) do
+    Telemetry.emit(:payment_signature, :validate, :error, %{reason: :invalid_payload})
+    {:error, :invalid_payload}
+  end
+
+  @spec do_validate(map(), map(), [module()]) ::
+          {:ok, map()} | {:error, validate_error() | term()}
+  defp do_validate(payload, requirements, schemes) do
     case Utils.map_value(payload, {"x402Version", :x402Version}) do
-      2 -> validate_v2(payload, requirements)
+      2 -> validate_v2(payload, requirements, schemes)
       version when version in [nil, 1] -> validation_error({:unsupported_x402_version, version})
       _version -> validation_error(:invalid_x402_version)
     end
   end
 
-  @spec validate_v2(map(), map()) :: {:ok, map()} | {:error, validate_error()}
-  defp validate_v2(payload, requirements) do
+  @spec validate_v2(map(), map(), [module()]) ::
+          {:ok, map()} | {:error, validate_error() | term()}
+  defp validate_v2(payload, requirements, schemes) do
     accepted = Utils.map_value(payload, {"accepted", :accepted})
     scheme_payload = Utils.map_value(payload, {"payload", :payload})
     resource = Utils.map_value(payload, {"resource", :resource})
@@ -204,7 +246,8 @@ defmodule X402.PaymentSignature do
          true <- is_nil(extensions) or is_map(extensions),
          :ok <- PaymentRequirements.validate(accepted),
          :ok <- match_v2_requirements(requirements, accepted),
-         :ok <- validate_scheme(payload, effective_requirements(requirements, accepted)) do
+         :ok <-
+           validate_scheme(payload, effective_requirements(requirements, accepted), schemes) do
       validation_success(payload)
     else
       false -> validation_error(:invalid_payload)
@@ -234,7 +277,7 @@ defmodule X402.PaymentSignature do
     {:ok, payload}
   end
 
-  @spec validation_error(validate_error()) :: {:error, validate_error()}
+  @spec validation_error(validate_error() | term()) :: {:error, validate_error() | term()}
   defp validation_error(reason) do
     Telemetry.emit(:payment_signature, :validate, :error, %{reason: reason})
     {:error, reason}
@@ -261,8 +304,26 @@ defmodule X402.PaymentSignature do
   @spec decode_and_validate(String.t(), map()) ::
           {:ok, map()} | {:error, decode_and_validate_error()}
   def decode_and_validate(value, requirements) when is_map(requirements) do
+    decode_and_validate(value, requirements, [])
+  end
+
+  def decode_and_validate(_value, _requirements) do
+    Telemetry.emit(:payment_signature, :decode_and_validate, :error, %{reason: :invalid_payload})
+    {:error, :invalid_payload}
+  end
+
+  @doc since: "0.6.0", group: :verification
+  @doc """
+  Decodes and validates a `PAYMENT-SIGNATURE` header with custom schemes.
+
+  Behaves like `decode_and_validate/2`; `opts` are passed to `validate/3`.
+  """
+  @spec decode_and_validate(String.t(), map(), keyword()) ::
+          {:ok, map()} | {:error, decode_and_validate_error() | term()}
+  def decode_and_validate(value, requirements, opts)
+      when is_map(requirements) and is_list(opts) do
     with {:ok, decoded} <- decode(value),
-         {:ok, validated} <- validate(decoded, requirements) do
+         {:ok, validated} <- validate(decoded, requirements, opts) do
       result = {:ok, validated}
       Telemetry.emit(:payment_signature, :decode_and_validate, :ok, %{})
       result
@@ -273,23 +334,22 @@ defmodule X402.PaymentSignature do
     end
   end
 
-  def decode_and_validate(_value, _requirements) do
+  def decode_and_validate(_value, _requirements, _opts) do
     Telemetry.emit(:payment_signature, :decode_and_validate, :error, %{reason: :invalid_payload})
     {:error, :invalid_payload}
   end
 
-  @spec validate_scheme(map(), map()) ::
-          :ok | {:error, {:invalid_upto_payment, upto_validation_error()}}
-  defp validate_scheme(payload, requirements) do
-    case effective_scheme(payload, requirements) do
-      "upto" ->
-        with {:ok, max_price} <- extract_max_price(payload, requirements),
-             {:ok, payment_value} <- extract_payment_value(payload) do
-          ensure_not_exceeds(payment_value, max_price)
-        end
+  # Scheme-specific structural validation dispatches through the scheme
+  # registry. Kinds with no registered scheme module pass through with :ok —
+  # the historical behavior for unknown schemes.
+  @spec validate_scheme(map(), map(), [module()]) :: :ok | {:error, term()}
+  defp validate_scheme(payload, requirements, schemes) do
+    scheme = effective_scheme(payload, requirements)
+    network = effective_network(payload, requirements)
 
-      _scheme ->
-        :ok
+    case Scheme.Registry.resolve(schemes, scheme, network) do
+      {:ok, module} -> Scheme.validate_payload(module, payload, requirements, [])
+      :error -> :ok
     end
   end
 
@@ -300,81 +360,10 @@ defmodule X402.PaymentSignature do
       Utils.nested_map_value(payload, [{"accepted", :accepted}, {"scheme", :scheme}])
   end
 
-  @spec extract_max_price(map(), map()) ::
-          {:ok, {non_neg_integer(), non_neg_integer()}}
-          | {:error, {:invalid_upto_payment, upto_validation_error()}}
-  defp extract_max_price(payload, requirements) do
-    value =
-      Utils.first_present([
-        Utils.map_value(requirements, {"amount", :amount}),
-        Utils.map_value(requirements, {"maxPrice", :maxPrice}),
-        Utils.map_value(requirements, {"maxAmountRequired", :maxAmountRequired}),
-        Utils.nested_map_value(payload, [{"accepted", :accepted}, {"amount", :amount}]),
-        Utils.map_value(payload, {"maxPrice", :maxPrice}),
-        Utils.map_value(payload, {"maxAmountRequired", :maxAmountRequired})
-      ])
-
-    case value do
-      nil ->
-        {:error, {:invalid_upto_payment, :missing_max_price}}
-
-      max_price ->
-        case Utils.parse_decimal(max_price) do
-          {:ok, parsed} -> {:ok, parsed}
-          :error -> {:error, {:invalid_upto_payment, :invalid_max_price}}
-        end
-    end
-  end
-
-  @spec extract_payment_value(map()) ::
-          {:ok, {non_neg_integer(), non_neg_integer()}}
-          | {:error, {:invalid_upto_payment, upto_validation_error()}}
-  defp extract_payment_value(payload) do
-    value =
-      Utils.first_present([
-        Utils.nested_map_value(payload, [
-          {"payload", :payload},
-          {"permit2Authorization", :permit2Authorization},
-          {"permitted", :permitted},
-          {"amount", :amount}
-        ]),
-        Utils.nested_map_value(payload, [
-          {"permit2Authorization", :permit2Authorization},
-          {"permitted", :permitted},
-          {"amount", :amount}
-        ]),
-        Utils.nested_map_value(payload, [{"payload", :payload}, {"maxAmount", :maxAmount}]),
-        Utils.map_value(payload, {"maxAmount", :maxAmount}),
-        Utils.map_value(payload, {"value", :value}),
-        Utils.nested_map_value(payload, [{"payload", :payload}, {"value", :value}]),
-        Utils.nested_map_value(payload, [
-          {"payload", :payload},
-          {"authorization", :authorization},
-          {"value", :value}
-        ]),
-        Utils.nested_map_value(payload, [{"authorization", :authorization}, {"value", :value}])
-      ])
-
-    case value do
-      nil ->
-        {:error, {:invalid_upto_payment, :missing_payment_value}}
-
-      payment_value ->
-        case Utils.parse_decimal(payment_value) do
-          {:ok, parsed} -> {:ok, parsed}
-          :error -> {:error, {:invalid_upto_payment, :invalid_payment_value}}
-        end
-    end
-  end
-
-  @spec ensure_not_exceeds(
-          {non_neg_integer(), non_neg_integer()},
-          {non_neg_integer(), non_neg_integer()}
-        ) :: :ok | {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
-  defp ensure_not_exceeds(payment_value, max_price) do
-    case Utils.compare_decimal(payment_value, max_price) do
-      :gt -> {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
-      _comparison -> :ok
-    end
+  @spec effective_network(map(), map()) :: String.t() | atom() | nil
+  defp effective_network(payload, requirements) do
+    Utils.map_value(requirements, {"network", :network}) ||
+      Utils.map_value(payload, {"network", :network}) ||
+      Utils.nested_map_value(payload, [{"accepted", :accepted}, {"network", :network}])
   end
 end

--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -10,10 +10,13 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     2. Requests with `PAYMENT-SIGNATURE` are decoded as `PaymentPayload` v2.
     3. `PaymentPayload.accepted` and echoed extensions are matched against the
        complete requirements advertised by the route.
-    4. Cheap local pre-checks run on the EIP-3009-style authorization object
-       (payTo binding, exact amount equality, validity window) so certain
-       mismatches answer 402 without a facilitator round-trip — see the
-       `:local_prechecks` option.
+    4. Cheap local pre-checks run for the matched scheme/network — resolved
+       through `X402.Scheme.Registry` — so certain mismatches answer 402
+       without a facilitator round-trip. The built-in EVM schemes check the
+       EIP-3009-style authorization object (payTo binding, exact amount
+       equality, validity window); see the `:local_prechecks` option.
+       Kinds with no registered scheme module skip straight to the
+       facilitator.
     5. Matched requirements are verified before the protected handler runs.
     6. Successful handler responses are settled immediately before they are
        sent. Successful settlements attach a `PAYMENT-RESPONSE` header and assign
@@ -93,6 +96,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     alias X402.PaymentResponse
     alias X402.PaymentSignature
     alias X402.Paywall
+    alias X402.Scheme
     alias X402.Utils
 
     require Logger
@@ -116,9 +120,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     @supported_payment_flow "authorization"
     @settlement_amount_private :x402_settlement_amount
     @default_max_timeout_seconds 60
-    # Mirrors the 6-second buffer the reference facilitators apply to
-    # validBefore so a payment does not expire mid-settlement.
-    @precheck_time_buffer_seconds 6
+    @precheck_time_buffer_seconds Scheme.EVM.time_buffer_seconds()
     @default_description "Payment required"
     @default_mime_type "application/json"
 
@@ -134,9 +136,12 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
 
     @accept_option_schema [
       scheme: [
-        type: {:in, @route_schemes},
+        type: :string,
         default: "exact",
-        doc: "Payment scheme (`exact` or `upto`)."
+        doc: """
+        Payment scheme (`exact`, `upto`, or the scheme name of a module
+        passed in the plug's `:schemes` option).
+        """
       ],
       price: [
         type: {:custom, __MODULE__, :validate_atomic_amount, []},
@@ -195,9 +200,13 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
         """
       ],
       scheme: [
-        type: {:in, @route_schemes},
+        type: :string,
         default: "exact",
-        doc: "Single-option scheme (used when `:accepts` is empty)."
+        doc: """
+        Single-option scheme (used when `:accepts` is empty): `exact`,
+        `upto`, or the scheme name of a module passed in the plug's
+        `:schemes` option.
+        """
       ],
       price: [
         type: {:custom, __MODULE__, :validate_atomic_amount, []},
@@ -303,17 +312,30 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
         required: true,
         doc: "Route gate definitions (see route options below)."
       ],
+      schemes: [
+        type: {:list, {:custom, Scheme, :validate_module, []}},
+        default: [],
+        doc: """
+        Additional `X402.Scheme` modules consulted (before the built-ins)
+        for scheme-specific payload validation and local pre-checks — see
+        `X402.Scheme.Registry`. Routes may use the scheme names these
+        modules declare.
+        """
+      ],
       local_prechecks: [
         type: :boolean,
         default: true,
         doc: """
-        Run cheap local checks on the EIP-3009-style `payload.authorization`
-        object before calling the facilitator: `to` must equal the route's
+        Run cheap local checks before calling the facilitator, dispatched to
+        the `X402.Scheme` module matching the requirements' scheme/network.
+        The built-in EVM schemes check the EIP-3009-style
+        `payload.authorization` object: `to` must equal the route's
         `pay_to`, `value` must equal the advertised amount for `"exact"`
-        routes, and the `validAfter`/`validBefore` window must cover now (with
-        a #{@precheck_time_buffer_seconds}s settlement buffer). Fields absent
-        from the payload are skipped, so schemes with other payload shapes
-        pass through untouched. Failures answer 402 without a facilitator
+        routes, and the `validAfter`/`validBefore` window must cover now
+        (with a #{@precheck_time_buffer_seconds}s settlement buffer). Fields
+        absent from the payload are skipped — as are kinds with no
+        registered scheme module — so payloads with other shapes pass
+        through untouched. Failures answer 402 without a facilitator
         round-trip.
         """
       ],
@@ -345,6 +367,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
             payment_identifier_cache: Cache.adapter() | nil,
             claim_order: claim_order(),
             routes: [compiled_route()],
+            schemes: [module()],
             local_prechecks: boolean(),
             paywall: module() | nil
           }
@@ -435,18 +458,21 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     def validate_payment_identifier_cache(server), do: {:ok, {ETSCache, server}}
 
     @doc false
-    @spec validate_route(term()) :: {:ok, map()} | {:error, String.t()}
-    def validate_route(route) when is_map(route) do
+    @spec validate_route(term(), [String.t()]) :: {:ok, map()} | {:error, String.t()}
+    def validate_route(route, allowed_schemes \\ @route_schemes)
+
+    def validate_route(route, allowed_schemes) when is_map(route) do
       with {:ok, keyword_route} <- map_to_keyword(route),
            {:ok, validated} <- validate_route_options(keyword_route),
            validated_map = Map.new(validated),
            :ok <- ensure_accepts_source(validated_map),
+           :ok <- ensure_route_schemes(validated_map, allowed_schemes),
            :ok <- ensure_supported_payment_flow(validated_map) do
         {:ok, validated_map}
       end
     end
 
-    def validate_route(_route), do: {:error, "expected a route map"}
+    def validate_route(_route, _allowed_schemes), do: {:error, "expected a route map"}
 
     @doc since: "0.1.0"
     @doc """
@@ -466,7 +492,8 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     """
     @spec init(keyword()) :: options()
     def init(opts) when is_list(opts) do
-      validated_opts = NimbleOptions.validate!(opts, @options_schema)
+      schemes = validated_schemes!(opts)
+      validated_opts = NimbleOptions.validate!(opts, options_schema(schemes))
 
       cache = Keyword.get(validated_opts, :payment_identifier_cache)
 
@@ -489,9 +516,33 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
           validated_opts
           |> Keyword.fetch!(:routes)
           |> Enum.map(&compile_route/1),
+        schemes: schemes,
         local_prechecks: Keyword.fetch!(validated_opts, :local_prechecks),
         paywall: Keyword.fetch!(validated_opts, :paywall)
       }
+    end
+
+    # The :schemes option is validated first, on its own, because the route
+    # validator needs the scheme names the configured modules declare.
+    @spec validated_schemes!(keyword()) :: [module()]
+    defp validated_schemes!(opts) do
+      opts
+      |> Keyword.take([:schemes])
+      |> NimbleOptions.validate!(Keyword.take(@options_schema, [:schemes]))
+      |> Keyword.fetch!(:schemes)
+    end
+
+    @spec options_schema([module()]) :: keyword()
+    defp options_schema(schemes) do
+      allowed_schemes = @route_schemes ++ Enum.map(schemes, & &1.scheme())
+
+      Keyword.update!(@options_schema, :routes, fn spec ->
+        Keyword.put(
+          spec,
+          :type,
+          {:list, {:custom, __MODULE__, :validate_route, [allowed_schemes]}}
+        )
+      end)
     end
 
     @doc since: "0.4.0"
@@ -596,8 +647,8 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
       payment_id = :crypto.hash(:sha256, header) |> Base.encode16(case: :lower)
 
       with {:ok, payment_payload, requirements} <-
-             decode_and_validate_payment(header, accepts, route.extensions),
-           :ok <- run_local_prechecks(opts.local_prechecks, payment_payload, requirements),
+             decode_and_validate_payment(header, accepts, route.extensions, opts.schemes),
+           :ok <- run_local_prechecks(opts, payment_payload, requirements),
            :ok <- claim_and_verify(opts, payment_id, payment_payload, requirements) do
         settlement_context = %{
           facilitator: opts.facilitator,
@@ -986,6 +1037,28 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
       end
     end
 
+    @spec ensure_route_schemes(map(), [String.t()]) :: :ok | {:error, String.t()}
+    defp ensure_route_schemes(route, allowed_schemes) do
+      route_schemes =
+        case Map.get(route, :accepts, []) do
+          accepts when is_list(accepts) and accepts != [] ->
+            Enum.map(accepts, &Map.get(&1, :scheme, "exact"))
+
+          _empty ->
+            [Map.get(route, :scheme, "exact")]
+        end
+
+      case Enum.reject(route_schemes, &(&1 in allowed_schemes)) do
+        [] ->
+          :ok
+
+        [unknown | _rest] ->
+          {:error,
+           "invalid value for :scheme option: expected one of #{inspect(allowed_schemes)} " <>
+             "(built-ins plus the scheme names of modules in :schemes), got: #{inspect(unknown)}"}
+      end
+    end
+
     @spec ensure_supported_payment_flow(map()) :: :ok | {:error, String.t()}
     defp ensure_supported_payment_flow(%{accepts: accepts})
          when is_list(accepts) and accepts != [] do
@@ -1106,18 +1179,26 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
       end
     end
 
-    @spec decode_and_validate_payment(String.t(), [map()], map()) ::
+    @spec decode_and_validate_payment(String.t(), [map()], map(), [module()]) ::
             {:ok, map(), map()} | {:error, term()}
-    defp decode_and_validate_payment(header, accepts, advertised_extensions)
+    defp decode_and_validate_payment(header, accepts, advertised_extensions, schemes)
          when is_list(accepts) and is_map(advertised_extensions) do
       with {:ok, payload} <- PaymentSignature.decode(header),
            :ok <- ensure_v2_payload(payload),
-           {:ok, payload} <- PaymentSignature.validate(payload),
+           {:ok, payload} <- validate_payment_payload(payload, schemes),
            {:ok, matched} <- find_matching_requirements(accepts, payload),
            :ok <- validate_extensions(payload, advertised_extensions) do
         {:ok, payload, matched}
       end
     end
+
+    # With no custom schemes the historical validate/1 path is kept as-is;
+    # custom schemes are threaded through validate/3.
+    @spec validate_payment_payload(map(), [module()]) :: {:ok, map()} | {:error, term()}
+    defp validate_payment_payload(payload, []), do: PaymentSignature.validate(payload)
+
+    defp validate_payment_payload(payload, schemes),
+      do: PaymentSignature.validate(payload, %{}, schemes: schemes)
 
     @spec ensure_v2_payload(map()) :: :ok | {:error, :invalid_x402_version}
     defp ensure_v2_payload(payload) do
@@ -1156,157 +1237,24 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
       end
     end
 
-    # Cheap local checks on the EIP-3009-style authorization object, run before
-    # the facilitator round-trip. They mirror the first checks every reference
-    # facilitator performs (payTo equality, exact amount equality, time
-    # window), so junk traffic is rejected without paying a verify call.
-    # Payloads without a `payload.authorization` map — other schemes, Permit2 —
-    # are skipped entirely, as is any individual absent field: the facilitator
-    # remains the authority, these checks only fail fast on certain mismatch.
-    @type precheck_failure ::
-            :pay_to_mismatch
-            | :amount_mismatch
-            | :invalid_authorization_value
-            | :authorization_not_yet_valid
-            | :authorization_expired
-            | :invalid_authorization_timing
+    # Cheap local checks run before the facilitator round-trip, dispatched
+    # to the X402.Scheme module resolved for the matched requirements'
+    # scheme/network (X402.Scheme.EVM implements the built-in EVM checks).
+    # Kinds with no registered scheme module are skipped entirely — exactly
+    # like the historical absent-authorization skip: the facilitator remains
+    # the authority, pre-checks only fail fast on certain mismatch.
+    @spec run_local_prechecks(options(), map(), map()) :: :ok | {:error, term()}
+    defp run_local_prechecks(%{local_prechecks: false}, _payload, _requirements), do: :ok
 
-    @spec run_local_prechecks(boolean(), map(), map()) ::
-            :ok | {:error, {:precheck_failed, precheck_failure()}}
-    defp run_local_prechecks(false, _payload, _requirements), do: :ok
-
-    defp run_local_prechecks(true, payload, requirements) do
-      case eip3009_authorization(payload) do
-        nil ->
-          :ok
-
-        authorization ->
-          with :ok <- precheck_pay_to(authorization, requirements),
-               :ok <- precheck_exact_amount(authorization, requirements) do
-            precheck_timing(authorization)
-          end
-      end
-    end
-
-    @spec eip3009_authorization(map()) :: map() | nil
-    defp eip3009_authorization(payload) do
-      case Utils.nested_map_value(payload, [
-             {"payload", :payload},
-             {"authorization", :authorization}
-           ]) do
-        authorization when is_map(authorization) -> authorization
-        _other -> nil
-      end
-    end
-
-    @spec precheck_pay_to(map(), map()) ::
-            :ok | {:error, {:precheck_failed, :pay_to_mismatch}}
-    defp precheck_pay_to(authorization, requirements) do
-      to = Utils.map_value(authorization, {"to", :to})
-      pay_to = Utils.map_value(requirements, {"payTo", :payTo})
-
-      case is_binary(to) and is_binary(pay_to) do
-        true ->
-          case same_address?(to, pay_to) do
-            true -> :ok
-            false -> {:error, {:precheck_failed, :pay_to_mismatch}}
-          end
-
-        false ->
-          :ok
-      end
-    end
-
-    @spec same_address?(String.t(), String.t()) :: boolean()
-    defp same_address?(left, right) do
-      case hex_address?(left) and hex_address?(right) do
-        true -> String.downcase(left) == String.downcase(right)
-        false -> left == right
-      end
-    end
-
-    @spec hex_address?(String.t()) :: boolean()
-    defp hex_address?(<<"0x", rest::binary>>) when rest != "",
-      do: Regex.match?(~r/^[0-9a-fA-F]+$/, rest)
-
-    defp hex_address?(_address), do: false
-
-    @spec precheck_exact_amount(map(), map()) ::
-            :ok | {:error, {:precheck_failed, :amount_mismatch | :invalid_authorization_value}}
-    defp precheck_exact_amount(authorization, requirements) do
+    defp run_local_prechecks(%{local_prechecks: true, schemes: schemes}, payload, requirements) do
       scheme = Utils.map_value(requirements, {"scheme", :scheme})
-      value = Utils.map_value(authorization, {"value", :value})
-      amount = Utils.map_value(requirements, {"amount", :amount})
+      network = Utils.map_value(requirements, {"network", :network})
 
-      case scheme == "exact" and not is_nil(value) and not is_nil(amount) do
-        true -> compare_exact_amount(value, amount)
-        false -> :ok
+      case Scheme.Registry.resolve(schemes, scheme, network) do
+        {:ok, module} -> Scheme.precheck(module, payload, requirements, [])
+        :error -> :ok
       end
     end
-
-    @spec compare_exact_amount(term(), term()) ::
-            :ok | {:error, {:precheck_failed, :amount_mismatch | :invalid_authorization_value}}
-    defp compare_exact_amount(value, amount) do
-      with {:ok, parsed_value} <- parse_precheck_amount(value),
-           {:ok, parsed_amount} <- parse_precheck_amount(amount) do
-        case Utils.compare_decimal(parsed_value, parsed_amount) do
-          :eq -> :ok
-          _other -> {:error, {:precheck_failed, :amount_mismatch}}
-        end
-      end
-    end
-
-    @spec parse_precheck_amount(term()) ::
-            {:ok, {non_neg_integer(), non_neg_integer()}}
-            | {:error, {:precheck_failed, :invalid_authorization_value}}
-    defp parse_precheck_amount(value) do
-      case Utils.parse_decimal(value) do
-        {:ok, parsed} -> {:ok, parsed}
-        :error -> {:error, {:precheck_failed, :invalid_authorization_value}}
-      end
-    end
-
-    @spec precheck_timing(map()) ::
-            :ok
-            | {:error,
-               {:precheck_failed,
-                :authorization_not_yet_valid
-                | :authorization_expired
-                | :invalid_authorization_timing}}
-    defp precheck_timing(authorization) do
-      now = System.system_time(:second)
-
-      with {:ok, valid_after} <-
-             optional_unix_time(Utils.map_value(authorization, {"validAfter", :validAfter})),
-           {:ok, valid_before} <-
-             optional_unix_time(Utils.map_value(authorization, {"validBefore", :validBefore})) do
-        cond do
-          is_integer(valid_after) and valid_after > now ->
-            {:error, {:precheck_failed, :authorization_not_yet_valid}}
-
-          is_integer(valid_before) and valid_before < now + @precheck_time_buffer_seconds ->
-            {:error, {:precheck_failed, :authorization_expired}}
-
-          true ->
-            :ok
-        end
-      end
-    end
-
-    @spec optional_unix_time(term()) ::
-            {:ok, integer() | nil} | {:error, {:precheck_failed, :invalid_authorization_timing}}
-    defp optional_unix_time(nil), do: {:ok, nil}
-    defp optional_unix_time(value) when is_integer(value), do: {:ok, value}
-
-    defp optional_unix_time(value) when is_binary(value) do
-      case Integer.parse(value) do
-        {parsed, ""} -> {:ok, parsed}
-        _other -> {:error, {:precheck_failed, :invalid_authorization_timing}}
-      end
-    end
-
-    defp optional_unix_time(_value),
-      do: {:error, {:precheck_failed, :invalid_authorization_timing}}
 
     @spec ensure_verify_success(map()) ::
             :ok
@@ -1636,6 +1584,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
     defp status_for_reason({:missing_fields, _fields}), do: 400
     defp status_for_reason({:precheck_failed, _reason}), do: 402
     defp status_for_reason({:invalid_upto_payment, _reason}), do: 400
+    defp status_for_reason({:invalid_scheme_payment, _reason}), do: 400
     defp status_for_reason({:invalid_fields, _fields}), do: 400
     defp status_for_reason(:invalid_payment_requirements), do: 400
     defp status_for_reason(:extension_echo_mismatch), do: 400
@@ -1732,6 +1681,7 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
       do: "payment authorization does not satisfy the payment requirements"
 
     defp rejection_error({:invalid_upto_payment, _reason}), do: "invalid_payload"
+    defp rejection_error({:invalid_scheme_payment, _reason}), do: "invalid_payload"
     defp rejection_error({:invalid_fields, _fields}), do: "invalid_payload"
     defp rejection_error(:invalid_payment_requirements), do: "invalid_payload"
     defp rejection_error(:extension_echo_mismatch), do: "invalid_payload"

--- a/lib/x402/scheme.ex
+++ b/lib/x402/scheme.ex
@@ -1,0 +1,289 @@
+defmodule X402.Scheme do
+  @moduledoc """
+  Behaviour for pluggable x402 payment schemes.
+
+  A *scheme* is x402's unit of extension: the pairing of a payment scheme
+  name (`"exact"`, `"upto"`, ...) with a family of CAIP-2 networks
+  (`"eip155:*"`, `"solana:*"`, ...). Everything scheme-specific this library
+  does — deciding whether the client can sign an advertised requirement,
+  producing the signed scheme `payload`, structurally validating an incoming
+  `PAYMENT-SIGNATURE`, and running cheap local pre-checks before the
+  facilitator round-trip — dispatches through this behaviour. Adding support
+  for a new chain or scheme means writing **one module** and passing it as
+  an option, not editing `X402.Client`, `X402.PaymentSignature`, or
+  `X402.Plug.PaymentGate`.
+
+  The built-in schemes are `X402.Scheme.ExactEVM` (`exact` on `eip155:*`
+  networks via EIP-3009) and `X402.Scheme.UptoEVM` (`upto` on `eip155:*`
+  networks, server-side only). Resolution — including wildcard CAIP-2
+  matching and exact-match precedence — is handled by
+  `X402.Scheme.Registry`.
+
+  ## Callbacks and the roles they serve
+
+  | Callback               | Role     | Consulted by                                 |
+  |------------------------|----------|----------------------------------------------|
+  | `c:scheme/0`           | metadata | `X402.Scheme.Registry.resolve/3`             |
+  | `c:networks/0`         | metadata | `X402.Scheme.Registry.resolve/3`             |
+  | `c:signable?/1`        | client   | `X402.Client.select_requirements/2`          |
+  | `c:sign/3`             | client   | `X402.Client.build_payment/3`                |
+  | `c:validate_payload/3` | server   | `X402.PaymentSignature.validate/3`           |
+  | `c:precheck/3`         | server   | `X402.Plug.PaymentGate` (`:local_prechecks`) |
+
+  Only `c:scheme/0` and `c:networks/0` are required. A scheme module
+  implements the callbacks for the roles it plays: a client-only scheme can
+  omit `c:validate_payload/3` and `c:precheck/3`; a server-only scheme (like
+  `X402.Scheme.UptoEVM`) can omit `c:sign/3`. Missing optional callbacks are
+  neutral — signing falls back to the `{:unsupported_kind, scheme, network}`
+  error, while validation and pre-checks pass through with `:ok` (the
+  facilitator remains the authority).
+
+  ## Adding a chain or scheme in one module
+
+  Implement the behaviour:
+
+      defmodule MyApp.CashScheme do
+        @behaviour X402.Scheme
+
+        @impl X402.Scheme
+        def scheme, do: "cash"
+
+        @impl X402.Scheme
+        def networks, do: ["local:*"]
+
+        # Client side: produce the scheme payload carried as
+        # PaymentPayload.payload.
+        @impl X402.Scheme
+        def sign(requirements, _signer, _opts) do
+          {:ok, %{"note" => "IOU " <> requirements["amount"]}}
+        end
+
+        # Server side: structural validation of the decoded payload.
+        @impl X402.Scheme
+        def validate_payload(payload, _requirements, _opts) do
+          case get_in(payload, ["payload", "note"]) do
+            note when is_binary(note) -> :ok
+            _missing -> {:error, {:invalid_scheme_payment, :missing_note}}
+          end
+        end
+
+        # Server side: cheap local pre-checks before the facilitator call.
+        @impl X402.Scheme
+        def precheck(payload, _requirements, _opts) do
+          case get_in(payload, ["payload", "counterfeit"]) do
+            true -> {:error, {:precheck_failed, :counterfeit_note}}
+            _other -> :ok
+          end
+        end
+      end
+
+  Then pass it where you use the SDK — every entry point takes a `:schemes`
+  option (a list of modules consulted before the built-ins):
+
+      # Resource server: gate routes may now use scheme "cash".
+      plug X402.Plug.PaymentGate,
+        schemes: [MyApp.CashScheme],
+        routes: [
+          %{
+            method: :get,
+            path: "/paid",
+            scheme: "cash",
+            price: "5",
+            network: "local:test",
+            asset: "note",
+            pay_to: "till"
+          }
+        ]
+
+      # Payer client: "cash" requirements become selectable and signable.
+      X402.Client.build_payment(payment_required, signer, schemes: [MyApp.CashScheme])
+
+      # Standalone header validation.
+      X402.PaymentSignature.validate(payload, requirements, schemes: [MyApp.CashScheme])
+
+  There is no global registration and no application environment: scheme
+  modules are passed explicitly as options, so two gates (or two clients) in
+  the same VM can support different scheme sets. A user module listed in
+  `:schemes` is consulted before the built-ins and can override them — see
+  `X402.Scheme.Registry` for the exact precedence rules.
+
+  ## Error conventions
+
+  * `c:sign/3` returns `{:ok, scheme_payload}` where `scheme_payload` is the
+    map carried as the v2 `PaymentPayload.payload`, or `{:error, reason}`.
+  * `c:validate_payload/3` failures should be
+    `{:error, {:invalid_scheme_payment, reason}}`, which
+    `X402.Plug.PaymentGate` answers with HTTP 400 Invalid Request (the
+    built-in `upto` scheme keeps its historical
+    `{:invalid_upto_payment, reason}` tuples, mapped the same way).
+    Unrecognized error shapes fail closed as HTTP 500.
+  * `c:precheck/3` failures should be `{:error, {:precheck_failed, reason}}`
+    so the gate answers 402 without a facilitator round-trip. Pre-checks
+    must only fail fast on certain mismatch — the facilitator remains the
+    authority.
+  """
+
+  alias X402.Signer
+
+  @typedoc "A module implementing `X402.Scheme`."
+  @type t :: module()
+
+  @doc """
+  The x402 scheme name this module implements (for example `"exact"`).
+  """
+  @callback scheme() :: String.t()
+
+  @doc """
+  The CAIP-2 network patterns this module supports.
+
+  A pattern is either an exact CAIP-2 identifier (`"eip155:8453"`) or a
+  prefix wildcard ending in `*` (`"eip155:*"`, or `"*"` for every network).
+  """
+  @callback networks() :: [String.t()]
+
+  @doc """
+  Whether the client can sign this specific requirements entry.
+
+  Called during `X402.Client.select_requirements/2` after structural
+  validation, letting a scheme reject entries that are missing
+  scheme-specific data (for example EIP-712 domain fields in `extra`).
+  Optional — when not implemented, every entry for a matching
+  scheme/network is considered signable.
+  """
+  @callback signable?(requirements :: map()) :: boolean()
+
+  @doc """
+  Signs the scheme-specific payment `payload` for the given requirements.
+
+  Receives the requirements entry exactly as the server advertised it, the
+  `X402.Signer`, and the client's validated build options (schemes that use
+  options — such as `:valid_after_buffer` — should `Keyword.take/2` what
+  they need). Returns the map carried as `PaymentPayload.payload`.
+  Optional — when not implemented, the scheme cannot be selected or signed
+  by `X402.Client`.
+  """
+  @callback sign(requirements :: map(), signer :: Signer.t(), opts :: keyword()) ::
+              {:ok, map()} | {:error, term()}
+
+  @doc """
+  Structurally validates a decoded `PAYMENT-SIGNATURE` payload.
+
+  Called by `X402.PaymentSignature.validate/3` after envelope validation,
+  with the effective requirements (the caller-supplied requirements, or the
+  payload's own `accepted` object when none were given). Optional — when
+  not implemented, validation passes through with `:ok`.
+  """
+  @callback validate_payload(payload :: map(), requirements :: map(), opts :: keyword()) ::
+              :ok | {:error, term()}
+
+  @doc """
+  Cheap local pre-checks run by `X402.Plug.PaymentGate` before the
+  facilitator round-trip.
+
+  Failures should be `{:error, {:precheck_failed, reason}}` (answered with
+  HTTP 402). Optional — when not implemented, the gate skips straight to
+  the facilitator.
+  """
+  @callback precheck(payload :: map(), requirements :: map(), opts :: keyword()) ::
+              :ok | {:error, term()}
+
+  @optional_callbacks signable?: 1, sign: 3, validate_payload: 3, precheck: 3
+
+  @required_callbacks [{:scheme, 0}, {:networks, 0}]
+
+  @doc since: "0.6.0"
+  @doc """
+  Validates that a term is a module implementing `X402.Scheme`.
+
+  Returns `{:ok, module}` for use as a NimbleOptions `{:custom, ...}`
+  validator — this is what backs the `:schemes` option on
+  `X402.Client.build_payment/3`, `X402.Plug.PaymentGate`, and
+  `X402.PaymentSignature.validate/3`.
+
+  ## Examples
+
+      iex> X402.Scheme.validate_module(X402.Scheme.ExactEVM)
+      {:ok, X402.Scheme.ExactEVM}
+
+      iex> X402.Scheme.validate_module(:not_a_scheme)
+      {:error, "expected a module implementing X402.Scheme"}
+  """
+  @spec validate_module(term()) :: {:ok, module()} | {:error, String.t()}
+  def validate_module(module) when is_atom(module) do
+    case X402.Behaviour.implements?(module, @required_callbacks) do
+      true -> {:ok, module}
+      false -> {:error, "expected a module implementing X402.Scheme"}
+    end
+  end
+
+  def validate_module(_invalid), do: {:error, "expected a module implementing X402.Scheme"}
+
+  @doc since: "0.6.0"
+  @doc """
+  Whether a scheme module implements the client-side `c:sign/3` callback.
+
+  ## Examples
+
+      iex> X402.Scheme.signs?(X402.Scheme.ExactEVM)
+      true
+
+      iex> X402.Scheme.signs?(X402.Scheme.UptoEVM)
+      false
+  """
+  @spec signs?(t()) :: boolean()
+  def signs?(module), do: Code.ensure_loaded?(module) and function_exported?(module, :sign, 3)
+
+  @doc since: "0.6.0"
+  @doc """
+  Invokes `c:signable?/1`, defaulting to `true` when not implemented.
+
+  ## Examples
+
+      iex> X402.Scheme.signable?(X402.Scheme.UptoEVM, %{})
+      true
+
+      iex> X402.Scheme.signable?(X402.Scheme.ExactEVM, %{})
+      false
+  """
+  @spec signable?(t(), map()) :: boolean()
+  def signable?(module, requirements) do
+    case Code.ensure_loaded?(module) and function_exported?(module, :signable?, 1) do
+      true -> module.signable?(requirements)
+      false -> true
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Invokes `c:validate_payload/3`, defaulting to `:ok` when not implemented.
+
+  ## Examples
+
+      iex> X402.Scheme.validate_payload(X402.Scheme.ExactEVM, %{}, %{}, [])
+      :ok
+  """
+  @spec validate_payload(t(), map(), map(), keyword()) :: :ok | {:error, term()}
+  def validate_payload(module, payload, requirements, opts \\ []) do
+    case Code.ensure_loaded?(module) and function_exported?(module, :validate_payload, 3) do
+      true -> module.validate_payload(payload, requirements, opts)
+      false -> :ok
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Invokes `c:precheck/3`, defaulting to `:ok` when not implemented.
+
+  ## Examples
+
+      iex> X402.Scheme.precheck(X402.Scheme.ExactEVM, %{"payload" => %{}}, %{}, [])
+      :ok
+  """
+  @spec precheck(t(), map(), map(), keyword()) :: :ok | {:error, term()}
+  def precheck(module, payload, requirements, opts \\ []) do
+    case Code.ensure_loaded?(module) and function_exported?(module, :precheck, 3) do
+      true -> module.precheck(payload, requirements, opts)
+      false -> :ok
+    end
+  end
+end

--- a/lib/x402/scheme/evm.ex
+++ b/lib/x402/scheme/evm.ex
@@ -1,0 +1,225 @@
+defmodule X402.Scheme.EVM do
+  @moduledoc """
+  Shared local pre-checks for EVM authorization-style scheme payloads.
+
+  Used by the built-in `X402.Scheme.ExactEVM` and `X402.Scheme.UptoEVM`
+  schemes to implement `c:X402.Scheme.precheck/3`, and reusable by
+  third-party EVM scheme modules whose payloads carry an EIP-3009-style
+  `payload.authorization` object.
+
+  The checks mirror the first checks every reference facilitator performs
+  (payTo equality, exact amount equality, time window), so junk traffic is
+  rejected without paying a facilitator verify call. Payloads without a
+  `payload.authorization` map — other payload shapes, Permit2 — are skipped
+  entirely, as is any individual absent field: the facilitator remains the
+  authority, these checks only fail fast on certain mismatch.
+  """
+
+  alias X402.Utils
+
+  # Mirrors the 6-second buffer the reference facilitators apply to
+  # validBefore so a payment does not expire mid-settlement.
+  @time_buffer_seconds 6
+
+  @typedoc "Reasons an authorization pre-check fails."
+  @type precheck_failure ::
+          :pay_to_mismatch
+          | :amount_mismatch
+          | :invalid_authorization_value
+          | :authorization_not_yet_valid
+          | :authorization_expired
+          | :invalid_authorization_timing
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the settlement buffer applied to `validBefore`, in seconds.
+
+  ## Examples
+
+      iex> X402.Scheme.EVM.time_buffer_seconds()
+      6
+  """
+  @spec time_buffer_seconds() :: pos_integer()
+  def time_buffer_seconds, do: @time_buffer_seconds
+
+  @doc since: "0.6.0"
+  @doc """
+  Runs cheap local checks on an EIP-3009-style `payload.authorization`.
+
+  Checks, in order: the authorization's `to` must equal the requirements'
+  `payTo` (case-insensitive for hex addresses); with `enforce_exact_amount:
+  true` the authorization's `value` must equal the requirements' `amount`;
+  and the `validAfter`/`validBefore` window must cover now (with a
+  #{@time_buffer_seconds}s settlement buffer on `validBefore`). Payloads
+  without a `payload.authorization` map pass with `:ok`, as does any
+  individual absent field.
+
+  ## Options
+
+  * `:enforce_exact_amount` (default `false`) — require `authorization.value`
+    to equal the requirements' `amount` exactly. Use for `exact`-style
+    schemes; for ceiling schemes such as `upto`, the signed value is a
+    maximum, not the settled amount.
+
+  ## Examples
+
+      iex> X402.Scheme.EVM.authorization_precheck(%{"payload" => %{}}, %{})
+      :ok
+
+      iex> payload = %{
+      ...>   "payload" => %{"authorization" => %{"to" => "0xAb", "value" => "10"}}
+      ...> }
+      iex> requirements = %{"payTo" => "0xab", "amount" => "10"}
+      iex> X402.Scheme.EVM.authorization_precheck(payload, requirements,
+      ...>   enforce_exact_amount: true
+      ...> )
+      :ok
+
+      iex> payload = %{
+      ...>   "payload" => %{"authorization" => %{"to" => "0xother", "value" => "10"}}
+      ...> }
+      iex> X402.Scheme.EVM.authorization_precheck(payload, %{"payTo" => "0xab"})
+      {:error, {:precheck_failed, :pay_to_mismatch}}
+  """
+  @spec authorization_precheck(map(), map(), keyword()) ::
+          :ok | {:error, {:precheck_failed, precheck_failure()}}
+  def authorization_precheck(payload, requirements, opts \\ [])
+      when is_map(payload) and is_map(requirements) and is_list(opts) do
+    case authorization(payload) do
+      nil ->
+        :ok
+
+      authorization ->
+        with :ok <- precheck_pay_to(authorization, requirements),
+             :ok <-
+               precheck_exact_amount(
+                 Keyword.get(opts, :enforce_exact_amount, false),
+                 authorization,
+                 requirements
+               ) do
+          precheck_timing(authorization)
+        end
+    end
+  end
+
+  @spec authorization(map()) :: map() | nil
+  defp authorization(payload) do
+    case Utils.nested_map_value(payload, [
+           {"payload", :payload},
+           {"authorization", :authorization}
+         ]) do
+      authorization when is_map(authorization) -> authorization
+      _other -> nil
+    end
+  end
+
+  @spec precheck_pay_to(map(), map()) ::
+          :ok | {:error, {:precheck_failed, :pay_to_mismatch}}
+  defp precheck_pay_to(authorization, requirements) do
+    to = Utils.map_value(authorization, {"to", :to})
+    pay_to = Utils.map_value(requirements, {"payTo", :payTo})
+
+    case is_binary(to) and is_binary(pay_to) do
+      true ->
+        case same_address?(to, pay_to) do
+          true -> :ok
+          false -> {:error, {:precheck_failed, :pay_to_mismatch}}
+        end
+
+      false ->
+        :ok
+    end
+  end
+
+  @spec same_address?(String.t(), String.t()) :: boolean()
+  defp same_address?(left, right) do
+    case hex_address?(left) and hex_address?(right) do
+      true -> String.downcase(left) == String.downcase(right)
+      false -> left == right
+    end
+  end
+
+  @spec hex_address?(String.t()) :: boolean()
+  defp hex_address?(<<"0x", rest::binary>>) when rest != "",
+    do: Regex.match?(~r/^[0-9a-fA-F]+$/, rest)
+
+  defp hex_address?(_address), do: false
+
+  @spec precheck_exact_amount(boolean(), map(), map()) ::
+          :ok | {:error, {:precheck_failed, :amount_mismatch | :invalid_authorization_value}}
+  defp precheck_exact_amount(false, _authorization, _requirements), do: :ok
+
+  defp precheck_exact_amount(true, authorization, requirements) do
+    value = Utils.map_value(authorization, {"value", :value})
+    amount = Utils.map_value(requirements, {"amount", :amount})
+
+    case not is_nil(value) and not is_nil(amount) do
+      true -> compare_exact_amount(value, amount)
+      false -> :ok
+    end
+  end
+
+  @spec compare_exact_amount(term(), term()) ::
+          :ok | {:error, {:precheck_failed, :amount_mismatch | :invalid_authorization_value}}
+  defp compare_exact_amount(value, amount) do
+    with {:ok, parsed_value} <- parse_precheck_amount(value),
+         {:ok, parsed_amount} <- parse_precheck_amount(amount) do
+      case Utils.compare_decimal(parsed_value, parsed_amount) do
+        :eq -> :ok
+        _other -> {:error, {:precheck_failed, :amount_mismatch}}
+      end
+    end
+  end
+
+  @spec parse_precheck_amount(term()) ::
+          {:ok, {non_neg_integer(), non_neg_integer()}}
+          | {:error, {:precheck_failed, :invalid_authorization_value}}
+  defp parse_precheck_amount(value) do
+    case Utils.parse_decimal(value) do
+      {:ok, parsed} -> {:ok, parsed}
+      :error -> {:error, {:precheck_failed, :invalid_authorization_value}}
+    end
+  end
+
+  @spec precheck_timing(map()) ::
+          :ok
+          | {:error,
+             {:precheck_failed,
+              :authorization_not_yet_valid
+              | :authorization_expired
+              | :invalid_authorization_timing}}
+  defp precheck_timing(authorization) do
+    now = System.system_time(:second)
+
+    with {:ok, valid_after} <-
+           optional_unix_time(Utils.map_value(authorization, {"validAfter", :validAfter})),
+         {:ok, valid_before} <-
+           optional_unix_time(Utils.map_value(authorization, {"validBefore", :validBefore})) do
+      cond do
+        is_integer(valid_after) and valid_after > now ->
+          {:error, {:precheck_failed, :authorization_not_yet_valid}}
+
+        is_integer(valid_before) and valid_before < now + @time_buffer_seconds ->
+          {:error, {:precheck_failed, :authorization_expired}}
+
+        true ->
+          :ok
+      end
+    end
+  end
+
+  @spec optional_unix_time(term()) ::
+          {:ok, integer() | nil} | {:error, {:precheck_failed, :invalid_authorization_timing}}
+  defp optional_unix_time(nil), do: {:ok, nil}
+  defp optional_unix_time(value) when is_integer(value), do: {:ok, value}
+
+  defp optional_unix_time(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {parsed, ""} -> {:ok, parsed}
+      _other -> {:error, {:precheck_failed, :invalid_authorization_timing}}
+    end
+  end
+
+  defp optional_unix_time(_value),
+    do: {:error, {:precheck_failed, :invalid_authorization_timing}}
+end

--- a/lib/x402/scheme/exact_evm.ex
+++ b/lib/x402/scheme/exact_evm.ex
@@ -1,0 +1,118 @@
+defmodule X402.Scheme.ExactEVM do
+  @moduledoc """
+  Built-in `X402.Scheme` for `exact` payments on EVM (`eip155:*`) networks.
+
+  Implements both roles:
+
+  * **Client** — signs an EIP-3009 `TransferWithAuthorization` through
+    `X402.EIP3009`, producing the
+    `%{"signature" => ..., "authorization" => ...}` scheme payload. An
+    entry is signable when its EIP-712 domain can be derived from the
+    requirements (`extra.name` / `extra.version` present, default `eip3009`
+    transfer method).
+  * **Server** — runs the local pre-checks on the EIP-3009 authorization
+    object before the facilitator round-trip: `to` must equal the
+    requirements' `payTo`, `value` must equal the advertised `amount`, and
+    the `validAfter`/`validBefore` window must cover now plus a settlement
+    buffer (`X402.Scheme.EVM.time_buffer_seconds/0`). Payloads without a
+    `payload.authorization` map are skipped.
+
+  Envelope validation of the `PAYMENT-SIGNATURE` payload is handled by
+  `X402.PaymentSignature`; this scheme adds no extra structural checks
+  (`c:X402.Scheme.validate_payload/3` returns `:ok`).
+  """
+
+  @behaviour X402.Scheme
+
+  alias X402.EIP3009
+  alias X402.Scheme.EVM
+  alias X402.Signer
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns `"exact"`.
+
+  ## Examples
+
+      iex> X402.Scheme.ExactEVM.scheme()
+      "exact"
+  """
+  @impl X402.Scheme
+  @spec scheme() :: String.t()
+  def scheme, do: "exact"
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns `["eip155:*"]` — every EVM network.
+
+  ## Examples
+
+      iex> X402.Scheme.ExactEVM.networks()
+      ["eip155:*"]
+  """
+  @impl X402.Scheme
+  @spec networks() :: [String.t()]
+  def networks, do: ["eip155:*"]
+
+  @doc since: "0.6.0"
+  @doc """
+  Whether the EIP-712 domain can be derived from the requirements.
+
+  ## Examples
+
+      iex> X402.Scheme.ExactEVM.signable?(%{
+      ...>   "network" => "eip155:84532",
+      ...>   "asset" => "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      ...>   "extra" => %{"name" => "USDC", "version" => "2"}
+      ...> })
+      true
+
+      iex> X402.Scheme.ExactEVM.signable?(%{"extra" => %{}})
+      false
+  """
+  @impl X402.Scheme
+  @spec signable?(map()) :: boolean()
+  def signable?(requirements) when is_map(requirements) do
+    match?({:ok, _domain}, EIP3009.domain(requirements))
+  end
+
+  def signable?(_requirements), do: false
+
+  @doc since: "0.6.0"
+  @doc """
+  Signs the EIP-3009 scheme payload via `X402.EIP3009.sign/3`.
+
+  Honors the client's `:valid_after_buffer` option; other options are
+  ignored.
+  """
+  @impl X402.Scheme
+  @spec sign(map(), Signer.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  def sign(requirements, signer, opts) do
+    EIP3009.sign(requirements, signer, Keyword.take(opts, [:valid_after_buffer]))
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Always `:ok` — envelope validation covers the `exact` payload shape.
+
+  ## Examples
+
+      iex> X402.Scheme.ExactEVM.validate_payload(%{}, %{}, [])
+      :ok
+  """
+  @impl X402.Scheme
+  @spec validate_payload(map(), map(), keyword()) :: :ok
+  def validate_payload(_payload, _requirements, _opts), do: :ok
+
+  @doc since: "0.6.0"
+  @doc """
+  Runs `X402.Scheme.EVM.authorization_precheck/3` with exact-amount
+  equality enforced.
+  """
+  @impl X402.Scheme
+  @spec precheck(map(), map(), keyword()) ::
+          :ok | {:error, {:precheck_failed, EVM.precheck_failure()}}
+  def precheck(payload, requirements, _opts) do
+    EVM.authorization_precheck(payload, requirements, enforce_exact_amount: true)
+  end
+end

--- a/lib/x402/scheme/registry.ex
+++ b/lib/x402/scheme/registry.ex
@@ -1,0 +1,153 @@
+defmodule X402.Scheme.Registry do
+  @moduledoc """
+  Resolves (scheme, network) pairs to `X402.Scheme` modules.
+
+  The default mapping is seeded with the built-in schemes —
+  `X402.Scheme.ExactEVM` (`"exact"` on `"eip155:*"`) and
+  `X402.Scheme.UptoEVM` (`"upto"` on `"eip155:*"`). There is no global
+  registration and no application environment: callers pass additional
+  scheme modules explicitly (the `:schemes` option on
+  `X402.Client.build_payment/3`, `X402.Plug.PaymentGate`, and
+  `X402.PaymentSignature.validate/3`), and those are consulted **before**
+  the built-ins, so a user module can override a built-in kind.
+
+  ## Resolution semantics
+
+  Candidate modules are the extra schemes followed by the built-ins,
+  filtered to those whose `c:X402.Scheme.scheme/0` equals the requested
+  scheme. Among candidates, the network decides:
+
+  1. An **exact** CAIP-2 match in `c:X402.Scheme.networks/0` always wins
+     over any wildcard match; ties go to the earlier module in the list.
+  2. Otherwise the **wildcard** patterns (trailing `*`, matched as a
+     prefix — `"eip155:*"`, or `"*"` for any network) are consulted; the
+     longest (most specific) matching pattern wins, and ties go to the
+     earlier module in the list.
+
+  Kinds that resolve to no module return `:error`; callers treat that as
+  "no scheme module registered" and fall back to their historical neutral
+  behavior (pass-through validation, skipped pre-checks, or the client's
+  `{:unsupported_kind, scheme, network}` error).
+
+  ## Examples
+
+      iex> X402.Scheme.Registry.resolve("exact", "eip155:8453")
+      {:ok, X402.Scheme.ExactEVM}
+
+      iex> X402.Scheme.Registry.resolve("upto", "eip155:84532")
+      {:ok, X402.Scheme.UptoEVM}
+
+      iex> X402.Scheme.Registry.resolve("exact", "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp")
+      :error
+  """
+
+  @builtins [X402.Scheme.ExactEVM, X402.Scheme.UptoEVM]
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the built-in scheme modules, in consultation order.
+
+  ## Examples
+
+      iex> X402.Scheme.Registry.builtins()
+      [X402.Scheme.ExactEVM, X402.Scheme.UptoEVM]
+  """
+  @spec builtins() :: [module()]
+  def builtins, do: @builtins
+
+  @doc since: "0.6.0"
+  @doc """
+  Resolves a (scheme, network) pair to a scheme module.
+
+  `extra_schemes` are consulted before the built-ins. Non-binary scheme or
+  network values resolve to `:error`.
+
+  ## Examples
+
+      iex> X402.Scheme.Registry.resolve([], "exact", "eip155:1")
+      {:ok, X402.Scheme.ExactEVM}
+
+      iex> X402.Scheme.Registry.resolve([], "cash", "eip155:1")
+      :error
+
+      iex> X402.Scheme.Registry.resolve([], nil, "eip155:1")
+      :error
+  """
+  @spec resolve([module()], term(), term()) :: {:ok, module()} | :error
+  def resolve(extra_schemes \\ [], scheme, network)
+
+  def resolve(extra_schemes, scheme, network)
+      when is_list(extra_schemes) and is_binary(scheme) and is_binary(network) do
+    candidates =
+      (extra_schemes ++ @builtins)
+      |> Enum.uniq()
+      |> Enum.filter(&(&1.scheme() == scheme))
+
+    with :error <- exact_match(candidates, network) do
+      wildcard_match(candidates, network)
+    end
+  end
+
+  def resolve(_extra_schemes, _scheme, _network), do: :error
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns whether a CAIP-2 network matches a network pattern.
+
+  A pattern ending in `*` matches any network starting with the prefix
+  before it; any other pattern must match exactly.
+
+  ## Examples
+
+      iex> X402.Scheme.Registry.network_matches?("eip155:*", "eip155:8453")
+      true
+
+      iex> X402.Scheme.Registry.network_matches?("eip155:8453", "eip155:1")
+      false
+
+      iex> X402.Scheme.Registry.network_matches?("*", "solana:mainnet")
+      true
+  """
+  @spec network_matches?(String.t(), String.t()) :: boolean()
+  def network_matches?(pattern, network) when is_binary(pattern) and is_binary(network) do
+    case String.split_at(pattern, -1) do
+      {prefix, "*"} -> String.starts_with?(network, prefix)
+      _exact -> pattern == network
+    end
+  end
+
+  def network_matches?(_pattern, _network), do: false
+
+  @spec exact_match([module()], String.t()) :: {:ok, module()} | :error
+  defp exact_match(candidates, network) do
+    case Enum.find(candidates, &(network in &1.networks())) do
+      nil -> :error
+      module -> {:ok, module}
+    end
+  end
+
+  @spec wildcard_match([module()], String.t()) :: {:ok, module()} | :error
+  defp wildcard_match(candidates, network) do
+    candidates
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {module, index} ->
+      for pattern <- module.networks(),
+          String.ends_with?(pattern, "*"),
+          network_matches?(pattern, network),
+          do: {byte_size(pattern), index, module}
+    end)
+    |> most_specific()
+  end
+
+  # Longest pattern (most specific prefix) wins; ties go to list order.
+  @spec most_specific([{non_neg_integer(), non_neg_integer(), module()}]) ::
+          {:ok, module()} | :error
+  defp most_specific([]), do: :error
+
+  defp most_specific(matches) do
+    {_size, _index, module} =
+      Enum.min_by(matches, fn {size, index, _module} -> {-size, index} end)
+
+    {:ok, module}
+  end
+end

--- a/lib/x402/scheme/upto_evm.ex
+++ b/lib/x402/scheme/upto_evm.ex
@@ -1,0 +1,182 @@
+defmodule X402.Scheme.UptoEVM do
+  @moduledoc """
+  Built-in `X402.Scheme` for `upto` payments on EVM (`eip155:*`) networks.
+
+  Server-side only in this release: `c:X402.Scheme.validate_payload/3`
+  validates that the payment value the client signed does not exceed the
+  advertised maximum (the requirements' `amount`, with `maxPrice` and
+  `maxAmountRequired` fallbacks), recognizing the Permit2
+  (`permit2Authorization.permitted.amount`), `maxAmount`, `value`, and
+  EIP-3009 `authorization.value` payload shapes. Failures are
+  `{:error, {:invalid_upto_payment, reason}}` — see `t:validation_error/0`.
+
+  Pre-checks reuse the shared EIP-3009 authorization checks
+  (`X402.Scheme.EVM.authorization_precheck/3` — payTo binding and validity
+  window) without the exact-amount equality: for `upto`, the signed value
+  is a ceiling, not the settled amount.
+
+  `c:X402.Scheme.sign/3` is intentionally not implemented — `X402.Client`
+  cannot yet sign `upto` payments, so `upto` requirements return
+  `{:error, {:unsupported_kind, "upto", network}}` from
+  `X402.Client.build_payment/3`.
+  """
+
+  @behaviour X402.Scheme
+
+  alias X402.Scheme.EVM
+  alias X402.Utils
+
+  @typedoc "Reasons an `upto` payment fails ceiling validation."
+  @type validation_error ::
+          :missing_max_price
+          | :missing_payment_value
+          | :invalid_max_price
+          | :invalid_payment_value
+          | :payment_value_exceeds_max_price
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns `"upto"`.
+
+  ## Examples
+
+      iex> X402.Scheme.UptoEVM.scheme()
+      "upto"
+  """
+  @impl X402.Scheme
+  @spec scheme() :: String.t()
+  def scheme, do: "upto"
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns `["eip155:*"]` — every EVM network.
+
+  ## Examples
+
+      iex> X402.Scheme.UptoEVM.networks()
+      ["eip155:*"]
+  """
+  @impl X402.Scheme
+  @spec networks() :: [String.t()]
+  def networks, do: ["eip155:*"]
+
+  @doc since: "0.6.0"
+  @doc """
+  Validates that the signed payment value stays within the ceiling.
+
+  ## Examples
+
+      iex> X402.Scheme.UptoEVM.validate_payload(
+      ...>   %{"payload" => %{"value" => "9000"}},
+      ...>   %{"amount" => "10000"},
+      ...>   []
+      ...> )
+      :ok
+
+      iex> X402.Scheme.UptoEVM.validate_payload(
+      ...>   %{"payload" => %{"value" => "10001"}},
+      ...>   %{"amount" => "10000"},
+      ...>   []
+      ...> )
+      {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
+  """
+  @impl X402.Scheme
+  @spec validate_payload(map(), map(), keyword()) ::
+          :ok | {:error, {:invalid_upto_payment, validation_error()}}
+  def validate_payload(payload, requirements, _opts) do
+    with {:ok, max_price} <- extract_max_price(payload, requirements),
+         {:ok, payment_value} <- extract_payment_value(payload) do
+      ensure_not_exceeds(payment_value, max_price)
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Runs `X402.Scheme.EVM.authorization_precheck/3` without exact-amount
+  equality — for `upto`, the signed value is a ceiling.
+  """
+  @impl X402.Scheme
+  @spec precheck(map(), map(), keyword()) ::
+          :ok | {:error, {:precheck_failed, EVM.precheck_failure()}}
+  def precheck(payload, requirements, _opts) do
+    EVM.authorization_precheck(payload, requirements, enforce_exact_amount: false)
+  end
+
+  @spec extract_max_price(map(), map()) ::
+          {:ok, {non_neg_integer(), non_neg_integer()}}
+          | {:error, {:invalid_upto_payment, :missing_max_price | :invalid_max_price}}
+  defp extract_max_price(payload, requirements) do
+    value =
+      Utils.first_present([
+        Utils.map_value(requirements, {"amount", :amount}),
+        Utils.map_value(requirements, {"maxPrice", :maxPrice}),
+        Utils.map_value(requirements, {"maxAmountRequired", :maxAmountRequired}),
+        Utils.nested_map_value(payload, [{"accepted", :accepted}, {"amount", :amount}]),
+        Utils.map_value(payload, {"maxPrice", :maxPrice}),
+        Utils.map_value(payload, {"maxAmountRequired", :maxAmountRequired})
+      ])
+
+    case value do
+      nil ->
+        {:error, {:invalid_upto_payment, :missing_max_price}}
+
+      max_price ->
+        case Utils.parse_decimal(max_price) do
+          {:ok, parsed} -> {:ok, parsed}
+          :error -> {:error, {:invalid_upto_payment, :invalid_max_price}}
+        end
+    end
+  end
+
+  @spec extract_payment_value(map()) ::
+          {:ok, {non_neg_integer(), non_neg_integer()}}
+          | {:error, {:invalid_upto_payment, :missing_payment_value | :invalid_payment_value}}
+  defp extract_payment_value(payload) do
+    value =
+      Utils.first_present([
+        Utils.nested_map_value(payload, [
+          {"payload", :payload},
+          {"permit2Authorization", :permit2Authorization},
+          {"permitted", :permitted},
+          {"amount", :amount}
+        ]),
+        Utils.nested_map_value(payload, [
+          {"permit2Authorization", :permit2Authorization},
+          {"permitted", :permitted},
+          {"amount", :amount}
+        ]),
+        Utils.nested_map_value(payload, [{"payload", :payload}, {"maxAmount", :maxAmount}]),
+        Utils.map_value(payload, {"maxAmount", :maxAmount}),
+        Utils.map_value(payload, {"value", :value}),
+        Utils.nested_map_value(payload, [{"payload", :payload}, {"value", :value}]),
+        Utils.nested_map_value(payload, [
+          {"payload", :payload},
+          {"authorization", :authorization},
+          {"value", :value}
+        ]),
+        Utils.nested_map_value(payload, [{"authorization", :authorization}, {"value", :value}])
+      ])
+
+    case value do
+      nil ->
+        {:error, {:invalid_upto_payment, :missing_payment_value}}
+
+      payment_value ->
+        case Utils.parse_decimal(payment_value) do
+          {:ok, parsed} -> {:ok, parsed}
+          :error -> {:error, {:invalid_upto_payment, :invalid_payment_value}}
+        end
+    end
+  end
+
+  @spec ensure_not_exceeds(
+          {non_neg_integer(), non_neg_integer()},
+          {non_neg_integer(), non_neg_integer()}
+        ) :: :ok | {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
+  defp ensure_not_exceeds(payment_value, max_price) do
+    case Utils.compare_decimal(payment_value, max_price) do
+      :gt -> {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
+      _comparison -> :ok
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -122,6 +122,7 @@ defmodule X402.MixProject do
         "guides/getting-started.md": [title: "Getting Started"],
         "guides/client.md": [title: "Paying for Resources"],
         "guides/plug-integration.md": [title: "Plug/Phoenix Integration"],
+        "guides/custom-schemes.md": [title: "Custom Payment Schemes"],
         "guides/mcp.md": [title: "Paid MCP Tools"],
         "guides/paywall.md": [title: "Browser Paywall"],
         "guides/live-smoke-tests.md": [title: "Live Smoke Tests"]
@@ -158,6 +159,13 @@ defmodule X402.MixProject do
           X402.Plug.PaymentGate,
           X402.Paywall,
           X402.Paywall.Default
+        ],
+        "Payment Schemes": [
+          X402.Scheme,
+          X402.Scheme.Registry,
+          X402.Scheme.ExactEVM,
+          X402.Scheme.UptoEVM,
+          X402.Scheme.EVM
         ],
         "MCP Transport": [
           X402.MCP,

--- a/test/x402/scheme/evm_test.exs
+++ b/test/x402/scheme/evm_test.exs
@@ -1,0 +1,141 @@
+defmodule X402.Scheme.EVMTest do
+  use ExUnit.Case, async: true
+
+  doctest X402.Scheme.EVM
+
+  alias X402.Scheme.EVM
+
+  @receiver "0x1111111111111111111111111111111111111111"
+
+  defp payload(authorization) do
+    %{"payload" => %{"signature" => "0xsig", "authorization" => authorization}}
+  end
+
+  defp valid_authorization(overrides \\ %{}) do
+    now = System.system_time(:second)
+
+    Map.merge(
+      %{
+        "from" => "0x2222222222222222222222222222222222222222",
+        "to" => @receiver,
+        "value" => "10000",
+        "validAfter" => Integer.to_string(now - 60),
+        "validBefore" => Integer.to_string(now + 600),
+        "nonce" => "0xnonce"
+      },
+      overrides
+    )
+  end
+
+  defp requirements do
+    %{"scheme" => "exact", "payTo" => @receiver, "amount" => "10000"}
+  end
+
+  describe "authorization_precheck/3" do
+    test "passes a valid authorization" do
+      assert EVM.authorization_precheck(payload(valid_authorization()), requirements(),
+               enforce_exact_amount: true
+             ) == :ok
+    end
+
+    test "skips payloads without an authorization map" do
+      assert EVM.authorization_precheck(%{"payload" => %{"transaction" => "tx"}}, requirements()) ==
+               :ok
+
+      assert EVM.authorization_precheck(%{}, requirements()) == :ok
+    end
+
+    test "compares payTo case-insensitively for hex addresses" do
+      authorization = valid_authorization(%{"to" => "0xAbCdEf1234567890aBcDeF1234567890AbCdEf12"})
+
+      requirements = %{
+        "scheme" => "exact",
+        "payTo" => "0xabcdef1234567890abcdef1234567890abcdef12",
+        "amount" => "10000"
+      }
+
+      assert EVM.authorization_precheck(payload(authorization), requirements) == :ok
+    end
+
+    test "rejects payTo mismatches" do
+      authorization =
+        valid_authorization(%{"to" => "0x9999999999999999999999999999999999999999"})
+
+      assert EVM.authorization_precheck(payload(authorization), requirements()) ==
+               {:error, {:precheck_failed, :pay_to_mismatch}}
+    end
+
+    test "compares non-hex recipients exactly" do
+      authorization = valid_authorization(%{"to" => "till"})
+
+      assert EVM.authorization_precheck(payload(authorization), %{"payTo" => "till"}) == :ok
+
+      assert EVM.authorization_precheck(payload(authorization), %{"payTo" => "TILL"}) ==
+               {:error, {:precheck_failed, :pay_to_mismatch}}
+    end
+
+    test "enforces exact amount equality only when requested" do
+      authorization = valid_authorization(%{"value" => "9999"})
+
+      assert EVM.authorization_precheck(payload(authorization), requirements(),
+               enforce_exact_amount: true
+             ) == {:error, {:precheck_failed, :amount_mismatch}}
+
+      assert EVM.authorization_precheck(payload(authorization), requirements()) == :ok
+    end
+
+    test "rejects unparsable authorization values when enforcing amounts" do
+      authorization = valid_authorization(%{"value" => "not-a-number"})
+
+      assert EVM.authorization_precheck(payload(authorization), requirements(),
+               enforce_exact_amount: true
+             ) == {:error, {:precheck_failed, :invalid_authorization_value}}
+    end
+
+    test "skips the amount check when either side is absent" do
+      authorization = Map.delete(valid_authorization(), "value")
+
+      assert EVM.authorization_precheck(payload(authorization), requirements(),
+               enforce_exact_amount: true
+             ) == :ok
+
+      assert EVM.authorization_precheck(
+               payload(valid_authorization()),
+               Map.delete(requirements(), "amount"),
+               enforce_exact_amount: true
+             ) == :ok
+    end
+
+    test "rejects authorizations that are not yet valid" do
+      future = System.system_time(:second) + 600
+      authorization = valid_authorization(%{"validAfter" => Integer.to_string(future)})
+
+      assert EVM.authorization_precheck(payload(authorization), requirements()) ==
+               {:error, {:precheck_failed, :authorization_not_yet_valid}}
+    end
+
+    test "rejects authorizations expiring within the settlement buffer" do
+      soon = System.system_time(:second) + 2
+      authorization = valid_authorization(%{"validBefore" => Integer.to_string(soon)})
+
+      assert EVM.authorization_precheck(payload(authorization), requirements()) ==
+               {:error, {:precheck_failed, :authorization_expired}}
+    end
+
+    test "rejects malformed timing values" do
+      authorization = valid_authorization(%{"validBefore" => "soon"})
+
+      assert EVM.authorization_precheck(payload(authorization), requirements()) ==
+               {:error, {:precheck_failed, :invalid_authorization_timing}}
+    end
+
+    test "skips absent timing fields" do
+      authorization =
+        valid_authorization()
+        |> Map.delete("validAfter")
+        |> Map.delete("validBefore")
+
+      assert EVM.authorization_precheck(payload(authorization), requirements()) == :ok
+    end
+  end
+end

--- a/test/x402/scheme/exact_evm_test.exs
+++ b/test/x402/scheme/exact_evm_test.exs
@@ -1,0 +1,88 @@
+defmodule X402.Scheme.ExactEVMTest do
+  use ExUnit.Case, async: true
+
+  doctest X402.Scheme.ExactEVM
+
+  alias X402.Scheme.ExactEVM
+  alias X402.Signer.LocalKey
+
+  @requirements %{
+    "scheme" => "exact",
+    "network" => "eip155:84532",
+    "amount" => "10000",
+    "asset" => "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+    "payTo" => "0x2222222222222222222222222222222222222222",
+    "maxTimeoutSeconds" => 300,
+    "extra" => %{"name" => "USDC", "version" => "2"}
+  }
+
+  defp signer do
+    {:ok, signer} = LocalKey.new(:crypto.strong_rand_bytes(32))
+    signer
+  end
+
+  describe "metadata" do
+    test "declares exact on every EVM network" do
+      assert ExactEVM.scheme() == "exact"
+      assert ExactEVM.networks() == ["eip155:*"]
+    end
+  end
+
+  describe "signable?/1" do
+    test "requires a derivable EIP-712 domain" do
+      assert ExactEVM.signable?(@requirements)
+      refute ExactEVM.signable?(Map.put(@requirements, "extra", %{}))
+      refute ExactEVM.signable?(nil)
+    end
+  end
+
+  describe "sign/3" do
+    test "produces the EIP-3009 scheme payload" do
+      assert {:ok, %{"signature" => "0x" <> _sig, "authorization" => authorization}} =
+               ExactEVM.sign(@requirements, signer(), valid_after_buffer: 60)
+
+      assert authorization["to"] == @requirements["payTo"]
+      assert authorization["value"] == @requirements["amount"]
+    end
+
+    test "ignores unrelated client build options" do
+      assert {:ok, _payload} =
+               ExactEVM.sign(@requirements, signer(), schemes: [], extensions: [])
+    end
+
+    test "propagates EIP-3009 errors" do
+      missing_domain = Map.put(@requirements, "extra", %{})
+
+      assert ExactEVM.sign(missing_domain, signer(), []) == {:error, {:missing_extra, "name"}}
+    end
+  end
+
+  describe "validate_payload/3" do
+    test "always passes" do
+      assert ExactEVM.validate_payload(%{"payload" => %{}}, @requirements, []) == :ok
+    end
+  end
+
+  describe "precheck/3" do
+    test "enforces exact amount equality" do
+      now = System.system_time(:second)
+
+      payload = %{
+        "payload" => %{
+          "authorization" => %{
+            "to" => @requirements["payTo"],
+            "value" => "9999",
+            "validAfter" => Integer.to_string(now - 60),
+            "validBefore" => Integer.to_string(now + 600)
+          }
+        }
+      }
+
+      assert ExactEVM.precheck(payload, @requirements, []) ==
+               {:error, {:precheck_failed, :amount_mismatch}}
+
+      matching = put_in(payload, ["payload", "authorization", "value"], "10000")
+      assert ExactEVM.precheck(matching, @requirements, []) == :ok
+    end
+  end
+end

--- a/test/x402/scheme/registry_test.exs
+++ b/test/x402/scheme/registry_test.exs
@@ -1,0 +1,141 @@
+defmodule X402.Scheme.RegistryTest do
+  use ExUnit.Case, async: true
+
+  doctest X402.Scheme.Registry
+
+  alias X402.Scheme.Registry
+
+  defmodule WildcardEVM do
+    @moduledoc false
+    @behaviour X402.Scheme
+
+    @impl X402.Scheme
+    def scheme, do: "exact"
+
+    @impl X402.Scheme
+    def networks, do: ["eip155:*"]
+  end
+
+  defmodule BaseSepoliaOnly do
+    @moduledoc false
+    @behaviour X402.Scheme
+
+    @impl X402.Scheme
+    def scheme, do: "exact"
+
+    @impl X402.Scheme
+    def networks, do: ["eip155:84532"]
+  end
+
+  defmodule SolanaExact do
+    @moduledoc false
+    @behaviour X402.Scheme
+
+    @impl X402.Scheme
+    def scheme, do: "exact"
+
+    @impl X402.Scheme
+    def networks, do: ["solana:*"]
+  end
+
+  defmodule CatchAll do
+    @moduledoc false
+    @behaviour X402.Scheme
+
+    @impl X402.Scheme
+    def scheme, do: "exact"
+
+    @impl X402.Scheme
+    def networks, do: ["*"]
+  end
+
+  describe "builtins/0" do
+    test "seeds exact and upto on EVM" do
+      assert Registry.builtins() == [X402.Scheme.ExactEVM, X402.Scheme.UptoEVM]
+    end
+  end
+
+  describe "resolve/3 with the built-ins" do
+    test "resolves exact and upto on any eip155 network" do
+      assert Registry.resolve("exact", "eip155:1") == {:ok, X402.Scheme.ExactEVM}
+      assert Registry.resolve("exact", "eip155:84532") == {:ok, X402.Scheme.ExactEVM}
+      assert Registry.resolve("upto", "eip155:8453") == {:ok, X402.Scheme.UptoEVM}
+    end
+
+    test "does not resolve unregistered kinds" do
+      assert Registry.resolve("exact", "solana:mainnet") == :error
+      assert Registry.resolve("cash", "eip155:1") == :error
+      assert Registry.resolve("upto", "solana:mainnet") == :error
+    end
+
+    test "does not resolve non-binary scheme or network" do
+      assert Registry.resolve([], nil, "eip155:1") == :error
+      assert Registry.resolve([], "exact", nil) == :error
+      assert Registry.resolve([], :exact, "eip155:1") == :error
+    end
+  end
+
+  describe "resolve/3 with extra schemes" do
+    test "extends resolution to new kinds" do
+      assert Registry.resolve([SolanaExact], "exact", "solana:mainnet") == {:ok, SolanaExact}
+      assert Registry.resolve([SolanaExact], "exact", "eip155:1") == {:ok, X402.Scheme.ExactEVM}
+    end
+
+    test "an exact network match beats any wildcard" do
+      # BaseSepoliaOnly is listed after the wildcard module but matches the
+      # network exactly, so it wins.
+      assert Registry.resolve([WildcardEVM, BaseSepoliaOnly], "exact", "eip155:84532") ==
+               {:ok, BaseSepoliaOnly}
+
+      # For other networks, the wildcard applies.
+      assert Registry.resolve([WildcardEVM, BaseSepoliaOnly], "exact", "eip155:1") ==
+               {:ok, WildcardEVM}
+    end
+
+    test "an extra exact match beats the built-in wildcard" do
+      assert Registry.resolve([BaseSepoliaOnly], "exact", "eip155:84532") ==
+               {:ok, BaseSepoliaOnly}
+    end
+
+    test "the longest wildcard prefix wins" do
+      # CatchAll ("*") is listed first, but the built-in "eip155:*" is more
+      # specific.
+      assert Registry.resolve([CatchAll], "exact", "eip155:1") == {:ok, X402.Scheme.ExactEVM}
+
+      # For networks no other pattern covers, the catch-all applies.
+      assert Registry.resolve([CatchAll], "exact", "tezos:mainnet") == {:ok, CatchAll}
+    end
+
+    test "equally specific wildcards go to the earlier module" do
+      # WildcardEVM's "eip155:*" ties with the built-in's; extra schemes are
+      # consulted first, so the user module overrides the built-in.
+      assert Registry.resolve([WildcardEVM], "exact", "eip155:1") == {:ok, WildcardEVM}
+    end
+
+    test "duplicate modules are ignored" do
+      assert Registry.resolve(
+               [X402.Scheme.ExactEVM, X402.Scheme.ExactEVM],
+               "exact",
+               "eip155:1"
+             ) == {:ok, X402.Scheme.ExactEVM}
+    end
+  end
+
+  describe "network_matches?/2" do
+    test "wildcard patterns match by prefix" do
+      assert Registry.network_matches?("eip155:*", "eip155:84532")
+      refute Registry.network_matches?("eip155:*", "solana:mainnet")
+      assert Registry.network_matches?("*", "anything:at-all")
+    end
+
+    test "plain patterns match exactly" do
+      assert Registry.network_matches?("eip155:1", "eip155:1")
+      refute Registry.network_matches?("eip155:1", "eip155:10")
+    end
+
+    test "non-binary input never matches" do
+      refute Registry.network_matches?(nil, "eip155:1")
+      refute Registry.network_matches?("eip155:*", nil)
+    end
+  end
+end

--- a/test/x402/scheme/upto_evm_test.exs
+++ b/test/x402/scheme/upto_evm_test.exs
@@ -1,0 +1,117 @@
+defmodule X402.Scheme.UptoEVMTest do
+  use ExUnit.Case, async: true
+
+  doctest X402.Scheme.UptoEVM
+
+  alias X402.Scheme.UptoEVM
+
+  @requirements %{
+    "scheme" => "upto",
+    "network" => "eip155:84532",
+    "amount" => "10000",
+    "asset" => "0xasset",
+    "payTo" => "0xreceiver",
+    "maxTimeoutSeconds" => 60,
+    "extra" => %{}
+  }
+
+  describe "metadata" do
+    test "declares upto on every EVM network" do
+      assert UptoEVM.scheme() == "upto"
+      assert UptoEVM.networks() == ["eip155:*"]
+    end
+
+    test "does not implement the client sign callback" do
+      refute function_exported?(UptoEVM, :sign, 3)
+    end
+  end
+
+  describe "validate_payload/3" do
+    test "accepts payments within the ceiling" do
+      payload = %{"payload" => %{"authorization" => %{"value" => "9000"}}}
+
+      assert UptoEVM.validate_payload(payload, @requirements, []) == :ok
+    end
+
+    test "rejects payments above the ceiling" do
+      payload = %{"payload" => %{"authorization" => %{"value" => "10001"}}}
+
+      assert UptoEVM.validate_payload(payload, @requirements, []) ==
+               {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
+    end
+
+    test "reads the Permit2 payload shape" do
+      payload = %{
+        "payload" => %{
+          "permit2Authorization" => %{"permitted" => %{"token" => "0xasset", "amount" => "10000"}}
+        }
+      }
+
+      assert UptoEVM.validate_payload(payload, @requirements, []) == :ok
+
+      oversized =
+        put_in(payload, ["payload", "permit2Authorization", "permitted", "amount"], "10001")
+
+      assert UptoEVM.validate_payload(oversized, @requirements, []) ==
+               {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
+    end
+
+    test "falls back to maxPrice and maxAmountRequired ceilings" do
+      payload = %{"payload" => %{"value" => "15"}}
+
+      assert UptoEVM.validate_payload(payload, %{"maxPrice" => "10"}, []) ==
+               {:error, {:invalid_upto_payment, :payment_value_exceeds_max_price}}
+
+      assert UptoEVM.validate_payload(payload, %{"maxAmountRequired" => "20"}, []) == :ok
+    end
+
+    test "rejects payments with no discernible value" do
+      payload = %{"payload" => %{"signature" => "0xsig"}}
+
+      assert UptoEVM.validate_payload(payload, @requirements, []) ==
+               {:error, {:invalid_upto_payment, :missing_payment_value}}
+    end
+
+    test "rejects payments with no discernible ceiling" do
+      payload = %{"payload" => %{"value" => "10"}}
+
+      assert UptoEVM.validate_payload(payload, %{}, []) ==
+               {:error, {:invalid_upto_payment, :missing_max_price}}
+    end
+
+    test "rejects unparsable values" do
+      payload = %{"payload" => %{"value" => "lots"}}
+
+      assert UptoEVM.validate_payload(payload, @requirements, []) ==
+               {:error, {:invalid_upto_payment, :invalid_payment_value}}
+
+      assert UptoEVM.validate_payload(%{"payload" => %{"value" => "10"}}, %{"amount" => "??"}, []) ==
+               {:error, {:invalid_upto_payment, :invalid_max_price}}
+    end
+  end
+
+  describe "precheck/3" do
+    test "checks payTo binding but not amount equality" do
+      now = System.system_time(:second)
+
+      payload = %{
+        "payload" => %{
+          "authorization" => %{
+            "to" => "0xreceiver",
+            "value" => "500",
+            "validAfter" => Integer.to_string(now - 60),
+            "validBefore" => Integer.to_string(now + 600)
+          }
+        }
+      }
+
+      # value != amount is fine for upto — the signed value is a ceiling.
+      assert UptoEVM.precheck(payload, @requirements, []) == :ok
+
+      mismatched = put_in(payload, ["payload", "authorization", "to"], "0xother")
+
+      assert UptoEVM.precheck(mismatched, @requirements, []) ==
+               {:error, {:precheck_failed, :pay_to_mismatch}}
+    end
+  end
+end

--- a/test/x402/scheme_integration_test.exs
+++ b/test/x402/scheme_integration_test.exs
@@ -1,0 +1,263 @@
+defmodule X402.SchemeIntegrationTest do
+  @moduledoc """
+  End-to-end test of a custom `X402.Scheme` registered via the `:schemes`
+  option: a toy "cash" scheme drives the full loop — the gate advertises a
+  cash route in `PAYMENT-REQUIRED`, `X402.Client.build_payment/3` selects
+  and signs it, and `X402.Plug.PaymentGate` validates, pre-checks,
+  verifies, and settles it against a Bypass-backed facilitator.
+  """
+
+  use ExUnit.Case, async: false
+
+  import Plug.Conn
+  import Plug.Test
+
+  alias X402.Client
+  alias X402.Facilitator
+  alias X402.PaymentRequired
+  alias X402.PaymentSignature
+  alias X402.Plug.PaymentGate
+  alias X402.Signer.LocalKey
+
+  defmodule CashScheme do
+    @moduledoc false
+    @behaviour X402.Scheme
+
+    @impl X402.Scheme
+    def scheme, do: "cash"
+
+    @impl X402.Scheme
+    def networks, do: ["local:*"]
+
+    @impl X402.Scheme
+    def sign(requirements, _signer, _opts) do
+      {:ok, %{"note" => "IOU " <> Map.fetch!(requirements, "amount")}}
+    end
+
+    @impl X402.Scheme
+    def validate_payload(payload, requirements, _opts) do
+      expected = "IOU " <> Map.fetch!(requirements, "amount")
+
+      case get_in(payload, ["payload", "note"]) do
+        ^expected -> :ok
+        _other -> {:error, {:invalid_scheme_payment, :missing_note}}
+      end
+    end
+
+    @impl X402.Scheme
+    def precheck(payload, _requirements, _opts) do
+      case get_in(payload, ["payload", "counterfeit"]) do
+        true -> {:error, {:precheck_failed, :counterfeit_note}}
+        _other -> :ok
+      end
+    end
+  end
+
+  @cash_route %{
+    method: :get,
+    path: "/cash/resource",
+    scheme: "cash",
+    price: "5000",
+    network: "local:test",
+    asset: "note",
+    pay_to: "till"
+  }
+
+  @default_verify {:ok, %{status: 200, body: %{"isValid" => true, "payer" => "payer-1"}}}
+
+  @default_settle {
+    :ok,
+    %{
+      status: 200,
+      body: %{
+        "success" => true,
+        "transaction" => "cash-receipt-1",
+        "network" => "local:test",
+        "payer" => "payer-1"
+      }
+    }
+  }
+
+  defp signer do
+    {:ok, signer} = LocalKey.new(:crypto.strong_rand_bytes(32))
+    signer
+  end
+
+  defp gate_opts(facilitator) do
+    [
+      routes: [@cash_route],
+      schemes: [CashScheme],
+      facilitator: facilitator
+    ]
+  end
+
+  defp run_request(conn, facilitator) do
+    conn = PaymentGate.call(conn, PaymentGate.init(gate_opts(facilitator)))
+
+    case conn.halted do
+      true -> conn
+      false -> Plug.Conn.send_resp(conn, 200, "cash accepted")
+    end
+  end
+
+  defp decode_payment_required!(conn) do
+    [header] = get_resp_header(conn, "payment-required")
+    assert {:ok, payload} = PaymentRequired.decode(header)
+    payload
+  end
+
+  test "a custom cash scheme drives the full client → gate → facilitator loop" do
+    facilitator = start_mock_facilitator()
+
+    # 1. Unpaid request: the gate advertises the cash route.
+    unpaid = run_request(conn(:get, "/cash/resource"), facilitator)
+
+    assert unpaid.status == 402
+    payment_required = decode_payment_required!(unpaid)
+
+    assert [accept] = payment_required["accepts"]
+    assert accept["scheme"] == "cash"
+    assert accept["network"] == "local:test"
+    assert accept["amount"] == "5000"
+
+    # 2. The payer client selects and signs the cash requirement.
+    assert {:ok, payload} =
+             Client.build_payment(payment_required, signer(), schemes: [CashScheme])
+
+    assert payload["accepted"] == accept
+    assert payload["payload"] == %{"note" => "IOU 5000"}
+    assert {:ok, header} = Client.encode_payment(payload)
+
+    # 3. The paid request passes validation, pre-checks, verify, and settle.
+    paid =
+      conn(:get, "/cash/resource")
+      |> put_req_header("payment-signature", header)
+      |> run_request(facilitator)
+
+    assert paid.status == 200
+    assert paid.resp_body == "cash accepted"
+
+    assert_receive {:verify_called, verified_payload, verified_requirements}
+    assert verified_payload["payload"] == %{"note" => "IOU 5000"}
+    assert verified_requirements["scheme"] == "cash"
+
+    assert_receive {:settle_called, _settled_payload, settled_requirements}
+    assert settled_requirements["scheme"] == "cash"
+
+    assert [_response] = get_resp_header(paid, "payment-response")
+  end
+
+  test "the client cannot select cash requirements without the scheme" do
+    facilitator = start_mock_facilitator()
+    unpaid = run_request(conn(:get, "/cash/resource"), facilitator)
+    payment_required = decode_payment_required!(unpaid)
+
+    assert Client.build_payment(payment_required, signer()) ==
+             {:error, :no_acceptable_requirements}
+  end
+
+  test "the scheme's validate_payload rejects tampered payloads before the facilitator" do
+    facilitator = start_mock_facilitator()
+    unpaid = run_request(conn(:get, "/cash/resource"), facilitator)
+    payment_required = decode_payment_required!(unpaid)
+
+    {:ok, payload} = Client.build_payment(payment_required, signer(), schemes: [CashScheme])
+    tampered = put_in(payload, ["payload", "note"], "IOU 1")
+    {:ok, header} = Client.encode_payment(tampered)
+
+    rejected =
+      conn(:get, "/cash/resource")
+      |> put_req_header("payment-signature", header)
+      |> run_request(facilitator)
+
+    # {:invalid_scheme_payment, _} maps to 400 Invalid Request.
+    assert rejected.status == 400
+    refute_receive {:verify_called, _payload, _requirements}
+  end
+
+  test "the scheme's precheck rejects counterfeit payloads before the facilitator" do
+    facilitator = start_mock_facilitator()
+    unpaid = run_request(conn(:get, "/cash/resource"), facilitator)
+    payment_required = decode_payment_required!(unpaid)
+
+    {:ok, payload} = Client.build_payment(payment_required, signer(), schemes: [CashScheme])
+    counterfeit = put_in(payload, ["payload", "counterfeit"], true)
+    {:ok, header} = Client.encode_payment(counterfeit)
+
+    rejected =
+      conn(:get, "/cash/resource")
+      |> put_req_header("payment-signature", header)
+      |> run_request(facilitator)
+
+    assert rejected.status == 402
+    refute_receive {:verify_called, _payload, _requirements}
+  end
+
+  test "cash routes require the scheme to be registered on the gate" do
+    assert_raise NimbleOptions.ValidationError, ~r/scheme/, fn ->
+      PaymentGate.init(routes: [@cash_route])
+    end
+  end
+
+  test "PaymentSignature.validate/3 consults the registered scheme" do
+    accepted = %{
+      "scheme" => "cash",
+      "network" => "local:test",
+      "amount" => "5000",
+      "asset" => "note",
+      "payTo" => "till",
+      "maxTimeoutSeconds" => 60,
+      "extra" => %{}
+    }
+
+    payload = %{
+      "x402Version" => 2,
+      "accepted" => accepted,
+      "payload" => %{"note" => "IOU 5000"}
+    }
+
+    assert PaymentSignature.validate(payload, %{}, schemes: [CashScheme]) == {:ok, payload}
+
+    tampered = put_in(payload, ["payload", "note"], "IOU 1")
+
+    assert PaymentSignature.validate(tampered, %{}, schemes: [CashScheme]) ==
+             {:error, {:invalid_scheme_payment, :missing_note}}
+
+    # Without the scheme registered, the kind is unknown and passes through.
+    assert PaymentSignature.validate(tampered) == {:ok, tampered}
+  end
+
+  # Bypass-backed facilitator harness, mirroring
+  # test/x402/plug/payment_gate_test.exs.
+  defp start_mock_facilitator do
+    owner = self()
+
+    bypass = Bypass.open()
+    stub_facilitator_endpoint(bypass, owner, "/verify", :verify_called, @default_verify)
+    stub_facilitator_endpoint(bypass, owner, "/settle", :settle_called, @default_settle)
+
+    suffix = System.unique_integer([:positive, :monotonic])
+    finch = String.to_atom("scheme_integration_finch_#{suffix}")
+    name = String.to_atom("scheme_integration_facilitator_#{suffix}")
+
+    start_supervised!(Supervisor.child_spec({Finch, name: finch}, id: finch))
+
+    start_supervised!(
+      {Facilitator,
+       name: name,
+       finch: finch,
+       max_retries: 0,
+       receive_timeout_ms: 1_000,
+       url: "http://localhost:#{bypass.port}"}
+    )
+  end
+
+  defp stub_facilitator_endpoint(bypass, owner, path, tag, {:ok, %{status: status, body: body}}) do
+    Bypass.stub(bypass, "POST", path, fn conn ->
+      {:ok, request_body, conn} = Plug.Conn.read_body(conn)
+      decoded = Jason.decode!(request_body)
+      send(owner, {tag, decoded["paymentPayload"], decoded["paymentRequirements"]})
+      Plug.Conn.resp(conn, status, Jason.encode!(body))
+    end)
+  end
+end

--- a/test/x402/scheme_test.exs
+++ b/test/x402/scheme_test.exs
@@ -1,0 +1,97 @@
+defmodule X402.SchemeTest do
+  use ExUnit.Case, async: true
+
+  doctest X402.Scheme
+
+  alias X402.Scheme
+
+  defmodule MetadataOnly do
+    @moduledoc false
+    @behaviour X402.Scheme
+
+    @impl X402.Scheme
+    def scheme, do: "metadata-only"
+
+    @impl X402.Scheme
+    def networks, do: ["test:*"]
+  end
+
+  defmodule FullScheme do
+    @moduledoc false
+    @behaviour X402.Scheme
+
+    @impl X402.Scheme
+    def scheme, do: "full"
+
+    @impl X402.Scheme
+    def networks, do: ["test:*"]
+
+    @impl X402.Scheme
+    def signable?(requirements), do: Map.get(requirements, "signable", false)
+
+    @impl X402.Scheme
+    def sign(_requirements, _signer, _opts), do: {:ok, %{"signed" => true}}
+
+    @impl X402.Scheme
+    def validate_payload(_payload, _requirements, _opts), do: {:error, :always_invalid}
+
+    @impl X402.Scheme
+    def precheck(_payload, _requirements, _opts), do: {:error, {:precheck_failed, :always}}
+  end
+
+  describe "validate_module/1" do
+    test "accepts modules implementing scheme/0 and networks/0" do
+      assert Scheme.validate_module(MetadataOnly) == {:ok, MetadataOnly}
+      assert Scheme.validate_module(FullScheme) == {:ok, FullScheme}
+    end
+
+    test "rejects modules missing the required callbacks" do
+      assert {:error, message} = Scheme.validate_module(Enum)
+      assert message =~ "X402.Scheme"
+    end
+
+    test "rejects non-module terms" do
+      assert {:error, _message} = Scheme.validate_module("not a module")
+      assert {:error, _message} = Scheme.validate_module(123)
+    end
+  end
+
+  describe "signs?/1" do
+    test "reflects whether sign/3 is exported" do
+      assert Scheme.signs?(FullScheme)
+      refute Scheme.signs?(MetadataOnly)
+    end
+  end
+
+  describe "signable?/2" do
+    test "defaults to true when signable?/1 is not implemented" do
+      assert Scheme.signable?(MetadataOnly, %{})
+    end
+
+    test "delegates to the module when implemented" do
+      assert Scheme.signable?(FullScheme, %{"signable" => true})
+      refute Scheme.signable?(FullScheme, %{})
+    end
+  end
+
+  describe "validate_payload/4" do
+    test "defaults to :ok when validate_payload/3 is not implemented" do
+      assert Scheme.validate_payload(MetadataOnly, %{}, %{}, []) == :ok
+    end
+
+    test "delegates to the module when implemented" do
+      assert Scheme.validate_payload(FullScheme, %{}, %{}, []) == {:error, :always_invalid}
+    end
+  end
+
+  describe "precheck/4" do
+    test "defaults to :ok when precheck/3 is not implemented" do
+      assert Scheme.precheck(MetadataOnly, %{}, %{}, []) == :ok
+    end
+
+    test "delegates to the module when implemented" do
+      assert Scheme.precheck(FullScheme, %{}, %{}, []) ==
+               {:error, {:precheck_failed, :always}}
+    end
+  end
+end


### PR DESCRIPTION
## What

Introduces the `X402.Scheme` behaviour and registry — the architectural seam the ecosystem analysis identified as the load-bearing design decision ([docs/ecosystem-comparison.md](https://github.com/cardotrejos/x402/blob/main/docs/ecosystem-comparison.md) §5.1, §5.3.1, §8 P1.1): every mature SDK makes a scheme a pluggable unit registered per (scheme, network); ours hardcoded scheme logic across three modules, so adding upto-Permit2 or SVM meant editing core files instead of adding one module.

- **Behaviour**: `scheme/0`, `networks/0` (CAIP-2 patterns with trailing-`*` wildcards), and optional `signable?/1`, `sign/3` (client), `validate_payload/3`, `precheck/3` (server) — missing callbacks default to neutral.
- **Registry**: exact CAIP-2 match beats wildcard, longest wildcard wins, user modules override built-ins. No app env — a `schemes: [module]` option on gate opts, client opts, and `PaymentSignature.validate`.
- **Built-ins extracted, not duplicated**: `X402.Scheme.ExactEVM` and `X402.Scheme.UptoEVM` carry the logic that lived in `X402.Client`'s dispatch, the gate's prechecks, and `PaymentSignature`'s upto ceiling check; `X402.Scheme.EVM` holds the shared authorization prechecks for third-party EVM schemes.

## Compatibility proof

**Zero existing tests modified** — the full suite passed unmodified immediately after the refactor, before any new tests were added. `validate/1,2` / `decode_and_validate/1,2` are byte-identical delegates; with no custom schemes the gate's validate call is literally the old call; `{:unsupported_kind, ...}` and `{:missing_extra, ...}` errors preserved; extension enrichers still run after payload assembly; MCP's call sites work unchanged.

## Testing

+31 doctests / +58 tests: registry precedence (exact vs wildcard, user override), and a full custom-scheme integration test — a toy "cash" scheme on `"local:*"` driven end-to-end: gate advertises → client selects/signs via `schemes:` → gate validates and prechecks (blocking counterfeits pre-facilitator) → verify/settle over the Bypass harness, plus negative paths. 176 doctests + 716 tests, 0 failures on current main. All gates green incl. dialyzer.

## Notes

New documented mapping `{:invalid_scheme_payment, reason}` → 400 for custom validate_payload errors. Two documented scoping refinements: unregistered kinds skip gate prechecks (matching the existing absent-authorization skip), and the upto ceiling check is scoped to `eip155:*` (the facilitator's independent scheme-only check still covers network-less requirements). `X402.Scheme`'s moduledoc is the "add a chain in one module" guide — the prerequisite for upto/Permit2 (P2.2) and SVM (P2.3).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors payment verification and signing dispatch across core client and plug paths; behavior is intended to be unchanged for built-in schemes, but mistakes in registry resolution or extracted pre-checks could affect live 402 flows.
> 
> **Overview**
> Introduces **`X402.Scheme`** as the single extension point for scheme-specific **client signing**, **payload validation**, and **gate pre-checks**, with **`X402.Scheme.Registry`** resolving `(scheme, network)` pairs (user modules before built-ins; exact CAIP-2 beats wildcards).
> 
> Existing EVM **`exact`** / **`upto`** logic moves into **`X402.Scheme.ExactEVM`**, **`X402.Scheme.UptoEVM`**, and shared **`X402.Scheme.EVM.authorization_precheck/3`**; **`X402.Client`**, **`X402.Plug.PaymentGate`**, **`X402.PaymentSignature`**, and **`X402.Client.Finch`** gain a **`schemes:`** option instead of hardcoded dispatch. Default paths stay the same when **`schemes`** is empty; unregistered kinds still pass validation, skip pre-checks, and yield **`{:unsupported_kind, scheme, network}`** on the client.
> 
> The gate accepts custom route **`scheme`** names only when registered, maps **`{:invalid_scheme_payment, _}`** to **HTTP 400**, and documents registration in **`guides/custom-schemes.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4407c2d0748aa518f933e467f952791267a8a4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->