### PR TITLE
feat: client-side upto payments via Permit2 witness signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Client-side `upto` payments via Permit2** (ecosystem report §8 P2.2):
+  the new `X402.Permit2` module builds and signs the upto-EVM scheme's
+  Permit2 `PermitWitnessTransferFrom` — `permitted.amount` is the
+  advertised **maximum** (the server settles for actual usage up to it),
+  the spender is the canonical `x402UptoPermit2Proxy`
+  (`0x4020A4f3b7b90ccA423B9fabCc0CE57C6C240002`), and the witness struct
+  `Witness(address to,address facilitator,uint256 validAfter)` binds the
+  requirements' `payTo` and `extra.facilitatorAddress` so only the
+  announced facilitator can settle. Signing hashes against the canonical
+  version-less Permit2 EIP-712 domain (name `"Permit2"`, chain id from
+  the CAIP-2 network, verifying contract
+  `0x000000000022D473030F116dDEE9F6B43aC78BA3`);
+  `X402.EIP712.domain_separator/1` now supports such version-less
+  domains. `X402.Scheme.UptoEVM` implements `sign/3` and `signable?/1`
+  (an `eip155:*` network plus `extra.facilitatorAddress`, as delivered
+  by the facilitator's `GET /supported`), so
+  `X402.Client.build_payment/3` and `X402.Client.Finch.request/3` pay
+  `upto` requirements out of the box; entries without a facilitator
+  address are never selected, and signing one returns
+  `{:error, {:missing_extra, "facilitatorAddress"}}`. See the new
+  Metered `upto` payments section in the client guide
 - `X402.Extensions.PaymentIdentifier.RedisCache` — a Redis-backed
   `X402.Extensions.PaymentIdentifier.Cache` adapter for clustered
   deployments (ROADMAP P1.3b), over the **new optional `redix` dependency**.

--- a/guides/client.md
+++ b/guides/client.md
@@ -17,7 +17,8 @@ letting the SDK handle the `402 → sign → retry` dance.
    responds with the resource, plus a `PAYMENT-RESPONSE` header containing the
    settlement receipt.
 
-The SDK signs the `exact` scheme on EVM (`eip155:*`) networks.
+The SDK signs the `exact` scheme (EIP-3009) and the `upto` scheme
+(Permit2) on EVM (`eip155:*`) networks.
 
 ## Quick start with Finch
 
@@ -106,6 +107,43 @@ alias X402.{Client, PaymentRequired}
 
 `Client.select_requirements/2` is also public if you want to inspect or
 choose the payment option yourself before signing.
+
+## Metered `upto` payments
+
+For variable-cost resources (LLM tokens, bandwidth, compute), servers
+advertise the `upto` scheme: the client authorizes a **maximum** amount
+and the server settles for the actual usage, up to that ceiling. The
+SDK signs `upto` requirements out of the box — `build_payment/3` (and
+`X402.Client.Finch.request/3`) picks them up like any other entry, with
+`:max_amount` guarding the ceiling you are willing to authorize:
+
+```elixir
+{:ok, payload} =
+  X402.Client.build_payment(payment_required, signer,
+    scheme: "upto",
+    max_amount: "5000000"
+  )
+```
+
+Under the hood the client signs a Permit2 `PermitWitnessTransferFrom`
+(`X402.Permit2`) against the canonical Permit2 contract, with the
+requirements' `amount` as `permitted.amount` (the ceiling) and a witness
+binding the server's `payTo` and the facilitator's address, so only that
+facilitator can settle it. Two things to know:
+
+- **`extra.facilitatorAddress` is required.** Facilitators announce
+  their address via `GET /supported` (`X402.Facilitator.supported/1`)
+  and resource servers forward it in each upto entry's `extra`. Entries
+  without it are never selected, and signing one directly returns
+  `{:error, {:missing_extra, "facilitatorAddress"}}`.
+- **Permit2 needs a one-time on-chain approval.** The payer's wallet
+  must have approved the canonical Permit2 contract for the token once
+  (`approve(Permit2, ...)`); see the gas-sponsoring extensions below for
+  facilitator-funded alternatives.
+
+The signed maximum is not what you pay — the server meters actual usage
+and settles for less (or nothing). See the
+[Plug Integration](plug-integration.md) guide for the server half.
 
 ## Gas-sponsoring extensions
 

--- a/lib/x402/client.ex
+++ b/lib/x402/client.ex
@@ -11,9 +11,10 @@ defmodule X402.Client do
 
   Signing dispatches through `X402.Scheme.Registry`: out of the box this
   client signs the `exact` scheme on EVM (`eip155:*`) networks via EIP-3009
-  (`X402.Scheme.ExactEVM`); other scheme/network combinations return
-  `{:error, {:unsupported_kind, scheme, network}}` unless a matching
-  `X402.Scheme` module is passed with the `:schemes` option.
+  (`X402.Scheme.ExactEVM`) and the `upto` scheme on EVM networks via
+  Permit2 (`X402.Scheme.UptoEVM`); other scheme/network combinations
+  return `{:error, {:unsupported_kind, scheme, network}}` unless a
+  matching `X402.Scheme` module is passed with the `:schemes` option.
 
   ## Example
 
@@ -119,9 +120,11 @@ defmodule X402.Client do
   option filters **and** that this client can sign: structurally valid per
   `X402.PaymentRequirements.validate/1` and resolved by
   `X402.Scheme.Registry` to a scheme module with a sign callback — by
-  default `exact` on an `eip155:*` network via `X402.Scheme.ExactEVM`,
-  which additionally requires the EIP-712 domain fields (`extra.name` /
-  `extra.version`). Pass additional schemes with the `:schemes` option.
+  default `exact` on an `eip155:*` network via `X402.Scheme.ExactEVM`
+  (which additionally requires the EIP-712 domain fields `extra.name` /
+  `extra.version`) and `upto` on an `eip155:*` network via
+  `X402.Scheme.UptoEVM` (which requires `extra.facilitatorAddress`). Pass
+  additional schemes with the `:schemes` option.
 
   The selected entry is returned exactly as the server sent it, so it can be
   echoed verbatim as the payload's `accepted` value.
@@ -193,8 +196,9 @@ defmodule X402.Client do
   gas-sponsored Permit2 approvals.
 
   Signing dispatches on the scheme and network of the chosen requirements
-  through `X402.Scheme.Registry`; out of the box this supports `exact` on
-  `eip155:*` networks (EIP-3009). Other combinations return
+  through `X402.Scheme.Registry`; out of the box this supports `exact`
+  (EIP-3009) and `upto` (Permit2) on `eip155:*` networks. Other
+  combinations return
   `{:error, {:unsupported_kind, scheme, network}}` unless a matching
   module is passed with the `:schemes` option. Scheme modules receive the
   validated build options, so options like `:valid_after_buffer` reach

--- a/lib/x402/eip712.ex
+++ b/lib/x402/eip712.ex
@@ -3,10 +3,12 @@ defmodule X402.EIP712 do
   Generic [EIP-712](https://eips.ethereum.org/EIPS/eip-712) hashing primitives.
 
   Shared by the x402 signing modules: `X402.EIP3009` hashes
-  `TransferWithAuthorization` structs with these primitives, and
+  `TransferWithAuthorization` structs with these primitives,
+  `X402.Permit2` hashes Permit2 `PermitWitnessTransferFrom` structs, and
   `X402.Extensions.EIP2612GasSponsoring` hashes EIP-2612 `Permit` structs.
   The module covers the common x402 domain shape
-  (`name`/`version`/`chainId`/`verifyingContract`) and the generic
+  (`name`/`version`/`chainId`/`verifyingContract`, the version optional
+  for version-less domains such as Permit2's) and the generic
   `hash_struct/2` / `digest/2` combination
 
       digest = keccak256(0x19 0x01 || domainSeparator || structHash)
@@ -22,17 +24,21 @@ defmodule X402.EIP712 do
   alias X402.Wallet
 
   @domain_type "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+  @domain_type_no_version "EIP712Domain(string name,uint256 chainId,address verifyingContract)"
 
   @typedoc """
   An EIP-712 domain map with `:name`, `:version`, `:chain_id`, and
   `:verifying_contract` keys.
 
   Functions accepting a domain also take the wire-style keys
-  (`"name"`, `"version"`, `"chainId"`, `"verifyingContract"`).
+  (`"name"`, `"version"`, `"chainId"`, `"verifyingContract"`). Domains
+  whose contracts declare no version (for example the canonical Permit2
+  contract) omit the version key entirely; `domain_separator/1` then hashes
+  the three-field `EIP712Domain` type.
   """
   @type domain :: %{
+          optional(:version) => String.t(),
           name: String.t(),
-          version: String.t(),
           chain_id: non_neg_integer(),
           verifying_contract: String.t()
         }
@@ -100,22 +106,31 @@ defmodule X402.EIP712 do
   Computes the EIP-712 domain separator for a domain map.
 
   Returns `keccak256(typeHash || keccak256(name) || keccak256(version) ||
-  chainId || verifyingContract)` as a 32-byte binary.
+  chainId || verifyingContract)` as a 32-byte binary. When the domain has
+  no version (absent or `nil` — for example the canonical Permit2
+  contract), the version-less three-field `EIP712Domain` type is hashed
+  instead, per EIP-712's rule that absent fields are dropped from the
+  domain type.
   """
   @spec domain_separator(map()) :: {:ok, <<_::256>>} | {:error, encode_error()}
   def domain_separator(domain) when is_map(domain) do
     with {:ok, keccak_module} <- keccak_module(),
          {:ok, name} <- fetch_field(domain, {"name", :name}),
-         {:ok, version} <- fetch_field(domain, {"version", :version}),
          {:ok, chain_id} <- fetch_field(domain, {"chainId", :chain_id}),
          {:ok, contract} <- fetch_field(domain, {"verifyingContract", :verifying_contract}),
          {:ok, chain_id_word} <- encode_uint256(chain_id),
          {:ok, contract_word} <- encode_address(contract) do
+      {type_hash, version_word} =
+        case Utils.map_value(domain, {"version", :version}) do
+          nil -> {keccak_module.hash_256(@domain_type_no_version), ""}
+          version -> {keccak_module.hash_256(@domain_type), keccak_module.hash_256(version)}
+        end
+
       {:ok,
        keccak_module.hash_256(
-         keccak_module.hash_256(@domain_type) <>
+         type_hash <>
            keccak_module.hash_256(name) <>
-           keccak_module.hash_256(version) <>
+           version_word <>
            chain_id_word <>
            contract_word
        )}

--- a/lib/x402/permit2.ex
+++ b/lib/x402/permit2.ex
@@ -1,0 +1,418 @@
+defmodule X402.Permit2 do
+  @moduledoc """
+  Permit2 `PermitWitnessTransferFrom` building and EIP-712 signing for the
+  x402 `upto` scheme on EVM networks.
+
+  Implements the client half of the `upto` scheme: building a Permit2
+  authorization from v2 payment requirements, computing its EIP-712 digest
+  against the canonical Permit2 domain, and signing it through the
+  `X402.Signer` behaviour to produce the scheme `payload` map
+
+      %{"signature" => "0x...", "permit2Authorization" => %{...}}
+
+  carried inside a v2 `PaymentPayload` (see `X402.Client.build_payment/3`
+  for the full envelope).
+
+  ## The upto authorization
+
+  Per the upto-EVM scheme specification, the client signs a
+  `PermitWitnessTransferFrom` message for the canonical
+  [Permit2](https://github.com/Uniswap/permit2) contract
+  (`#{"0x000000000022D473030F116dDEE9F6B43aC78BA3"}`) where
+
+  * `permitted.token` / `permitted.amount` are the requirements' `asset`
+    and `amount` — the amount is the **maximum** the client authorizes; the
+    server settles for the actual usage, up to this ceiling;
+  * `spender` is the `x402UptoPermit2Proxy` contract
+    (`#{"0x4020A4f3b7b90ccA423B9fabCc0CE57C6C240002"}`), deployed at the
+    same address on every supported EVM chain;
+  * the witness struct
+    `Witness(address to,address facilitator,uint256 validAfter)` binds the
+    requirements' `payTo` (`to`) and the facilitator announced in
+    `extra.facilitatorAddress` (`facilitator`), so no other party can
+    settle the authorization. Facilitators announce their address via
+    `GET /supported` (`X402.Facilitator.supported/1`), and resource
+    servers forward it inside each upto requirements entry's `extra`.
+
+  The EIP-712 domain is the canonical Permit2 domain — name `"Permit2"`,
+  the chain id from the CAIP-2 `network`, the Permit2 contract as the
+  verifying contract, and **no version field**.
+
+  Cryptographic operations require the optional `ex_secp256k1` and
+  `ex_keccak` dependencies and return `{:error, :missing_dependency}` when
+  they are unavailable; the library itself compiles without them.
+  """
+
+  alias X402.EIP712
+  alias X402.Signer
+  alias X402.Utils
+
+  @permit2_address "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+  @upto_proxy_address "0x4020A4f3b7b90ccA423B9fabCc0CE57C6C240002"
+
+  @token_permissions_type "TokenPermissions(address token,uint256 amount)"
+  @upto_witness_type "Witness(address to,address facilitator,uint256 validAfter)"
+
+  # EIP-712 encodeType: referenced struct types are appended in alphabetical
+  # order (TokenPermissions before Witness).
+  @upto_permit_type "PermitWitnessTransferFrom(TokenPermissions permitted,address spender," <>
+                      "uint256 nonce,uint256 deadline,Witness witness)" <>
+                      @token_permissions_type <> @upto_witness_type
+
+  @typed_data_types %{
+    "EIP712Domain" => [
+      %{"name" => "name", "type" => "string"},
+      %{"name" => "chainId", "type" => "uint256"},
+      %{"name" => "verifyingContract", "type" => "address"}
+    ],
+    "PermitWitnessTransferFrom" => [
+      %{"name" => "permitted", "type" => "TokenPermissions"},
+      %{"name" => "spender", "type" => "address"},
+      %{"name" => "nonce", "type" => "uint256"},
+      %{"name" => "deadline", "type" => "uint256"},
+      %{"name" => "witness", "type" => "Witness"}
+    ],
+    "TokenPermissions" => [
+      %{"name" => "token", "type" => "address"},
+      %{"name" => "amount", "type" => "uint256"}
+    ],
+    "Witness" => [
+      %{"name" => "to", "type" => "address"},
+      %{"name" => "facilitator", "type" => "address"},
+      %{"name" => "validAfter", "type" => "uint256"}
+    ]
+  }
+
+  @typedoc """
+  A Permit2 `PermitWitnessTransferFrom` authorization in wire shape.
+
+  String keys `"from"`, `"permitted"` (`%{"token", "amount"}`),
+  `"spender"`, `"nonce"`, `"deadline"`, and `"witness"`
+  (`%{"to", "facilitator", "validAfter"}`).
+  """
+  @type authorization :: %{optional(String.t()) => String.t() | map()}
+
+  @typedoc "The scheme `payload` map for a signed upto Permit2 payment."
+  @type payload :: %{optional(String.t()) => String.t() | authorization()}
+
+  @type domain_error :: :invalid_requirements | :unsupported_network
+
+  @type authorization_error ::
+          :invalid_requirements | {:missing_extra, String.t()}
+
+  @type encode_error :: EIP712.encode_error()
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the canonical Permit2 contract address.
+
+  ## Examples
+
+      iex> X402.Permit2.permit2_address()
+      "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+  """
+  @spec permit2_address() :: String.t()
+  def permit2_address, do: @permit2_address
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the `x402UptoPermit2Proxy` contract address — the upto spender.
+
+  Deployed at the same address on every supported EVM chain via `CREATE2`.
+
+  ## Examples
+
+      iex> X402.Permit2.upto_proxy_address()
+      "0x4020A4f3b7b90ccA423B9fabCc0CE57C6C240002"
+  """
+  @spec upto_proxy_address() :: String.t()
+  def upto_proxy_address, do: @upto_proxy_address
+
+  @doc since: "0.6.0"
+  @doc """
+  Signs the `upto` Permit2 scheme payload for the given requirements.
+
+  Derives the canonical Permit2 domain from the requirements' `network`,
+  builds a fresh authorization from the signer's address (`from`), the
+  requirements' `asset`/`amount` (`permitted`), `payTo` and
+  `extra.facilitatorAddress` (the witness), and `maxTimeoutSeconds` (the
+  `deadline`), computes the EIP-712 digest, and signs it through `signer`.
+
+  Requirements without `extra.facilitatorAddress` return
+  `{:error, {:missing_extra, "facilitatorAddress"}}` — the facilitator
+  address is required so the witness can bind settlement to it.
+
+  ## Examples
+
+      {:ok, signer} = X402.Signer.LocalKey.new(private_key)
+
+      {:ok, %{"signature" => _, "permit2Authorization" => _}} =
+        X402.Permit2.sign_upto(
+          %{
+            "scheme" => "upto",
+            "network" => "eip155:84532",
+            "amount" => "5000000",
+            "asset" => "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+            "payTo" => "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+            "maxTimeoutSeconds" => 300,
+            "extra" => %{
+              "name" => "USDC",
+              "version" => "2",
+              "facilitatorAddress" => "0x2222222222222222222222222222222222222222"
+            }
+          },
+          signer
+        )
+  """
+  @spec sign_upto(map(), Signer.t()) ::
+          {:ok, payload()}
+          | {:error, domain_error() | authorization_error() | encode_error() | term()}
+  def sign_upto(requirements, signer) when is_map(requirements) do
+    with {:ok, domain} <- upto_domain(requirements),
+         {:ok, from} <- Signer.address(signer),
+         {:ok, authorization} <- build_upto_authorization(requirements, from),
+         {:ok, signature} <- sign_authorization(signer, domain, authorization) do
+      {:ok, %{"signature" => signature, "permit2Authorization" => authorization}}
+    end
+  end
+
+  def sign_upto(_requirements, _signer), do: {:error, :invalid_requirements}
+
+  @doc since: "0.6.0"
+  @doc """
+  Derives the canonical Permit2 EIP-712 domain from v2 payment requirements.
+
+  The domain is `name: "Permit2"`, the chain id from the CAIP-2 `network`,
+  and the canonical Permit2 contract as the verifying contract. Permit2
+  declares no domain version, so the returned map carries no `:version`
+  key and `X402.EIP712.domain_separator/1` hashes the three-field
+  `EIP712Domain` type.
+
+  ## Examples
+
+      iex> X402.Permit2.upto_domain(%{"network" => "eip155:84532"})
+      {:ok,
+       %{
+         name: "Permit2",
+         chain_id: 84532,
+         verifying_contract: "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+       }}
+
+      iex> X402.Permit2.upto_domain(%{"network" => "solana:mainnet"})
+      {:error, :unsupported_network}
+  """
+  @spec upto_domain(map()) :: {:ok, EIP712.domain()} | {:error, domain_error()}
+  def upto_domain(requirements) when is_map(requirements) do
+    network = Utils.map_value(requirements, {"network", :network})
+
+    with {:ok, chain_id} <- EIP712.chain_id_from_caip2(network) do
+      {:ok, %{name: "Permit2", chain_id: chain_id, verifying_contract: @permit2_address}}
+    end
+  end
+
+  def upto_domain(_requirements), do: {:error, :invalid_requirements}
+
+  @doc since: "0.6.0"
+  @doc """
+  Fetches the facilitator address from the requirements' `extra`.
+
+  The upto scheme requires `extra.facilitatorAddress` — the facilitator
+  announces it via `GET /supported` (`X402.Facilitator.supported/1`) and
+  the resource server forwards it in each upto requirements entry; the
+  client binds it into the signed witness.
+
+  ## Examples
+
+      iex> X402.Permit2.facilitator_address(%{
+      ...>   "extra" => %{"facilitatorAddress" => "0x2222222222222222222222222222222222222222"}
+      ...> })
+      {:ok, "0x2222222222222222222222222222222222222222"}
+
+      iex> X402.Permit2.facilitator_address(%{"extra" => %{}})
+      {:error, {:missing_extra, "facilitatorAddress"}}
+  """
+  @spec facilitator_address(map()) ::
+          {:ok, String.t()} | {:error, {:missing_extra, String.t()}}
+  def facilitator_address(requirements) when is_map(requirements) do
+    extra = Utils.map_value(requirements, {"extra", :extra}) || %{}
+
+    case is_map(extra) && Utils.map_value(extra, {"facilitatorAddress", :facilitatorAddress}) do
+      address when is_binary(address) and address != "" -> {:ok, address}
+      _missing -> {:error, {:missing_extra, "facilitatorAddress"}}
+    end
+  end
+
+  def facilitator_address(_requirements), do: {:error, {:missing_extra, "facilitatorAddress"}}
+
+  @doc since: "0.6.0"
+  @doc """
+  Builds an upto `PermitWitnessTransferFrom` authorization in wire shape.
+
+  `permitted` carries the requirements' `asset` and maximum `amount`; the
+  `spender` is the `x402UptoPermit2Proxy`; the `nonce` is a fresh random
+  uint256; the `deadline` is now plus `maxTimeoutSeconds`; and the witness
+  binds `payTo` (`to`), `extra.facilitatorAddress` (`facilitator`), and
+  `validAfter` `"0"` (immediately valid), mirroring the reference SDKs.
+
+  Field values are validated when the digest is computed, not here.
+  """
+  @spec build_upto_authorization(map(), String.t()) ::
+          {:ok, authorization()} | {:error, authorization_error()}
+  def build_upto_authorization(requirements, from)
+      when is_map(requirements) and is_binary(from) do
+    amount = Utils.map_value(requirements, {"amount", :amount})
+    asset = Utils.map_value(requirements, {"asset", :asset})
+    pay_to = Utils.map_value(requirements, {"payTo", :payTo})
+    max_timeout = Utils.map_value(requirements, {"maxTimeoutSeconds", :maxTimeoutSeconds})
+
+    with {:ok, facilitator} <- facilitator_address(requirements) do
+      if is_binary(amount) and is_binary(asset) and is_binary(pay_to) and
+           is_integer(max_timeout) and max_timeout > 0 do
+        {:ok,
+         %{
+           "from" => from,
+           "permitted" => %{"token" => asset, "amount" => amount},
+           "spender" => @upto_proxy_address,
+           "nonce" => random_nonce(),
+           "deadline" => Integer.to_string(System.os_time(:second) + max_timeout),
+           "witness" => %{"to" => pay_to, "facilitator" => facilitator, "validAfter" => "0"}
+         }}
+      else
+        {:error, :invalid_requirements}
+      end
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Signs an authorization's EIP-712 digest with a signer.
+
+  Returns the `0x`-prefixed 65-byte `r || s || v` signature.
+  """
+  @spec sign_authorization(Signer.t(), map(), map()) ::
+          {:ok, String.t()} | {:error, encode_error() | term()}
+  def sign_authorization(signer, domain, authorization)
+      when is_map(domain) and is_map(authorization) do
+    with {:ok, digest} <- upto_digest(domain, authorization),
+         {:ok, signature} <- Signer.sign_eip712(signer, digest, typed_data(domain, authorization)) do
+      {:ok, "0x" <> Base.encode16(signature, case: :lower)}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Computes the EIP-712 digest of an upto `PermitWitnessTransferFrom`.
+
+  Returns `keccak256(0x19 0x01 || domainSeparator || structHash)` as a
+  32-byte binary — the value the client signs and the value to recover
+  the payer address from (`X402.EIP3009.recover_signer/2`). `domain` and
+  `authorization` accept both the internal snake-case atom keys and the
+  wire-style string keys; the authorization's `from` is not part of the
+  signed struct (Permit2 recovers the owner from the signature).
+  """
+  @spec upto_digest(map(), map()) :: {:ok, <<_::256>>} | {:error, encode_error()}
+  def upto_digest(domain, authorization) when is_map(domain) and is_map(authorization) do
+    with {:ok, struct_hash} <- struct_hash(authorization) do
+      EIP712.digest(domain, struct_hash)
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns a fresh random uint256 nonce as a decimal string.
+
+  Permit2 uses unordered nonces; the reference SDKs draw 32 random bytes
+  per authorization, making collisions negligible.
+
+  ## Examples
+
+      iex> nonce = X402.Permit2.random_nonce()
+      iex> String.match?(nonce, ~r/^[0-9]+$/)
+      true
+  """
+  @spec random_nonce() :: String.t()
+  def random_nonce do
+    32 |> :crypto.strong_rand_bytes() |> :binary.decode_unsigned() |> Integer.to_string()
+  end
+
+  # -- Struct hashing ---------------------------------------------------------
+
+  @spec struct_hash(map()) :: {:ok, <<_::256>>} | {:error, encode_error()}
+  defp struct_hash(authorization) do
+    with {:ok, permitted} <- fetch_field(authorization, {"permitted", :permitted}),
+         {:ok, spender} <- fetch_field(authorization, {"spender", :spender}),
+         {:ok, nonce} <- fetch_field(authorization, {"nonce", :nonce}),
+         {:ok, deadline} <- fetch_field(authorization, {"deadline", :deadline}),
+         {:ok, witness} <- fetch_field(authorization, {"witness", :witness}),
+         {:ok, permitted_hash} <- token_permissions_hash(permitted),
+         {:ok, witness_hash} <- witness_hash(witness),
+         {:ok, spender_word} <- EIP712.encode_address(spender),
+         {:ok, nonce_word} <- EIP712.encode_uint256(nonce),
+         {:ok, deadline_word} <- EIP712.encode_uint256(deadline) do
+      EIP712.hash_struct(@upto_permit_type, [
+        permitted_hash,
+        spender_word,
+        nonce_word,
+        deadline_word,
+        witness_hash
+      ])
+    end
+  end
+
+  @spec token_permissions_hash(term()) :: {:ok, <<_::256>>} | {:error, encode_error()}
+  defp token_permissions_hash(permitted) when is_map(permitted) do
+    with {:ok, token} <- fetch_field(permitted, {"token", :token}),
+         {:ok, amount} <- fetch_field(permitted, {"amount", :amount}),
+         {:ok, token_word} <- EIP712.encode_address(token),
+         {:ok, amount_word} <- EIP712.encode_uint256(amount) do
+      EIP712.hash_struct(@token_permissions_type, [token_word, amount_word])
+    end
+  end
+
+  defp token_permissions_hash(_permitted), do: {:error, {:missing_field, "permitted"}}
+
+  @spec witness_hash(term()) :: {:ok, <<_::256>>} | {:error, encode_error()}
+  defp witness_hash(witness) when is_map(witness) do
+    with {:ok, to} <- fetch_field(witness, {"to", :to}),
+         {:ok, facilitator} <- fetch_field(witness, {"facilitator", :facilitator}),
+         {:ok, valid_after} <- fetch_field(witness, {"validAfter", :validAfter}),
+         {:ok, to_word} <- EIP712.encode_address(to),
+         {:ok, facilitator_word} <- EIP712.encode_address(facilitator),
+         {:ok, valid_after_word} <- EIP712.encode_uint256(valid_after) do
+      EIP712.hash_struct(@upto_witness_type, [to_word, facilitator_word, valid_after_word])
+    end
+  end
+
+  defp witness_hash(_witness), do: {:error, {:missing_field, "witness"}}
+
+  @spec typed_data(map(), map()) :: Signer.typed_data()
+  defp typed_data(domain, authorization) do
+    %{
+      "types" => @typed_data_types,
+      "primaryType" => "PermitWitnessTransferFrom",
+      "domain" => %{
+        "name" => Utils.map_value(domain, {"name", :name}),
+        "chainId" => Utils.map_value(domain, {"chainId", :chain_id}),
+        "verifyingContract" => Utils.map_value(domain, {"verifyingContract", :verifying_contract})
+      },
+      "message" => %{
+        "permitted" => Utils.map_value(authorization, {"permitted", :permitted}),
+        "spender" => Utils.map_value(authorization, {"spender", :spender}),
+        "nonce" => Utils.map_value(authorization, {"nonce", :nonce}),
+        "deadline" => Utils.map_value(authorization, {"deadline", :deadline}),
+        "witness" => Utils.map_value(authorization, {"witness", :witness})
+      }
+    }
+  end
+
+  # -- Field access -----------------------------------------------------------
+
+  @spec fetch_field(map(), {String.t(), atom()}) ::
+          {:ok, term()} | {:error, {:missing_field, String.t()}}
+  defp fetch_field(map, {string_key, _atom_key} = key) do
+    case Utils.map_value(map, key) do
+      nil -> {:error, {:missing_field, string_key}}
+      value -> {:ok, value}
+    end
+  end
+end

--- a/lib/x402/scheme.ex
+++ b/lib/x402/scheme.ex
@@ -15,9 +15,8 @@ defmodule X402.Scheme do
 
   The built-in schemes are `X402.Scheme.ExactEVM` (`exact` on `eip155:*`
   networks via EIP-3009) and `X402.Scheme.UptoEVM` (`upto` on `eip155:*`
-  networks, server-side only). Resolution — including wildcard CAIP-2
-  matching and exact-match precedence — is handled by
-  `X402.Scheme.Registry`.
+  networks via Permit2). Resolution — including wildcard CAIP-2 matching
+  and exact-match precedence — is handled by `X402.Scheme.Registry`.
 
   ## Callbacks and the roles they serve
 
@@ -32,8 +31,8 @@ defmodule X402.Scheme do
 
   Only `c:scheme/0` and `c:networks/0` are required. A scheme module
   implements the callbacks for the roles it plays: a client-only scheme can
-  omit `c:validate_payload/3` and `c:precheck/3`; a server-only scheme (like
-  `X402.Scheme.UptoEVM`) can omit `c:sign/3`. Missing optional callbacks are
+  omit `c:validate_payload/3` and `c:precheck/3`; a server-only scheme can
+  omit `c:sign/3`. Missing optional callbacks are
   neutral — signing falls back to the `{:unsupported_kind, scheme, network}`
   error, while validation and pre-checks pass through with `:ok` (the
   facilitator remains the authority).
@@ -228,7 +227,7 @@ defmodule X402.Scheme do
       true
 
       iex> X402.Scheme.signs?(X402.Scheme.UptoEVM)
-      false
+      true
   """
   @spec signs?(t()) :: boolean()
   def signs?(module), do: Code.ensure_loaded?(module) and function_exported?(module, :sign, 3)
@@ -239,7 +238,10 @@ defmodule X402.Scheme do
 
   ## Examples
 
-      iex> X402.Scheme.signable?(X402.Scheme.UptoEVM, %{})
+      iex> X402.Scheme.signable?(X402.Scheme.UptoEVM, %{
+      ...>   "network" => "eip155:84532",
+      ...>   "extra" => %{"facilitatorAddress" => "0x2222222222222222222222222222222222222222"}
+      ...> })
       true
 
       iex> X402.Scheme.signable?(X402.Scheme.ExactEVM, %{})

--- a/lib/x402/scheme/upto_evm.ex
+++ b/lib/x402/scheme/upto_evm.ex
@@ -2,28 +2,38 @@ defmodule X402.Scheme.UptoEVM do
   @moduledoc """
   Built-in `X402.Scheme` for `upto` payments on EVM (`eip155:*`) networks.
 
-  Server-side only in this release: `c:X402.Scheme.validate_payload/3`
-  validates that the payment value the client signed does not exceed the
-  advertised maximum (the requirements' `amount`, with `maxPrice` and
-  `maxAmountRequired` fallbacks), recognizing the Permit2
-  (`permit2Authorization.permitted.amount`), `maxAmount`, `value`, and
-  EIP-3009 `authorization.value` payload shapes. Failures are
-  `{:error, {:invalid_upto_payment, reason}}` — see `t:validation_error/0`.
+  Implements both roles:
+
+  * **Client** — signs a Permit2 `PermitWitnessTransferFrom` through
+    `X402.Permit2`, producing the
+    `%{"signature" => ..., "permit2Authorization" => ...}` scheme payload.
+    The signed `permitted.amount` is the advertised **maximum**; the
+    server settles for the actual usage, up to that ceiling. An entry is
+    signable when its network is EVM (`eip155:*`) and its `extra` carries
+    the `facilitatorAddress` the witness must bind (facilitators announce
+    it via `GET /supported` — `X402.Facilitator.supported/1`); signing
+    without it fails with `{:error, {:missing_extra, "facilitatorAddress"}}`.
+  * **Server** — `c:X402.Scheme.validate_payload/3` validates that the
+    payment value the client signed does not exceed the advertised maximum
+    (the requirements' `amount`, with `maxPrice` and `maxAmountRequired`
+    fallbacks), recognizing the Permit2
+    (`permit2Authorization.permitted.amount`), `maxAmount`, `value`, and
+    EIP-3009 `authorization.value` payload shapes. Failures are
+    `{:error, {:invalid_upto_payment, reason}}` — see
+    `t:validation_error/0`.
 
   Pre-checks reuse the shared EIP-3009 authorization checks
   (`X402.Scheme.EVM.authorization_precheck/3` — payTo binding and validity
   window) without the exact-amount equality: for `upto`, the signed value
-  is a ceiling, not the settled amount.
-
-  `c:X402.Scheme.sign/3` is intentionally not implemented — `X402.Client`
-  cannot yet sign `upto` payments, so `upto` requirements return
-  `{:error, {:unsupported_kind, "upto", network}}` from
-  `X402.Client.build_payment/3`.
+  is a ceiling, not the settled amount. Permit2 payloads carry no
+  `payload.authorization` map and pass through to the facilitator.
   """
 
   @behaviour X402.Scheme
 
+  alias X402.Permit2
   alias X402.Scheme.EVM
+  alias X402.Signer
   alias X402.Utils
 
   @typedoc "Reasons an `upto` payment fails ceiling validation."
@@ -59,6 +69,47 @@ defmodule X402.Scheme.UptoEVM do
   @impl X402.Scheme
   @spec networks() :: [String.t()]
   def networks, do: ["eip155:*"]
+
+  @doc since: "0.6.0"
+  @doc """
+  Whether the client can sign this requirements entry.
+
+  Requires an EVM (`eip155:*`) network the Permit2 domain can be derived
+  from and a `facilitatorAddress` in `extra` for the witness binding.
+
+  ## Examples
+
+      iex> X402.Scheme.UptoEVM.signable?(%{
+      ...>   "network" => "eip155:84532",
+      ...>   "extra" => %{"facilitatorAddress" => "0x2222222222222222222222222222222222222222"}
+      ...> })
+      true
+
+      iex> X402.Scheme.UptoEVM.signable?(%{"network" => "eip155:84532", "extra" => %{}})
+      false
+  """
+  @impl X402.Scheme
+  @spec signable?(map()) :: boolean()
+  def signable?(requirements) when is_map(requirements) do
+    match?({:ok, _domain}, Permit2.upto_domain(requirements)) and
+      match?({:ok, _address}, Permit2.facilitator_address(requirements))
+  end
+
+  def signable?(_requirements), do: false
+
+  @doc since: "0.6.0"
+  @doc """
+  Signs the Permit2 `upto` scheme payload via `X402.Permit2.sign_upto/2`.
+
+  The client's build options are ignored — the authorization is valid
+  immediately (`witness.validAfter` `"0"`) and expires after the
+  requirements' `maxTimeoutSeconds`, mirroring the reference SDKs.
+  """
+  @impl X402.Scheme
+  @spec sign(map(), Signer.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  def sign(requirements, signer, _opts) do
+    Permit2.sign_upto(requirements, signer)
+  end
 
   @doc since: "0.6.0"
   @doc """

--- a/test/x402/client_test.exs
+++ b/test/x402/client_test.exs
@@ -236,7 +236,9 @@ defmodule X402.ClientTest do
                payload["payload"]
 
       assert authorization["permitted"]["amount"] == upto["amount"]
-      assert authorization["witness"]["facilitator"] == "0x2222222222222222222222222222222222222222"
+
+      assert authorization["witness"]["facilitator"] ==
+               "0x2222222222222222222222222222222222222222"
 
       # Without the facilitator address, the upto scheme cannot sign.
       assert Client.build_payment(Map.put(upto, "extra", %{}), signer()) ==

--- a/test/x402/client_test.exs
+++ b/test/x402/client_test.exs
@@ -211,13 +211,36 @@ defmodule X402.ClientTest do
     end
 
     test "returns unsupported_kind for schemes and networks it cannot sign" do
-      upto = Map.put(@evm_requirements, "scheme", "upto")
+      cash = Map.put(@evm_requirements, "scheme", "cash")
 
-      assert Client.build_payment(upto, signer()) ==
-               {:error, {:unsupported_kind, "upto", "eip155:84532"}}
+      assert Client.build_payment(cash, signer()) ==
+               {:error, {:unsupported_kind, "cash", "eip155:84532"}}
 
       assert Client.build_payment(@solana_requirements, signer()) ==
                {:error, {:unsupported_kind, "exact", "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"}}
+    end
+
+    test "signs upto requirements via Permit2 when extra carries facilitatorAddress" do
+      upto =
+        @evm_requirements
+        |> Map.put("scheme", "upto")
+        |> put_in(
+          ["extra", "facilitatorAddress"],
+          "0x2222222222222222222222222222222222222222"
+        )
+
+      assert {:ok, payload} = Client.build_payment(upto, signer())
+      assert payload["accepted"] == upto
+
+      assert %{"signature" => "0x" <> _, "permit2Authorization" => authorization} =
+               payload["payload"]
+
+      assert authorization["permitted"]["amount"] == upto["amount"]
+      assert authorization["witness"]["facilitator"] == "0x2222222222222222222222222222222222222222"
+
+      # Without the facilitator address, the upto scheme cannot sign.
+      assert Client.build_payment(Map.put(upto, "extra", %{}), signer()) ==
+               {:error, {:missing_extra, "facilitatorAddress"}}
     end
 
     test "propagates signing errors for bare requirements" do

--- a/test/x402/eip712_test.exs
+++ b/test/x402/eip712_test.exs
@@ -79,6 +79,25 @@ defmodule X402.EIP712Test do
       assert EIP712.domain_separator(%{@domain | verifying_contract: "0xnope"}) ==
                {:error, :invalid_address}
     end
+
+    test "hashes the three-field EIP712Domain type for version-less domains" do
+      domain = %{name: "Permit2", chain_id: 84_532, verifying_contract: @contract}
+
+      "0x" <> contract_hex = @contract
+      contract_word = <<0::96, Base.decode16!(contract_hex, case: :mixed)::binary>>
+
+      expected =
+        ExKeccak.hash_256(
+          ExKeccak.hash_256("EIP712Domain(string name,uint256 chainId,address verifyingContract)") <>
+            ExKeccak.hash_256("Permit2") <> <<84_532::256>> <> contract_word
+        )
+
+      assert EIP712.domain_separator(domain) == {:ok, expected}
+
+      # A versioned domain hashes differently.
+      assert {:ok, versioned} = EIP712.domain_separator(Map.put(domain, :version, "1"))
+      refute versioned == expected
+    end
   end
 
   describe "hash_struct/2 and digest/2" do

--- a/test/x402/permit2_test.exs
+++ b/test/x402/permit2_test.exs
@@ -162,9 +162,7 @@ defmodule X402.Permit2Test do
 
       domain_separator =
         ExKeccak.hash_256(
-          ExKeccak.hash_256(
-            "EIP712Domain(string name,uint256 chainId,address verifyingContract)"
-          ) <>
+          ExKeccak.hash_256("EIP712Domain(string name,uint256 chainId,address verifyingContract)") <>
             ExKeccak.hash_256("Permit2") <> <<84_532::256>> <> address_word(@permit2)
         )
 

--- a/test/x402/permit2_test.exs
+++ b/test/x402/permit2_test.exs
@@ -1,0 +1,224 @@
+defmodule X402.Permit2Test do
+  use ExUnit.Case, async: true
+
+  doctest X402.Permit2
+
+  alias X402.EIP3009
+  alias X402.Permit2
+  alias X402.Signer
+  alias X402.Signer.LocalKey
+
+  @asset "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+  @pay_to "0x209693Bc6afc0C5328bA36FaF03C514EF312287C"
+  @facilitator "0x2222222222222222222222222222222222222222"
+  @spender "0x4020A4f3b7b90ccA423B9fabCc0CE57C6C240002"
+  @permit2 "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+
+  @requirements %{
+    "scheme" => "upto",
+    "network" => "eip155:84532",
+    "amount" => "5000000",
+    "asset" => @asset,
+    "payTo" => @pay_to,
+    "maxTimeoutSeconds" => 300,
+    "extra" => %{
+      "name" => "USDC",
+      "version" => "2",
+      "facilitatorAddress" => @facilitator
+    }
+  }
+
+  # EIP-712 type strings transcribed from the reference contracts: the
+  # canonical Permit2 _PERMIT_TRANSFER_FROM_WITNESS_TYPEHASH_STUB plus the
+  # x402UptoPermit2Proxy WITNESS_TYPE_STRING.
+  @permit_stub "PermitWitnessTransferFrom(TokenPermissions permitted,address spender," <>
+                 "uint256 nonce,uint256 deadline,"
+  @witness_type_string "Witness witness)TokenPermissions(address token,uint256 amount)" <>
+                         "Witness(address to,address facilitator,uint256 validAfter)"
+
+  defp signer do
+    {:ok, signer} = LocalKey.new("0x" <> String.duplicate("11", 32))
+    signer
+  end
+
+  defp address_word("0x" <> hex), do: <<0::96, Base.decode16!(hex, case: :mixed)::binary>>
+
+  defp uint_word(value) when is_binary(value),
+    do: <<String.to_integer(value)::unsigned-big-integer-size(256)>>
+
+  describe "upto_domain/1" do
+    test "carries no version key" do
+      assert {:ok, domain} = Permit2.upto_domain(@requirements)
+      refute Map.has_key?(domain, :version)
+      assert domain.verifying_contract == @permit2
+    end
+
+    test "rejects malformed requirements" do
+      assert Permit2.upto_domain("nope") == {:error, :invalid_requirements}
+      assert Permit2.upto_domain(%{"network" => "eip155:x"}) == {:error, :unsupported_network}
+    end
+  end
+
+  describe "facilitator_address/1" do
+    test "accepts atom-keyed requirements" do
+      assert Permit2.facilitator_address(%{extra: %{facilitatorAddress: @facilitator}}) ==
+               {:ok, @facilitator}
+    end
+
+    test "rejects missing, empty, or malformed extra" do
+      for requirements <- [%{}, %{"extra" => %{}}, %{"extra" => "nope"}, "nope"] do
+        assert Permit2.facilitator_address(requirements) ==
+                 {:error, {:missing_extra, "facilitatorAddress"}}
+      end
+
+      assert Permit2.facilitator_address(%{"extra" => %{"facilitatorAddress" => ""}}) ==
+               {:error, {:missing_extra, "facilitatorAddress"}}
+    end
+  end
+
+  describe "build_upto_authorization/2" do
+    test "builds the wire-shape authorization" do
+      before_build = System.os_time(:second)
+      {:ok, from} = Signer.address(signer())
+
+      assert {:ok, authorization} = Permit2.build_upto_authorization(@requirements, from)
+
+      assert authorization["from"] == from
+      assert authorization["permitted"] == %{"token" => @asset, "amount" => "5000000"}
+      assert authorization["spender"] == @spender
+
+      assert authorization["witness"] == %{
+               "to" => @pay_to,
+               "facilitator" => @facilitator,
+               "validAfter" => "0"
+             }
+
+      deadline = String.to_integer(authorization["deadline"])
+      assert deadline >= before_build + 300
+      assert deadline <= System.os_time(:second) + 300
+
+      assert String.match?(authorization["nonce"], ~r/^[0-9]+$/)
+    end
+
+    test "draws a fresh nonce per authorization" do
+      {:ok, first} = Permit2.build_upto_authorization(@requirements, @pay_to)
+      {:ok, second} = Permit2.build_upto_authorization(@requirements, @pay_to)
+
+      refute first["nonce"] == second["nonce"]
+    end
+
+    test "requires extra.facilitatorAddress" do
+      requirements = Map.put(@requirements, "extra", %{"name" => "USDC", "version" => "2"})
+
+      assert Permit2.build_upto_authorization(requirements, @pay_to) ==
+               {:error, {:missing_extra, "facilitatorAddress"}}
+    end
+
+    test "rejects structurally invalid requirements" do
+      for broken <- [
+            Map.delete(@requirements, "amount"),
+            Map.delete(@requirements, "payTo"),
+            Map.put(@requirements, "maxTimeoutSeconds", 0),
+            Map.put(@requirements, "maxTimeoutSeconds", "300")
+          ] do
+        assert Permit2.build_upto_authorization(broken, @pay_to) ==
+                 {:error, :invalid_requirements}
+      end
+    end
+  end
+
+  describe "upto_digest/2" do
+    test "matches an independent computation from the contract type strings" do
+      {:ok, domain} = Permit2.upto_domain(@requirements)
+
+      authorization = %{
+        "from" => "0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a",
+        "permitted" => %{"token" => @asset, "amount" => "5000000"},
+        "spender" => @spender,
+        "nonce" => "1234567890",
+        "deadline" => "1740672154",
+        "witness" => %{"to" => @pay_to, "facilitator" => @facilitator, "validAfter" => "0"}
+      }
+
+      token_hash =
+        ExKeccak.hash_256(
+          ExKeccak.hash_256("TokenPermissions(address token,uint256 amount)") <>
+            address_word(@asset) <> uint_word("5000000")
+        )
+
+      witness_hash =
+        ExKeccak.hash_256(
+          ExKeccak.hash_256("Witness(address to,address facilitator,uint256 validAfter)") <>
+            address_word(@pay_to) <> address_word(@facilitator) <> uint_word("0")
+        )
+
+      struct_hash =
+        ExKeccak.hash_256(
+          ExKeccak.hash_256(@permit_stub <> @witness_type_string) <>
+            token_hash <>
+            address_word(@spender) <>
+            uint_word("1234567890") <> uint_word("1740672154") <> witness_hash
+        )
+
+      domain_separator =
+        ExKeccak.hash_256(
+          ExKeccak.hash_256(
+            "EIP712Domain(string name,uint256 chainId,address verifyingContract)"
+          ) <>
+            ExKeccak.hash_256("Permit2") <> <<84_532::256>> <> address_word(@permit2)
+        )
+
+      expected = ExKeccak.hash_256(<<0x19, 0x01>> <> domain_separator <> struct_hash)
+
+      assert Permit2.upto_digest(domain, authorization) == {:ok, expected}
+    end
+
+    test "returns structured errors for missing or malformed fields" do
+      {:ok, domain} = Permit2.upto_domain(@requirements)
+      {:ok, authorization} = Permit2.build_upto_authorization(@requirements, @pay_to)
+
+      assert Permit2.upto_digest(domain, Map.delete(authorization, "witness")) ==
+               {:error, {:missing_field, "witness"}}
+
+      assert Permit2.upto_digest(domain, Map.put(authorization, "permitted", "nope")) ==
+               {:error, {:missing_field, "permitted"}}
+
+      broken = put_in(authorization, ["witness", "facilitator"], "0xnope")
+      assert Permit2.upto_digest(domain, broken) == {:error, :invalid_address}
+
+      broken = put_in(authorization, ["permitted", "amount"], "not a number")
+      assert Permit2.upto_digest(domain, broken) == {:error, :invalid_amount}
+    end
+  end
+
+  describe "sign_upto/2" do
+    test "produces a signature that recovers to the signer over the digest" do
+      signer = signer()
+      {:ok, from} = Signer.address(signer)
+
+      assert {:ok, payload} = Permit2.sign_upto(@requirements, signer)
+      assert %{"signature" => "0x" <> _, "permit2Authorization" => authorization} = payload
+      assert authorization["from"] == from
+
+      {:ok, domain} = Permit2.upto_domain(@requirements)
+      {:ok, digest} = Permit2.upto_digest(domain, authorization)
+
+      assert EIP3009.recover_signer(digest, payload["signature"]) == {:ok, from}
+    end
+
+    test "requires extra.facilitatorAddress" do
+      requirements = Map.put(@requirements, "extra", %{"name" => "USDC", "version" => "2"})
+
+      assert Permit2.sign_upto(requirements, signer()) ==
+               {:error, {:missing_extra, "facilitatorAddress"}}
+    end
+
+    test "rejects non-EVM networks and malformed input" do
+      solana = Map.put(@requirements, "network", "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp")
+
+      assert Permit2.sign_upto(solana, signer()) == {:error, :unsupported_network}
+      assert Permit2.sign_upto("nope", signer()) == {:error, :invalid_requirements}
+      assert Permit2.sign_upto(@requirements, :not_a_signer) == {:error, :invalid_signer}
+    end
+  end
+end

--- a/test/x402/scheme/upto_evm_test.exs
+++ b/test/x402/scheme/upto_evm_test.exs
@@ -4,6 +4,7 @@ defmodule X402.Scheme.UptoEVMTest do
   doctest X402.Scheme.UptoEVM
 
   alias X402.Scheme.UptoEVM
+  alias X402.Signer.LocalKey
 
   @requirements %{
     "scheme" => "upto",
@@ -42,7 +43,7 @@ defmodule X402.Scheme.UptoEVMTest do
 
   describe "sign/3" do
     test "signs the Permit2 upto payload through X402.Permit2" do
-      {:ok, signer} = X402.Signer.LocalKey.new("0x" <> String.duplicate("11", 32))
+      {:ok, signer} = LocalKey.new("0x" <> String.duplicate("11", 32))
 
       requirements = %{
         "scheme" => "upto",

--- a/test/x402/scheme/upto_evm_test.exs
+++ b/test/x402/scheme/upto_evm_test.exs
@@ -21,8 +21,45 @@ defmodule X402.Scheme.UptoEVMTest do
       assert UptoEVM.networks() == ["eip155:*"]
     end
 
-    test "does not implement the client sign callback" do
-      refute function_exported?(UptoEVM, :sign, 3)
+    test "implements the client sign callback" do
+      assert function_exported?(UptoEVM, :sign, 3)
+    end
+  end
+
+  describe "signable?/1" do
+    test "requires an EVM network and extra.facilitatorAddress" do
+      signable = %{
+        "network" => "eip155:84532",
+        "extra" => %{"facilitatorAddress" => "0x2222222222222222222222222222222222222222"}
+      }
+
+      assert UptoEVM.signable?(signable)
+      refute UptoEVM.signable?(put_in(signable, ["extra"], %{}))
+      refute UptoEVM.signable?(Map.put(signable, "network", "solana:mainnet"))
+      refute UptoEVM.signable?("nope")
+    end
+  end
+
+  describe "sign/3" do
+    test "signs the Permit2 upto payload through X402.Permit2" do
+      {:ok, signer} = X402.Signer.LocalKey.new("0x" <> String.duplicate("11", 32))
+
+      requirements = %{
+        "scheme" => "upto",
+        "network" => "eip155:84532",
+        "amount" => "10000",
+        "asset" => "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+        "payTo" => "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+        "maxTimeoutSeconds" => 60,
+        "extra" => %{"facilitatorAddress" => "0x2222222222222222222222222222222222222222"}
+      }
+
+      assert {:ok, payload} = UptoEVM.sign(requirements, signer, valid_after_buffer: 60)
+      assert %{"signature" => "0x" <> _, "permit2Authorization" => authorization} = payload
+      assert authorization["permitted"]["amount"] == "10000"
+
+      assert UptoEVM.sign(put_in(requirements, ["extra"], %{}), signer, []) ==
+               {:error, {:missing_extra, "facilitatorAddress"}}
     end
   end
 

--- a/test/x402/upto_client_integration_test.exs
+++ b/test/x402/upto_client_integration_test.exs
@@ -1,0 +1,225 @@
+defmodule X402.UptoClientIntegrationTest do
+  @moduledoc """
+  End-to-end test of the built-in `upto` scheme's client half: the gate
+  advertises a metered upto route (with the facilitator address in
+  `extra`), `X402.Client.build_payment/3` selects and signs it via
+  Permit2, the signature recovers to the payer over the EIP-712 digest,
+  and `X402.Plug.PaymentGate` validates, verifies, and settles the
+  metered amount against a Bypass-backed facilitator.
+  """
+
+  use ExUnit.Case, async: false
+
+  import Plug.Conn
+  import Plug.Test
+
+  alias X402.Client
+  alias X402.EIP3009
+  alias X402.Facilitator
+  alias X402.PaymentRequired
+  alias X402.PaymentSignature
+  alias X402.Permit2
+  alias X402.Plug.PaymentGate
+  alias X402.Signer
+  alias X402.Signer.LocalKey
+
+  @asset "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+  @pay_to "0x209693Bc6afc0C5328bA36FaF03C514EF312287C"
+  @facilitator_address "0x3333333333333333333333333333333333333333"
+  @max_amount "20000"
+
+  @upto_route %{
+    method: :get,
+    path: "/metered/resource",
+    scheme: "upto",
+    price: @max_amount,
+    network: "eip155:84532",
+    asset: @asset,
+    pay_to: @pay_to,
+    extra: %{
+      "name" => "USDC",
+      "version" => "2",
+      "facilitatorAddress" => @facilitator_address
+    }
+  }
+
+  @default_verify {:ok, %{status: 200, body: %{"isValid" => true, "payer" => "0xpayer"}}}
+
+  @default_settle {
+    :ok,
+    %{
+      status: 200,
+      body: %{
+        "success" => true,
+        "transaction" => "0x" <> String.duplicate("ab", 32),
+        "network" => "eip155:84532",
+        "payer" => "0xpayer"
+      }
+    }
+  }
+
+  defp signer do
+    {:ok, signer} = LocalKey.new(:crypto.strong_rand_bytes(32))
+    signer
+  end
+
+  defp gate_opts(facilitator), do: [routes: [@upto_route], facilitator: facilitator]
+
+  defp run_request(conn, facilitator) do
+    conn = PaymentGate.call(conn, PaymentGate.init(gate_opts(facilitator)))
+
+    case conn.halted do
+      true -> conn
+      false -> Plug.Conn.send_resp(conn, 200, "metered response")
+    end
+  end
+
+  defp decode_payment_required!(conn) do
+    [header] = get_resp_header(conn, "payment-required")
+    assert {:ok, payload} = PaymentRequired.decode(header)
+    payload
+  end
+
+  defp advertised_requirements(facilitator) do
+    unpaid = run_request(conn(:get, "/metered/resource"), facilitator)
+    assert unpaid.status == 402
+
+    assert [accept] = decode_payment_required!(unpaid)["accepts"]
+    {decode_payment_required!(unpaid), accept}
+  end
+
+  test "the client signs an advertised upto requirement and the gate settles the metered amount" do
+    facilitator = start_mock_facilitator()
+
+    # 1. Unpaid request: the gate advertises the upto route with the
+    #    facilitator address the witness must bind.
+    {payment_required, accept} = advertised_requirements(facilitator)
+
+    assert accept["scheme"] == "upto"
+    assert accept["amount"] == @max_amount
+    assert accept["extra"]["facilitatorAddress"] == @facilitator_address
+
+    # 2. The payer client selects and signs the upto requirement.
+    signer = signer()
+    {:ok, payer} = Signer.address(signer)
+
+    assert {:ok, payload} = Client.build_payment(payment_required, signer)
+    assert payload["accepted"] == accept
+
+    assert %{"signature" => signature, "permit2Authorization" => authorization} =
+             payload["payload"]
+
+    assert authorization["from"] == payer
+    assert authorization["permitted"] == %{"token" => @asset, "amount" => @max_amount}
+    assert authorization["spender"] == Permit2.upto_proxy_address()
+
+    assert authorization["witness"] == %{
+             "to" => @pay_to,
+             "facilitator" => @facilitator_address,
+             "validAfter" => "0"
+           }
+
+    # 3. The signature recovers to the payer over the Permit2 EIP-712
+    #    digest — domain and type encoding round-trip.
+    {:ok, domain} = Permit2.upto_domain(accept)
+    {:ok, digest} = Permit2.upto_digest(domain, authorization)
+    assert EIP3009.recover_signer(digest, signature) == {:ok, payer}
+
+    # 4. The encoded header round-trips through decode_and_validate
+    #    against the advertised requirements.
+    assert {:ok, header} = Client.encode_payment(payload)
+    assert PaymentSignature.decode_and_validate(header, accept) == {:ok, payload}
+
+    # 5. The paid request passes the gate: validation, pre-checks, the
+    #    facilitator verify (against the maximum), and settle.
+    paid =
+      conn(:get, "/metered/resource")
+      |> put_req_header("payment-signature", header)
+      |> run_request(facilitator)
+
+    assert paid.status == 200
+    assert paid.resp_body == "metered response"
+
+    assert_receive {:verify_called, verified_payload, verified_requirements}
+    assert verified_payload["payload"]["permit2Authorization"] == authorization
+    assert verified_requirements["amount"] == @max_amount
+
+    assert_receive {:settle_called, _payload, %{"amount" => @max_amount}}
+    assert [_response] = get_resp_header(paid, "payment-response")
+  end
+
+  test "put_settlement_amount/2 meters the settled amount below the signed maximum" do
+    facilitator = start_mock_facilitator()
+    {payment_required, _accept} = advertised_requirements(facilitator)
+
+    {:ok, payload} = Client.build_payment(payment_required, signer())
+    {:ok, header} = Client.encode_payment(payload)
+
+    gated =
+      conn(:get, "/metered/resource")
+      |> put_req_header("payment-signature", header)
+      |> PaymentGate.call(PaymentGate.init(gate_opts(facilitator)))
+
+    refute gated.halted
+
+    # The handler measured 1858 atomic units of usage.
+    assert {:ok, gated} = PaymentGate.put_settlement_amount(gated, "1858")
+    response = Plug.Conn.send_resp(gated, 200, "usage complete")
+
+    assert response.status == 200
+    assert_receive {:verify_called, _payload, %{"amount" => @max_amount}}
+    assert_receive {:settle_called, settled_payload, %{"amount" => "1858"}}
+
+    # The client-signed ceiling is untouched; only the settlement
+    # requirements carry the metered amount.
+    assert settled_payload["payload"]["permit2Authorization"]["permitted"]["amount"] ==
+             @max_amount
+  end
+
+  test "the client cannot sign the route when extra lacks the facilitator address" do
+    facilitator = start_mock_facilitator()
+    {payment_required, accept} = advertised_requirements(facilitator)
+
+    without_facilitator =
+      put_in(payment_required["accepts"], [
+        Map.put(accept, "extra", %{"name" => "USDC", "version" => "2"})
+      ])
+
+    assert Client.build_payment(without_facilitator, signer()) ==
+             {:error, :no_acceptable_requirements}
+  end
+
+  # Bypass-backed facilitator harness, mirroring
+  # test/x402/scheme_integration_test.exs.
+  defp start_mock_facilitator do
+    owner = self()
+
+    bypass = Bypass.open()
+    stub_facilitator_endpoint(bypass, owner, "/verify", :verify_called, @default_verify)
+    stub_facilitator_endpoint(bypass, owner, "/settle", :settle_called, @default_settle)
+
+    suffix = System.unique_integer([:positive, :monotonic])
+    finch = String.to_atom("upto_integration_finch_#{suffix}")
+    name = String.to_atom("upto_integration_facilitator_#{suffix}")
+
+    start_supervised!(Supervisor.child_spec({Finch, name: finch}, id: finch))
+
+    start_supervised!(
+      {Facilitator,
+       name: name,
+       finch: finch,
+       max_retries: 0,
+       receive_timeout_ms: 1_000,
+       url: "http://localhost:#{bypass.port}"}
+    )
+  end
+
+  defp stub_facilitator_endpoint(bypass, owner, path, tag, {:ok, %{status: status, body: body}}) do
+    Bypass.stub(bypass, "POST", path, fn conn ->
+      {:ok, request_body, conn} = Plug.Conn.read_body(conn)
+      decoded = Jason.decode!(request_body)
+      send(owner, {tag, decoded["paymentPayload"], decoded["paymentRequirements"]})
+      Plug.Conn.resp(conn, status, Jason.encode!(body))
+    end)
+  end
+end


### PR DESCRIPTION
## What

Makes the `upto` scheme client-signable via Permit2 ([docs/ecosystem-comparison.md](https://github.com/cardotrejos/x402/blob/main/docs/ecosystem-comparison.md) §8 P2.2 — usage-based pricing is what APIs actually want; previously we could validate upto but not pay it). Built on the X402.Scheme seam (#70): the whole feature is one new module plus a `sign/3` on the existing `UptoEVM` scheme.

- **`X402.Permit2`**: PermitWitnessTransferFrom typed data per `scheme_upto_evm.md`, confirmed **byte-for-byte against the audited proxy contract's `WITNESS_TYPE_STRING`/`WITNESS_TYPEHASH`** (`contracts/evm/src/x402UptoPermit2Proxy.sol`) and the TS client types: canonical Permit2 domain (name-only + chainId + verifyingContract `0x…78BA3` — `X402.EIP712` learned version-less domains), witness binding `{to: payTo, facilitator: extra.facilitatorAddress, validAfter}`, spender = the canonical witness proxy.
- **Scheme seam wiring**: `UptoEVM.sign/3` + `signable?/1` (requires `eip155:*` + `extra.facilitatorAddress` — delivered by GET `/supported`, i.e. `X402.Facilitator.supported/1`; `{:missing_extra, "facilitatorAddress"}` when absent). `select_requirements/2` now picks signable upto entries.
- **Zero validate-side changes needed** — the existing gate/signature side already reads the spec shape; the round-trip proves self-interop.

## Testing

+31 tests/doctests (suite 189 doctests + 764 tests, 0 failures): the digest is pinned against an independent inline computation built from the contract constants, with signer-address recovery over the produced signature; an end-to-end test drives 402 → build_payment → gate verify (ceiling) → `put_settlement_amount` metered settle mirroring the spec's Phase-4 partial-settlement example. All gates green incl. dialyzer.

## Notes

Nonce is the decimal-string random uint256 the TS/Python clients emit (the spec's JSON example shows hex; validate side parses neither, both verify). `witness.validAfter` is "0" matching both reference clients.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New cryptographic payment signing and facilitator binding in the witness must match on-chain Permit2/proxy semantics; incorrect EIP-712 encoding would produce un-settleable authorizations, though existing server validation is unchanged and coverage is extensive.
> 
> **Overview**
> Adds **client-side signing for the `upto` scheme** on EVM networks, so payers can authorize a maximum and servers can settle for actual usage (previously `upto` was validate-only on the server).
> 
> The new **`X402.Permit2`** module builds and EIP-712-signs Permit2 **`PermitWitnessTransferFrom`**: ceiling from requirements `amount`, spender **`x402UptoPermit2Proxy`**, and a witness binding **`payTo`** plus **`extra.facilitatorAddress`** so only the advertised facilitator can settle. **`X402.EIP712.domain_separator/1`** now handles **version-less** Permit2 domains. **`X402.Scheme.UptoEVM`** gains **`sign/3`** and **`signable?/1`** (requires `eip155:*` and facilitator address); **`X402.Client.build_payment/3`** / Finch select and sign `upto` like `exact`, skipping entries without facilitator address.
> 
> Docs and changelog describe metered payments; tests pin the digest to contract type strings, cover signing/recovery, and add a **402 → sign → gate verify/settle** integration including **`put_settlement_amount`** metering below the signed max.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b94bc3d615c6ae9c59395ddd4b4d693b7036dd98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->