### PR TITLE
feat: SVM (Solana) exact scheme — client signing and structural validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   address are never selected, and signing one returns
   `{:error, {:missing_extra, "facilitatorAddress"}}`. See the new
   Metered `upto` payments section in the client guide
+- **SVM (Solana) `exact` scheme — `X402.Scheme.ExactSVM`** (ecosystem
+  report §8 P2.3): the client half of `exact` on `solana:*` networks plus
+  structural server-side validation, registered as a built-in. `sign/3`
+  builds the reference v0 transaction byte-for-byte (`SetComputeUnitLimit`,
+  `SetComputeUnitPrice`, SPL Token / Token-2022 `TransferChecked` to the
+  ATA derived from `payTo` + `asset`, and a Memo — the seller's
+  `extra.memo` or a random nonce), signs it with the payer's Ed25519 key,
+  and leaves the sponsor's (`extra.feePayer`, required) signature slot as
+  the zeroed placeholder of a partially signed transaction. Blockhash
+  resolution follows the spec (server's `extra.recentBlockhash` hint, then
+  the new `:svm_blockhash` / `:svm_blockhash_fetcher` client options), and
+  `:svm_decimals` / `:svm_token_program` cover mints outside the built-in
+  known-asset table. `validate_payload/3` enforces the wire shape (Base64,
+  1232-byte cap, decodable v0/legacy transaction, advertised fee payer as
+  account 0); `precheck/3` enforces the facilitator's static-path
+  whitelist (spec §3.1: 3–7 instructions in the reference order, the
+  5 lamports/CU cap, §2.1.1 fee payer isolation, transfer semantics, memo
+  enforcement) without any RPC. On-chain verification and settlement stay
+  facilitator-delegated; transactions using address lookup tables skip the
+  local pre-checks
+- **`X402.Signer.SolanaKey` and the optional `sign_ed25519/2` signer
+  callback**: Ed25519 signing over OTP's `:crypto` (no new dependencies);
+  `new/1` accepts a raw 32-byte seed, a 64-byte `solana-keygen` keypair,
+  or Base58/Base64 encodings of either. The `X402.Signer` chain-family
+  callbacks are now both optional — a signer implements the families it
+  supports and the dispatchers return `{:error, :unsupported_signer}` for
+  the rest
+- **Solana primitives, dependency-free**: `X402.Base58` (Bitcoin-alphabet
+  encode/decode), `X402.Solana` (address validation, Ed25519 on-curve
+  check, `find_program_address/2`, `associated_token_address/3`), and
+  `X402.Solana.Transaction` (compact-u16, v0 message compilation matching
+  `@solana/kit`'s account ordering byte-for-byte, wire
+  serialization/decoding). Cross-checked against fixtures generated with
+  the official Solana TypeScript stack
 - `X402.Extensions.PaymentIdentifier.RedisCache` — a Redis-backed
   `X402.Extensions.PaymentIdentifier.Cache` adapter for clustered
   deployments (ROADMAP P1.3b), over the **new optional `redix` dependency**.

--- a/guides/client.md
+++ b/guides/client.md
@@ -198,6 +198,52 @@ added alongside it, per the spec's append-only rule. Resource servers
 declare support with `build_extension/0` and validate a client's echoed
 data with `extract_info/1` and `validate_info/1` on either module.
 
+## Paying on Solana (SVM)
+
+The client also signs the `exact` scheme on `solana:*` networks out of the
+box, following the x402 SVM scheme specification: it builds a v0 Solana
+transaction — compute budget instructions, an SPL Token / Token-2022
+`TransferChecked` to the Associated Token Account derived from the server's
+`payTo` and `asset`, and a Memo for transaction uniqueness — signs it with
+the payer's Ed25519 key, and leaves the fee payer's signature slot empty.
+The server's sponsor (`extra.feePayer`, **required** in the advertised
+requirements) verifies and co-signs at settlement, so the payer never pays
+network fees. On-chain verification and settlement stay with the
+facilitator; the SDK never talks to a Solana RPC node.
+
+```elixir
+{:ok, signer} = X402.Signer.SolanaKey.new(System.fetch_env!("SOLANA_PAYER_KEY"))
+
+{:ok, payload} =
+  X402.Client.build_payment(payment_required, signer,
+    network: "solana:*",
+    # Only needed when the server's 402 does not include an
+    # extra.recentBlockhash hint: bring a blockhash yourself...
+    svm_blockhash: recent_blockhash
+    # ...or let the client fetch one through your RPC layer:
+    # svm_blockhash_fetcher: fn _network -> MyApp.RPC.latest_blockhash() end
+  )
+```
+
+`X402.Signer.SolanaKey.new/1` accepts a raw 32-byte Ed25519 seed, a
+64-byte `solana-keygen` keypair, or the Base58/Base64 encoding of either.
+Signing uses OTP's `:crypto` — no extra dependencies.
+
+Two option pairs matter for less common setups:
+
+* **Blockhash** — servers should advertise `extra.recentBlockhash` in
+  their requirements (it saves the client an RPC round-trip); when they
+  do, no option is needed. Otherwise pass `:svm_blockhash` or
+  `:svm_blockhash_fetcher`.
+* **Asset metadata** — `TransferChecked` needs the mint's decimals and
+  owning token program. Well-known stablecoins (USDC, USDT, USDG, PYUSD,
+  CASH on mainnet/devnet/testnet) are built in; for other mints pass
+  `:svm_decimals` and `:svm_token_program`.
+
+Custom Solana signers implement the optional
+`X402.Signer.sign_ed25519/2` callback instead of `sign_eip712/3` — see
+below.
+
 ## Custom signers
 
 `X402.Signer.LocalKey` holds a raw private key in memory — fine for testing
@@ -225,6 +271,12 @@ end
 
 Anything that returns `{:ok, address}` and `{:ok, signature}` plugs into
 `X402.Client.build_payment/3` and `X402.Client.Finch.request/3` unchanged.
+
+The chain-family callbacks are optional: implement `sign_eip712/3` for EVM
+payments, `sign_ed25519/2` (a 64-byte Ed25519 signature over the Solana
+transaction message bytes) for SVM payments, or both. A scheme asked to
+sign with a signer that lacks its callback returns
+`{:error, :unsupported_signer}`.
 
 ## Telemetry
 

--- a/lib/x402/base58.ex
+++ b/lib/x402/base58.ex
@@ -1,0 +1,131 @@
+defmodule X402.Base58 do
+  @moduledoc """
+  Base58 encoding and decoding using the Bitcoin alphabet.
+
+  Solana addresses, transaction signatures, and blockhashes are Base58
+  strings over the Bitcoin alphabet
+  (`123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz` — no `0`,
+  `O`, `I`, or `l`). Leading zero bytes encode as leading `1` characters,
+  one per byte, matching the reference implementations.
+
+  Pure functions with no dependencies; used by `X402.Solana` and
+  `X402.Scheme.ExactSVM`.
+  """
+
+  @alphabet ~c"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+  @typedoc "A Base58-encoded string."
+  @type encoded :: String.t()
+
+  digit_index = Enum.with_index(@alphabet)
+
+  @doc since: "0.6.0"
+  @doc """
+  Encodes a binary as a Base58 string.
+
+  Test vectors are the Bitcoin Core `base58_encode_decode.json` suite.
+
+  ## Examples
+
+      iex> X402.Base58.encode("")
+      ""
+
+      iex> X402.Base58.encode(<<0x61>>)
+      "2g"
+
+      iex> X402.Base58.encode(<<0x62, 0x62, 0x62>>)
+      "a3gV"
+
+      iex> X402.Base58.encode(<<0x51, 0x6B, 0x6F, 0xCD, 0x0F>>)
+      "ABnLTmg"
+
+      iex> X402.Base58.encode("simply a long string")
+      "2cFupjhnEsSn59qHXstmK2ffpLv2"
+
+      iex> X402.Base58.encode(<<0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>)
+      "1111111111"
+  """
+  @spec encode(binary()) :: encoded()
+  def encode(binary) when is_binary(binary) do
+    {zeros, rest} = split_leading_zeros(binary)
+    digits = rest |> :binary.decode_unsigned() |> encode_digits([])
+    IO.iodata_to_binary([List.duplicate(?1, zeros) | digits])
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Decodes a Base58 string, returning `:error` for invalid characters.
+
+  ## Examples
+
+      iex> X402.Base58.decode("2g")
+      {:ok, "a"}
+
+      iex> X402.Base58.decode("a3gV")
+      {:ok, "bbb"}
+
+      iex> X402.Base58.decode("1111111111")
+      {:ok, <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>}
+
+      iex> X402.Base58.decode("")
+      {:ok, ""}
+
+      iex> X402.Base58.decode("invalid0base58")
+      :error
+
+      iex> X402.Base58.decode(:not_a_string)
+      :error
+  """
+  @spec decode(term()) :: {:ok, binary()} | :error
+  def decode(string) when is_binary(string) do
+    with {:ok, chars} <- valid_charlist(string) do
+      {zeros, rest} = Enum.split_while(chars, &(&1 == ?1))
+      {:ok, :binary.copy(<<0>>, length(zeros)) <> decode_digits(rest)}
+    end
+  end
+
+  def decode(_string), do: :error
+
+  @spec split_leading_zeros(binary()) :: {non_neg_integer(), binary()}
+  defp split_leading_zeros(binary) do
+    zeros =
+      binary
+      |> :binary.bin_to_list()
+      |> Enum.take_while(&(&1 == 0))
+      |> length()
+
+    {zeros, :binary.part(binary, zeros, byte_size(binary) - zeros)}
+  end
+
+  @spec encode_digits(non_neg_integer(), [char()]) :: [char()]
+  defp encode_digits(0, acc), do: acc
+
+  defp encode_digits(n, acc) do
+    encode_digits(div(n, 58), [Enum.at(@alphabet, rem(n, 58)) | acc])
+  end
+
+  @spec valid_charlist(binary()) :: {:ok, charlist()} | :error
+  defp valid_charlist(string) do
+    chars = String.to_charlist(string)
+
+    case Enum.all?(chars, &(&1 in @alphabet)) do
+      true -> {:ok, chars}
+      false -> :error
+    end
+  end
+
+  @spec decode_digits(charlist()) :: binary()
+  defp decode_digits(chars) do
+    chars
+    |> Enum.reduce(0, fn char, acc -> acc * 58 + digit_value(char) end)
+    |> integer_to_binary()
+  end
+
+  @spec integer_to_binary(non_neg_integer()) :: binary()
+  defp integer_to_binary(0), do: ""
+  defp integer_to_binary(n), do: :binary.encode_unsigned(n)
+
+  for {char, index} <- digit_index do
+    defp digit_value(unquote(char)), do: unquote(index)
+  end
+end

--- a/lib/x402/client.ex
+++ b/lib/x402/client.ex
@@ -11,10 +11,12 @@ defmodule X402.Client do
 
   Signing dispatches through `X402.Scheme.Registry`: out of the box this
   client signs the `exact` scheme on EVM (`eip155:*`) networks via EIP-3009
-  (`X402.Scheme.ExactEVM`) and the `upto` scheme on EVM networks via
-  Permit2 (`X402.Scheme.UptoEVM`); other scheme/network combinations
-  return `{:error, {:unsupported_kind, scheme, network}}` unless a
-  matching `X402.Scheme` module is passed with the `:schemes` option.
+  (`X402.Scheme.ExactEVM`), on Solana (`solana:*`) networks via a
+  partially signed v0 transaction (`X402.Scheme.ExactSVM`), and the
+  `upto` scheme on EVM networks via Permit2 (`X402.Scheme.UptoEVM`);
+  other scheme/network combinations return
+  `{:error, {:unsupported_kind, scheme, network}}` unless a matching
+  `X402.Scheme` module is passed with the `:schemes` option.
 
   ## Example
 
@@ -89,6 +91,39 @@ defmodule X402.Client do
                            `{:ok, payload}` or `{:error, reason}` — see
                            `X402.Extensions.EIP2612GasSponsoring.enricher/2` and
                            `X402.Extensions.ERC20ApprovalGasSponsoring.enricher/1`.
+                           """
+                         ],
+                         svm_blockhash: [
+                           type: :string,
+                           doc: """
+                           Base58 recent blockhash for SVM (Solana) payments,
+                           used when the server's `extra.recentBlockhash` hint
+                           is absent — see `X402.Scheme.ExactSVM`.
+                           """
+                         ],
+                         svm_blockhash_fetcher: [
+                           type: {:fun, 1},
+                           doc: """
+                           1-arity fun receiving the CAIP-2 network and
+                           returning `{:ok, blockhash}` for SVM payments (for
+                           example a wrapper around an RPC client's
+                           `getLatestBlockhash`).
+                           """
+                         ],
+                         svm_decimals: [
+                           type: :non_neg_integer,
+                           doc: """
+                           The SVM asset's decimals for `TransferChecked`,
+                           for mints outside `X402.Scheme.ExactSVM`'s
+                           known-asset table.
+                           """
+                         ],
+                         svm_token_program: [
+                           type: :string,
+                           doc: """
+                           The SVM asset's owning token program (SPL Token or
+                           Token-2022 address), for mints outside
+                           `X402.Scheme.ExactSVM`'s known-asset table.
                            """
                          ]
                        ]
@@ -196,13 +231,14 @@ defmodule X402.Client do
   gas-sponsored Permit2 approvals.
 
   Signing dispatches on the scheme and network of the chosen requirements
-  through `X402.Scheme.Registry`; out of the box this supports `exact`
-  (EIP-3009) and `upto` (Permit2) on `eip155:*` networks. Other
-  combinations return
+  through `X402.Scheme.Registry`; out of the box this supports `exact` on
+  `eip155:*` networks (EIP-3009) and on `solana:*` networks (partially
+  signed v0 transactions), plus `upto` on `eip155:*` networks (Permit2).
+  Other combinations return
   `{:error, {:unsupported_kind, scheme, network}}` unless a matching
   module is passed with the `:schemes` option. Scheme modules receive the
-  validated build options, so options like `:valid_after_buffer` reach
-  `c:X402.Scheme.sign/3`.
+  validated build options, so options like `:valid_after_buffer` (EVM) and
+  `:svm_blockhash` (SVM) reach `c:X402.Scheme.sign/3`.
 
   ## Options
 

--- a/lib/x402/scheme.ex
+++ b/lib/x402/scheme.ex
@@ -14,9 +14,11 @@ defmodule X402.Scheme do
   `X402.Plug.PaymentGate`.
 
   The built-in schemes are `X402.Scheme.ExactEVM` (`exact` on `eip155:*`
-  networks via EIP-3009) and `X402.Scheme.UptoEVM` (`upto` on `eip155:*`
-  networks via Permit2). Resolution — including wildcard CAIP-2 matching
-  and exact-match precedence — is handled by `X402.Scheme.Registry`.
+  networks via EIP-3009), `X402.Scheme.ExactSVM` (`exact` on `solana:*`
+  networks via partially signed v0 transactions), and `X402.Scheme.UptoEVM`
+  (`upto` on `eip155:*` networks via Permit2). Resolution — including
+  wildcard CAIP-2 matching and exact-match precedence — is handled by
+  `X402.Scheme.Registry`.
 
   ## Callbacks and the roles they serve
 

--- a/lib/x402/scheme/exact_svm.ex
+++ b/lib/x402/scheme/exact_svm.ex
@@ -1,0 +1,768 @@
+defmodule X402.Scheme.ExactSVM do
+  @moduledoc """
+  Built-in `X402.Scheme` for `exact` payments on Solana (`solana:*`) networks.
+
+  Follows the x402 `exact` SVM scheme specification: the client builds a
+  **version 0** Solana transaction with the reference instruction layout —
+
+  1. Compute Budget `SetComputeUnitLimit`
+  2. Compute Budget `SetComputeUnitPrice`
+  3. SPL Token / Token-2022 `TransferChecked` to the Associated Token
+     Account derived from `payTo` and `asset`
+  4. SPL Memo (the seller's `extra.memo`, or a random nonce for
+     transaction uniqueness)
+
+  — signs it with the payer's Ed25519 key, and leaves the fee payer's
+  signature slot as a 64-byte zero placeholder (a *partially signed*
+  transaction). The wire payload is `%{"transaction" => base64}`, exactly
+  as the reference TypeScript and Python clients produce.
+
+  ## Roles
+
+  * **Client** — `sign/3` builds and partially signs the transaction. The
+    signer must implement the optional `c:X402.Signer.sign_ed25519/2`
+    callback (`X402.Signer.SolanaKey` does). An entry is signable when
+    `extra.feePayer` is present: the sponsor's public key is **required**
+    (it becomes account 0 / the empty signature slot).
+  * **Server** — `validate_payload/3` runs structural checks that any
+    valid `exact` SVM payment must satisfy (decodable Base64, the 1232-byte
+    transaction size cap, a parseable v0/legacy transaction, fee payer
+    match). `precheck/3` additionally enforces the facilitator's *static
+    verification path* whitelist (spec §3.1): 3–7 instructions in the
+    reference order, compute-budget bounds, fee payer isolation, transfer
+    semantics against the requirements, and memo enforcement.
+
+  **On-chain verification and settlement remain facilitator-delegated**:
+  this module never talks to a Solana RPC node. The facilitator resolves
+  address lookup tables, simulates, signs as `feePayer`, and submits
+  (spec §2–3). Transactions using address lookup tables skip `precheck/3`
+  (the account set cannot be resolved locally) and are left to the
+  facilitator, and smart-wallet (CPI-wrapped) payments — the spec's opt-in
+  Path 2 — will fail the static-path pre-checks; gates fronting a
+  facilitator with `enableSmartWalletVerification` should disable
+  `:local_prechecks` for those routes.
+
+  ## Client options
+
+  `sign/3` honors these `X402.Client.build_payment/3` options:
+
+  * `:svm_blockhash` — a Base58 recent blockhash for the transaction
+    lifetime. Used when the requirements' `extra.recentBlockhash` hint is
+    absent or malformed; keeps the module RPC-free.
+  * `:svm_blockhash_fetcher` — a 1-arity fun receiving the CAIP-2 network
+    and returning `{:ok, blockhash}` (for example a wrapper around your
+    RPC client's `getLatestBlockhash`). Consulted after `:svm_blockhash`.
+  * `:svm_decimals` / `:svm_token_program` — the mint's decimals and
+    owning token program, needed by `TransferChecked`. Defaults come from
+    the reference SDKs' known-asset table (USDC, USDT, USDG, PYUSD, CASH);
+    for other mints pass both explicitly (production clients read them
+    from the mint account via RPC).
+
+  Blockhash resolution order (per the spec): a valid
+  `extra.recentBlockhash` from the server wins, then `:svm_blockhash`,
+  then `:svm_blockhash_fetcher`; with none, `{:error, :missing_blockhash}`.
+  """
+
+  @behaviour X402.Scheme
+
+  alias X402.Signer
+  alias X402.Solana
+  alias X402.Solana.Transaction
+  alias X402.Utils
+
+  # Reference client defaults (typescript/packages/mechanisms/svm constants).
+  @default_compute_unit_limit 20_000
+  @default_compute_unit_price_microlamports 1
+  # Static-path cap: 5 lamports per compute unit (spec §3.1).
+  @max_compute_unit_price_microlamports 5_000_000
+  @max_memo_bytes 256
+  @nonce_bytes 16
+  @u64_max 0xFFFFFFFFFFFFFFFF
+
+  # Known mints from the reference SDKs' default-asset tables
+  # (mainnet/devnet/testnet). Mint addresses are globally unique, so the
+  # table is keyed by mint alone: {decimals, token_program}.
+  @known_assets %{
+    # USDC (mainnet)
+    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" => {6, :token},
+    # USDT (mainnet)
+    "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB" => {6, :token},
+    # USDG (mainnet)
+    "2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH" => {6, :token_2022},
+    # PYUSD (mainnet)
+    "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo" => {6, :token_2022},
+    # CASH (mainnet)
+    "CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH" => {6, :token_2022},
+    # USDC (devnet/testnet)
+    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU" => {6, :token},
+    # USDG (devnet/testnet)
+    "4F6PM96JJxngmHnZLBh9n58RH4aTVNWvDs2nuwrT5BP7" => {6, :token_2022},
+    # PYUSD (devnet/testnet)
+    "CXk2AMBfi3TwaEL2468s6zP8xq9NxTXjp9gjMgzeUynM" => {6, :token_2022}
+  }
+
+  @typedoc "Reasons `precheck/3` fails fast with `{:error, {:precheck_failed, reason}}`."
+  @type precheck_failure ::
+          :invalid_transaction
+          | :fee_payer_not_isolated
+          | :instruction_count
+          | :invalid_compute_limit_instruction
+          | :invalid_compute_price_instruction
+          | :compute_price_too_high
+          | :missing_transfer_instruction
+          | :amount_mismatch
+          | :mint_mismatch
+          | :recipient_mismatch
+          | :unknown_optional_instruction
+          | :memo_count
+          | :memo_mismatch
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns `"exact"`.
+
+  ## Examples
+
+      iex> X402.Scheme.ExactSVM.scheme()
+      "exact"
+  """
+  @impl X402.Scheme
+  @spec scheme() :: String.t()
+  def scheme, do: "exact"
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns `["solana:*"]` — every Solana network.
+
+  ## Examples
+
+      iex> X402.Scheme.ExactSVM.networks()
+      ["solana:*"]
+  """
+  @impl X402.Scheme
+  @spec networks() :: [String.t()]
+  def networks, do: ["solana:*"]
+
+  @doc since: "0.6.0"
+  @doc """
+  Whether the entry carries the required sponsor data.
+
+  `extra.feePayer` is required by the SVM `exact` scheme (the sponsor's
+  public key becomes the transaction's fee payer), and `asset`/`payTo`
+  must be valid Solana addresses.
+
+  ## Examples
+
+      iex> X402.Scheme.ExactSVM.signable?(%{
+      ...>   "asset" => "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      ...>   "payTo" => "GyGKxMyg1p9SsHfm15MkNUu1u9TN2JtTspcdmrtGUdse",
+      ...>   "extra" => %{"feePayer" => "9hSR6S7WPtxmTojgo6GG3k4yDPecgJY292j7xrsUGWBu"}
+      ...> })
+      true
+
+      iex> X402.Scheme.ExactSVM.signable?(%{"extra" => %{}})
+      false
+  """
+  @impl X402.Scheme
+  @spec signable?(map()) :: boolean()
+  def signable?(requirements) when is_map(requirements) do
+    Solana.valid_address?(fee_payer(requirements)) and
+      Solana.valid_address?(Utils.map_value(requirements, {"asset", :asset})) and
+      Solana.valid_address?(Utils.map_value(requirements, {"payTo", :pay_to}))
+  end
+
+  def signable?(_requirements), do: false
+
+  @doc since: "0.6.0"
+  @doc """
+  Builds and partially signs the SVM `exact` transaction.
+
+  Returns `{:ok, %{"transaction" => base64}}` — the wire scheme payload —
+  or a structured error: `{:error, :missing_fee_payer}` when the
+  requirements lack `extra.feePayer`, `{:error, :missing_blockhash}` when
+  no blockhash source is available, `{:error, {:unknown_asset, mint}}`
+  for mints outside the known-asset table without explicit
+  `:svm_decimals`/`:svm_token_program`, and `{:error, :unsupported_signer}`
+  when the signer cannot sign Ed25519.
+  """
+  @impl X402.Scheme
+  @spec sign(map(), Signer.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  def sign(requirements, signer, opts) do
+    asset = Utils.map_value(requirements, {"asset", :asset})
+    pay_to = Utils.map_value(requirements, {"payTo", :pay_to})
+
+    with {:ok, fee_payer} <- require_fee_payer(requirements),
+         {:ok, payer} <- payer_address(signer),
+         {:ok, amount} <- parse_amount(Utils.map_value(requirements, {"amount", :amount})),
+         :ok <- validate_address(asset, :invalid_asset),
+         :ok <- validate_address(pay_to, :invalid_pay_to),
+         {:ok, decimals, token_program} <- resolve_asset(asset, opts),
+         {:ok, blockhash} <- resolve_blockhash(requirements, opts),
+         {:ok, memo_data} <- resolve_memo(requirements),
+         {:ok, source_ata} <- Solana.associated_token_address(payer, asset, token_program),
+         {:ok, dest_ata} <- Solana.associated_token_address(pay_to, asset, token_program),
+         {:ok, compiled} <-
+           compile_transfer(fee_payer, %{
+             source: source_ata,
+             mint: asset,
+             destination: dest_ata,
+             authority: payer,
+             amount: amount,
+             decimals: decimals,
+             token_program: token_program,
+             memo: memo_data,
+             blockhash: blockhash
+           }),
+         {:ok, signature} <- Signer.sign_ed25519(signer, compiled.bytes) do
+      wire = Transaction.serialize(compiled, %{payer => signature})
+      {:ok, %{"transaction" => Base.encode64(wire)}}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Structural validation of a decoded `PAYMENT-SIGNATURE` payload.
+
+  Checks what any valid `exact` SVM payment must satisfy without RPC:
+  `payload.transaction` present, Base64-decodable, within the network's
+  1232-byte transaction size cap, parseable as a v0 or legacy Solana
+  transaction, and — when the requirements advertise `extra.feePayer` —
+  carrying that fee payer as account 0. Failures return
+  `{:error, {:invalid_scheme_payment, reason}}`.
+
+  ## Examples
+
+      iex> X402.Scheme.ExactSVM.validate_payload(%{"payload" => %{}}, %{}, [])
+      {:error, {:invalid_scheme_payment, :missing_transaction}}
+
+      iex> X402.Scheme.ExactSVM.validate_payload(
+      ...>   %{"payload" => %{"transaction" => "!!!"}},
+      ...>   %{},
+      ...>   []
+      ...> )
+      {:error, {:invalid_scheme_payment, :invalid_base64}}
+  """
+  @impl X402.Scheme
+  @spec validate_payload(map(), map(), keyword()) ::
+          :ok | {:error, {:invalid_scheme_payment, atom()}}
+  def validate_payload(payload, requirements, _opts) do
+    with {:ok, wire} <- decode_wire(payload),
+         {:ok, decoded} <- decode_transaction(wire) do
+      validate_fee_payer(decoded, requirements)
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Static-path pre-checks (spec §3.1) before the facilitator round-trip.
+
+  Enforces the facilitator's static verification whitelist as far as it is
+  verifiable without RPC: 3–7 top-level instructions in the reference
+  order (`SetComputeUnitLimit`, `SetComputeUnitPrice`, `TransferChecked`,
+  then only Lighthouse/Memo), the ≤ 5 lamports/CU priority-fee cap, fee
+  payer isolation (§2.1.1 — the fee payer referenced by no instruction),
+  transfer semantics against the requirements (amount equality, mint,
+  destination ATA), and memo enforcement when `extra.memo` is present.
+
+  Transactions using address lookup tables pass through with `:ok` — their
+  account set cannot be resolved without RPC, so the facilitator remains
+  the authority (§2.1.2). Failures return
+  `{:error, {:precheck_failed, reason}}` and the gate answers 402 without
+  a facilitator call.
+  """
+  @impl X402.Scheme
+  @spec precheck(map(), map(), keyword()) ::
+          :ok | {:error, {:precheck_failed, precheck_failure()}}
+  def precheck(payload, requirements, _opts) do
+    with {:ok, wire} <- precheck_wire(payload),
+         {:ok, decoded} <- precheck_decode(wire) do
+      case decoded.address_table_lookups do
+        0 -> run_static_prechecks(decoded, requirements)
+        _lookups -> :ok
+      end
+    end
+  end
+
+  # -- sign/3 internals -------------------------------------------------------
+
+  @spec fee_payer(map()) :: term()
+  defp fee_payer(requirements) do
+    case Utils.map_value(requirements, {"extra", :extra}) do
+      extra when is_map(extra) -> Utils.map_value(extra, {"feePayer", :fee_payer})
+      _extra -> nil
+    end
+  end
+
+  @spec require_fee_payer(map()) :: {:ok, String.t()} | {:error, :missing_fee_payer}
+  defp require_fee_payer(requirements) do
+    case fee_payer(requirements) do
+      fee_payer when is_binary(fee_payer) ->
+        case Solana.valid_address?(fee_payer) do
+          true -> {:ok, fee_payer}
+          false -> {:error, :missing_fee_payer}
+        end
+
+      _missing ->
+        {:error, :missing_fee_payer}
+    end
+  end
+
+  @spec payer_address(Signer.t()) :: {:ok, String.t()} | {:error, term()}
+  defp payer_address(signer) do
+    with {:ok, address} <- Signer.address(signer) do
+      case Solana.valid_address?(address) do
+        true -> {:ok, address}
+        false -> {:error, :invalid_payer_address}
+      end
+    end
+  end
+
+  @spec parse_amount(term()) :: {:ok, non_neg_integer()} | {:error, :invalid_amount}
+  defp parse_amount(amount) when is_integer(amount) and amount >= 0 and amount <= @u64_max,
+    do: {:ok, amount}
+
+  defp parse_amount(amount) when is_binary(amount) do
+    case Integer.parse(amount) do
+      {value, ""} when value >= 0 and value <= @u64_max -> {:ok, value}
+      _other -> {:error, :invalid_amount}
+    end
+  end
+
+  defp parse_amount(_amount), do: {:error, :invalid_amount}
+
+  @spec validate_address(term(), atom()) :: :ok | {:error, atom()}
+  defp validate_address(address, error) do
+    case Solana.valid_address?(address) do
+      true -> :ok
+      false -> {:error, error}
+    end
+  end
+
+  @spec resolve_asset(String.t(), keyword()) ::
+          {:ok, byte(), String.t()} | {:error, term()}
+  defp resolve_asset(asset, opts) do
+    case {Keyword.get(opts, :svm_decimals), Keyword.get(opts, :svm_token_program)} do
+      {nil, nil} ->
+        known_asset(asset)
+
+      {nil, program} ->
+        with {:ok, decimals, _default_program} <- known_asset(asset), do: {:ok, decimals, program}
+
+      {decimals, nil} ->
+        case known_asset(asset) do
+          {:ok, _decimals, program} -> {:ok, decimals, program}
+          {:error, _unknown} -> {:ok, decimals, Solana.token_program()}
+        end
+
+      {decimals, program} ->
+        {:ok, decimals, program}
+    end
+  end
+
+  @spec known_asset(String.t()) ::
+          {:ok, byte(), String.t()} | {:error, {:unknown_asset, String.t()}}
+  defp known_asset(asset) do
+    case Map.fetch(@known_assets, asset) do
+      {:ok, {decimals, :token}} -> {:ok, decimals, Solana.token_program()}
+      {:ok, {decimals, :token_2022}} -> {:ok, decimals, Solana.token_2022_program()}
+      :error -> {:error, {:unknown_asset, asset}}
+    end
+  end
+
+  @spec resolve_blockhash(map(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  defp resolve_blockhash(requirements, opts) do
+    hinted = extra_value(requirements, {"recentBlockhash", :recent_blockhash})
+
+    cond do
+      Solana.valid_address?(hinted) ->
+        {:ok, hinted}
+
+      is_binary(Keyword.get(opts, :svm_blockhash)) ->
+        blockhash = Keyword.fetch!(opts, :svm_blockhash)
+
+        case Solana.valid_address?(blockhash) do
+          true -> {:ok, blockhash}
+          false -> {:error, :invalid_blockhash}
+        end
+
+      is_function(Keyword.get(opts, :svm_blockhash_fetcher), 1) ->
+        fetch_blockhash(
+          Keyword.fetch!(opts, :svm_blockhash_fetcher),
+          Utils.map_value(requirements, {"network", :network})
+        )
+
+      true ->
+        {:error, :missing_blockhash}
+    end
+  end
+
+  @spec fetch_blockhash((String.t() -> term()), term()) ::
+          {:ok, String.t()} | {:error, term()}
+  defp fetch_blockhash(fetcher, network) do
+    case fetcher.(network) do
+      {:ok, blockhash} ->
+        case Solana.valid_address?(blockhash) do
+          true -> {:ok, blockhash}
+          false -> {:error, :invalid_blockhash}
+        end
+
+      {:error, reason} ->
+        {:error, {:blockhash_fetch_failed, reason}}
+
+      other ->
+        {:error, {:blockhash_fetch_failed, other}}
+    end
+  end
+
+  @spec resolve_memo(map()) :: {:ok, binary()} | {:error, :memo_too_long}
+  defp resolve_memo(requirements) do
+    case extra_value(requirements, {"memo", :memo}) do
+      memo when is_binary(memo) and byte_size(memo) <= @max_memo_bytes ->
+        {:ok, memo}
+
+      memo when is_binary(memo) ->
+        {:error, :memo_too_long}
+
+      _absent ->
+        {:ok, Base.encode16(:crypto.strong_rand_bytes(@nonce_bytes), case: :lower)}
+    end
+  end
+
+  @spec extra_value(map(), {String.t(), atom()}) :: term()
+  defp extra_value(requirements, keys) do
+    case Utils.map_value(requirements, {"extra", :extra}) do
+      extra when is_map(extra) -> Utils.map_value(extra, keys)
+      _extra -> nil
+    end
+  end
+
+  @spec compile_transfer(String.t(), map()) ::
+          {:ok, Transaction.compiled()} | {:error, :invalid_address}
+  defp compile_transfer(fee_payer, params) do
+    instructions = [
+      Transaction.set_compute_unit_limit(@default_compute_unit_limit),
+      Transaction.set_compute_unit_price(@default_compute_unit_price_microlamports),
+      Transaction.transfer_checked(Map.take(params, transfer_keys())),
+      Transaction.memo(params.memo)
+    ]
+
+    Transaction.compile(fee_payer, instructions, params.blockhash)
+  end
+
+  @spec transfer_keys() :: [atom()]
+  defp transfer_keys,
+    do: [:source, :mint, :destination, :authority, :amount, :decimals, :token_program]
+
+  # -- validate_payload/3 internals -------------------------------------------
+
+  @spec decode_wire(map()) :: {:ok, binary()} | {:error, {:invalid_scheme_payment, atom()}}
+  defp decode_wire(payload) do
+    case scheme_transaction(payload) do
+      transaction when is_binary(transaction) ->
+        case Base.decode64(transaction) do
+          {:ok, wire} -> check_size(wire)
+          :error -> {:error, {:invalid_scheme_payment, :invalid_base64}}
+        end
+
+      _missing ->
+        {:error, {:invalid_scheme_payment, :missing_transaction}}
+    end
+  end
+
+  @spec check_size(binary()) ::
+          {:ok, binary()} | {:error, {:invalid_scheme_payment, :transaction_too_large}}
+  defp check_size(wire) do
+    case byte_size(wire) <= Transaction.max_transaction_size() do
+      true -> {:ok, wire}
+      false -> {:error, {:invalid_scheme_payment, :transaction_too_large}}
+    end
+  end
+
+  @spec scheme_transaction(map()) :: term()
+  defp scheme_transaction(payload) when is_map(payload) do
+    case Utils.map_value(payload, {"payload", :payload}) do
+      scheme_payload when is_map(scheme_payload) ->
+        Utils.map_value(scheme_payload, {"transaction", :transaction})
+
+      _other ->
+        nil
+    end
+  end
+
+  defp scheme_transaction(_payload), do: nil
+
+  @spec decode_transaction(binary()) ::
+          {:ok, Transaction.decoded()} | {:error, {:invalid_scheme_payment, atom()}}
+  defp decode_transaction(wire) do
+    case Transaction.decode(wire) do
+      {:ok, decoded} when decoded.num_required_signatures >= 1 -> {:ok, decoded}
+      _error -> {:error, {:invalid_scheme_payment, :invalid_transaction}}
+    end
+  end
+
+  @spec validate_fee_payer(Transaction.decoded(), map()) ::
+          :ok | {:error, {:invalid_scheme_payment, :fee_payer_mismatch}}
+  defp validate_fee_payer(decoded, requirements) do
+    with fee_payer when is_binary(fee_payer) <- fee_payer(requirements),
+         {:ok, expected} <- Solana.decode_address(fee_payer) do
+      case decoded.static_accounts do
+        [^expected | _rest] -> :ok
+        _mismatch -> {:error, {:invalid_scheme_payment, :fee_payer_mismatch}}
+      end
+    else
+      # No (valid) advertised fee payer to compare against.
+      _absent -> :ok
+    end
+  end
+
+  # -- precheck/3 internals ---------------------------------------------------
+
+  @spec precheck_wire(map()) :: {:ok, binary()} | {:error, {:precheck_failed, atom()}}
+  defp precheck_wire(payload) do
+    case decode_wire(payload) do
+      {:ok, wire} -> {:ok, wire}
+      {:error, {:invalid_scheme_payment, _reason}} -> precheck_error(:invalid_transaction)
+    end
+  end
+
+  @spec precheck_decode(binary()) ::
+          {:ok, Transaction.decoded()} | {:error, {:precheck_failed, atom()}}
+  defp precheck_decode(wire) do
+    case Transaction.decode(wire) do
+      {:ok, decoded} -> {:ok, decoded}
+      {:error, _reason} -> precheck_error(:invalid_transaction)
+    end
+  end
+
+  @spec run_static_prechecks(Transaction.decoded(), map()) ::
+          :ok | {:error, {:precheck_failed, precheck_failure()}}
+  defp run_static_prechecks(decoded, requirements) do
+    instructions = decoded.instructions
+
+    with :ok <- check_fee_payer_isolation(instructions),
+         :ok <- check_instruction_count(instructions),
+         :ok <- check_indices_in_range(decoded),
+         [limit_ix, price_ix, transfer_ix | optional] = instructions,
+         :ok <- check_compute_limit(limit_ix, decoded),
+         :ok <- check_compute_price(price_ix, decoded),
+         :ok <- check_transfer(transfer_ix, decoded, requirements),
+         :ok <- check_optional_instructions(optional, decoded) do
+      check_memo(optional, decoded, requirements)
+    end
+  end
+
+  # §2.1.1 — the fee payer (account 0) must not be referenced by any
+  # instruction, as a program or an account. Holds for both verification
+  # paths, so it is always a certain mismatch.
+  @spec check_fee_payer_isolation([map()]) :: :ok | {:error, {:precheck_failed, atom()}}
+  defp check_fee_payer_isolation(instructions) do
+    isolated? =
+      Enum.all?(instructions, fn instruction ->
+        instruction.program_index != 0 and 0 not in instruction.account_indices
+      end)
+
+    case isolated? do
+      true -> :ok
+      false -> precheck_error(:fee_payer_not_isolated)
+    end
+  end
+
+  @spec check_instruction_count([map()]) :: :ok | {:error, {:precheck_failed, atom()}}
+  defp check_instruction_count(instructions) when length(instructions) in 3..7, do: :ok
+  defp check_instruction_count(_instructions), do: precheck_error(:instruction_count)
+
+  @spec check_indices_in_range(Transaction.decoded()) ::
+          :ok | {:error, {:precheck_failed, atom()}}
+  defp check_indices_in_range(decoded) do
+    account_count = length(decoded.static_accounts)
+
+    in_range? =
+      Enum.all?(decoded.instructions, fn instruction ->
+        instruction.program_index < account_count and
+          Enum.all?(instruction.account_indices, &(&1 < account_count))
+      end)
+
+    case in_range? do
+      true -> :ok
+      false -> precheck_error(:invalid_transaction)
+    end
+  end
+
+  @spec check_compute_limit(map(), Transaction.decoded()) ::
+          :ok | {:error, {:precheck_failed, atom()}}
+  defp check_compute_limit(instruction, decoded) do
+    compute_budget? = program_at(decoded, instruction.program_index) == compute_budget_pubkey()
+
+    case {compute_budget?, instruction.data} do
+      {true, <<2, _units::32-little>>} -> :ok
+      _invalid -> precheck_error(:invalid_compute_limit_instruction)
+    end
+  end
+
+  @spec check_compute_price(map(), Transaction.decoded()) ::
+          :ok | {:error, {:precheck_failed, atom()}}
+  defp check_compute_price(instruction, decoded) do
+    compute_budget? = program_at(decoded, instruction.program_index) == compute_budget_pubkey()
+
+    case {compute_budget?, instruction.data} do
+      {true, <<3, price::64-little>>} when price <= @max_compute_unit_price_microlamports ->
+        :ok
+
+      {true, <<3, _price::64-little>>} ->
+        precheck_error(:compute_price_too_high)
+
+      _invalid ->
+        precheck_error(:invalid_compute_price_instruction)
+    end
+  end
+
+  @spec check_transfer(map(), Transaction.decoded(), map()) ::
+          :ok | {:error, {:precheck_failed, atom()}}
+  defp check_transfer(instruction, decoded, requirements) do
+    program = program_at(decoded, instruction.program_index)
+    token_program = token_program_for(program)
+
+    with {:token_program, {:ok, token_program_address}} <- {:token_program, token_program},
+         {:layout, <<12, amount::64-little, _decimals>>} <- {:layout, instruction.data},
+         {:accounts, [_source, mint_index, destination_index, _authority | _rest]} <-
+           {:accounts, instruction.account_indices} do
+      check_transfer_semantics(
+        %{
+          amount: amount,
+          mint: account_at(decoded, mint_index),
+          destination: account_at(decoded, destination_index),
+          token_program: token_program_address
+        },
+        requirements
+      )
+    else
+      {_step, _mismatch} -> precheck_error(:missing_transfer_instruction)
+    end
+  end
+
+  # Semantic mismatches on the positional transfer are terminal on both
+  # verification paths (spec §3.3: semantic failures never fall through to
+  # Path 2), so they are certain mismatches. Each check is skipped when the
+  # corresponding requirements field cannot be interpreted locally.
+  @spec check_transfer_semantics(map(), map()) :: :ok | {:error, {:precheck_failed, atom()}}
+  defp check_transfer_semantics(transfer, requirements) do
+    with :ok <- check_amount(transfer.amount, requirements),
+         :ok <- check_mint(transfer.mint, requirements) do
+      check_recipient(transfer, requirements)
+    end
+  end
+
+  @spec check_amount(non_neg_integer(), map()) :: :ok | {:error, {:precheck_failed, atom()}}
+  defp check_amount(amount, requirements) do
+    case parse_amount(Utils.map_value(requirements, {"amount", :amount})) do
+      {:ok, ^amount} -> :ok
+      {:ok, _other} -> precheck_error(:amount_mismatch)
+      {:error, _invalid} -> :ok
+    end
+  end
+
+  @spec check_mint(binary() | nil, map()) :: :ok | {:error, {:precheck_failed, atom()}}
+  defp check_mint(mint, requirements) do
+    case Solana.decode_address(Utils.map_value(requirements, {"asset", :asset})) do
+      {:ok, ^mint} -> :ok
+      {:ok, _other} -> precheck_error(:mint_mismatch)
+      {:error, _invalid} -> :ok
+    end
+  end
+
+  @spec check_recipient(map(), map()) :: :ok | {:error, {:precheck_failed, atom()}}
+  defp check_recipient(transfer, requirements) do
+    pay_to = Utils.map_value(requirements, {"payTo", :pay_to})
+    asset = Utils.map_value(requirements, {"asset", :asset})
+
+    with true <- Solana.valid_address?(pay_to),
+         true <- Solana.valid_address?(asset),
+         {:ok, expected_ata} <-
+           Solana.associated_token_address(pay_to, asset, transfer.token_program),
+         {:ok, expected} <- Solana.decode_address(expected_ata) do
+      case transfer.destination do
+        ^expected -> :ok
+        _mismatch -> precheck_error(:recipient_mismatch)
+      end
+    else
+      # Requirements not locally interpretable — leave it to the facilitator.
+      _skip -> :ok
+    end
+  end
+
+  @spec check_optional_instructions([map()], Transaction.decoded()) ::
+          :ok | {:error, {:precheck_failed, atom()}}
+  defp check_optional_instructions(optional, decoded) do
+    allowed = [memo_pubkey(), lighthouse_pubkey()]
+
+    valid? =
+      Enum.all?(optional, fn instruction ->
+        program_at(decoded, instruction.program_index) in allowed
+      end)
+
+    case valid? do
+      true -> :ok
+      false -> precheck_error(:unknown_optional_instruction)
+    end
+  end
+
+  @spec check_memo([map()], Transaction.decoded(), map()) ::
+          :ok | {:error, {:precheck_failed, atom()}}
+  defp check_memo(optional, decoded, requirements) do
+    case extra_value(requirements, {"memo", :memo}) do
+      memo when is_binary(memo) ->
+        memos =
+          Enum.filter(optional, fn instruction ->
+            program_at(decoded, instruction.program_index) == memo_pubkey()
+          end)
+
+        case memos do
+          [%{data: ^memo}] -> :ok
+          [_one] -> precheck_error(:memo_mismatch)
+          _other -> precheck_error(:memo_count)
+        end
+
+      _absent ->
+        :ok
+    end
+  end
+
+  @spec program_at(Transaction.decoded(), non_neg_integer()) :: binary() | nil
+  defp program_at(decoded, index), do: account_at(decoded, index)
+
+  @spec account_at(Transaction.decoded(), non_neg_integer()) :: binary() | nil
+  defp account_at(decoded, index), do: Enum.at(decoded.static_accounts, index)
+
+  @spec precheck_error(atom()) :: {:error, {:precheck_failed, atom()}}
+  defp precheck_error(reason), do: {:error, {:precheck_failed, reason}}
+
+  @spec token_program_for(binary() | nil) :: {:ok, String.t()} | :error
+  defp token_program_for(program_pubkey) do
+    cond do
+      program_pubkey == token_pubkey() -> {:ok, Solana.token_program()}
+      program_pubkey == token_2022_pubkey() -> {:ok, Solana.token_2022_program()}
+      true -> :error
+    end
+  end
+
+  @spec token_pubkey() :: binary()
+  defp token_pubkey, do: decode_known!(Solana.token_program())
+
+  @spec token_2022_pubkey() :: binary()
+  defp token_2022_pubkey, do: decode_known!(Solana.token_2022_program())
+
+  @spec compute_budget_pubkey() :: binary()
+  defp compute_budget_pubkey, do: decode_known!(Solana.compute_budget_program())
+
+  @spec memo_pubkey() :: binary()
+  defp memo_pubkey, do: decode_known!(Solana.memo_program())
+
+  @spec lighthouse_pubkey() :: binary()
+  defp lighthouse_pubkey, do: decode_known!(Solana.lighthouse_program())
+
+  @spec decode_known!(String.t()) :: binary()
+  defp decode_known!(address) do
+    {:ok, pubkey} = Solana.decode_address(address)
+    pubkey
+  end
+end

--- a/lib/x402/scheme/registry.ex
+++ b/lib/x402/scheme/registry.ex
@@ -3,7 +3,8 @@ defmodule X402.Scheme.Registry do
   Resolves (scheme, network) pairs to `X402.Scheme` modules.
 
   The default mapping is seeded with the built-in schemes —
-  `X402.Scheme.ExactEVM` (`"exact"` on `"eip155:*"`) and
+  `X402.Scheme.ExactEVM` (`"exact"` on `"eip155:*"`),
+  `X402.Scheme.ExactSVM` (`"exact"` on `"solana:*"`), and
   `X402.Scheme.UptoEVM` (`"upto"` on `"eip155:*"`). There is no global
   registration and no application environment: callers pass additional
   scheme modules explicitly (the `:schemes` option on
@@ -38,10 +39,10 @@ defmodule X402.Scheme.Registry do
       {:ok, X402.Scheme.UptoEVM}
 
       iex> X402.Scheme.Registry.resolve("exact", "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp")
-      :error
+      {:ok, X402.Scheme.ExactSVM}
   """
 
-  @builtins [X402.Scheme.ExactEVM, X402.Scheme.UptoEVM]
+  @builtins [X402.Scheme.ExactEVM, X402.Scheme.ExactSVM, X402.Scheme.UptoEVM]
 
   @doc since: "0.6.0"
   @doc """
@@ -50,7 +51,7 @@ defmodule X402.Scheme.Registry do
   ## Examples
 
       iex> X402.Scheme.Registry.builtins()
-      [X402.Scheme.ExactEVM, X402.Scheme.UptoEVM]
+      [X402.Scheme.ExactEVM, X402.Scheme.ExactSVM, X402.Scheme.UptoEVM]
   """
   @spec builtins() :: [module()]
   def builtins, do: @builtins

--- a/lib/x402/signer.ex
+++ b/lib/x402/signer.ex
@@ -23,10 +23,20 @@ defmodule X402.Signer do
   `0`/`1` or `27`/`28`; the dispatcher normalizes it to `27`/`28` as expected
   by EIP-3009 contracts.
 
-  ## Built-in implementation
+  ## Chain families
+
+  EVM payments sign EIP-712 typed data through `c:sign_eip712/3`. Solana
+  (SVM) payments instead sign raw transaction message bytes with Ed25519
+  through the optional `c:sign_ed25519/2` callback — a signer implements
+  the callbacks for the chain families it supports, and schemes report a
+  signer without the needed callback as `{:error, :unsupported_signer}`.
+
+  ## Built-in implementations
 
   `X402.Signer.LocalKey` signs with a raw secp256k1 private key and requires
   the optional `ex_secp256k1` and `ex_keccak` dependencies.
+  `X402.Signer.SolanaKey` signs with an Ed25519 key through OTP's `:crypto`
+  (no extra dependencies).
   """
 
   @typedoc "A struct whose module implements `X402.Signer`."
@@ -42,6 +52,9 @@ defmodule X402.Signer do
   @typedoc "A raw 65-byte `r || s || v` signature."
   @type signature :: <<_::520>>
 
+  @typedoc "A raw 64-byte Ed25519 signature."
+  @type ed25519_signature :: <<_::512>>
+
   @doc """
   Returns the signer's payment address (for EVM, a `0x`-prefixed hex address).
   """
@@ -53,10 +66,26 @@ defmodule X402.Signer do
   `digest` is the precomputed 32-byte EIP-712 digest
   (`keccak256(0x19 0x01 || domainSeparator || structHash)`). `typed_data` is
   the full EIP-712 typed data for implementations that cannot sign raw
-  digests.
+  digests. Optional — implement it for signers that support EVM payments.
   """
   @callback sign_eip712(signer :: t(), digest :: binary(), typed_data :: typed_data()) ::
               {:ok, signature()} | {:error, term()}
+
+  @doc """
+  Signs a message with Ed25519 and returns the raw 64-byte signature.
+
+  Used by SVM (Solana) schemes, where `message` is the serialized
+  transaction message bytes (including the version prefix). Optional —
+  implement it for signers that support Solana payments.
+  """
+  @callback sign_ed25519(signer :: t(), message :: binary()) ::
+              {:ok, ed25519_signature()} | {:error, term()}
+
+  # Chain-family callbacks are optional: a signer implements the ones for
+  # the families it supports (EVM signers omit sign_ed25519, Solana signers
+  # omit sign_eip712), and the dispatchers report the gap as
+  # {:error, :unsupported_signer}.
+  @optional_callbacks sign_eip712: 3, sign_ed25519: 2
 
   @doc since: "0.6.0"
   @doc """
@@ -86,12 +115,51 @@ defmodule X402.Signer do
   @spec sign_eip712(t(), binary(), typed_data()) :: {:ok, signature()} | {:error, term()}
   def sign_eip712(%module{} = signer, digest, typed_data)
       when is_binary(digest) and is_map(typed_data) do
-    with {:ok, signature} <- module.sign_eip712(signer, digest, typed_data) do
-      normalize_signature(signature)
+    case Code.ensure_loaded?(module) and function_exported?(module, :sign_eip712, 3) do
+      true ->
+        with {:ok, signature} <- module.sign_eip712(signer, digest, typed_data) do
+          normalize_signature(signature)
+        end
+
+      false ->
+        {:error, :unsupported_signer}
     end
   end
 
   def sign_eip712(_signer, _digest, _typed_data), do: {:error, :invalid_signer}
+
+  @doc since: "0.6.0"
+  @doc """
+  Signs a message with Ed25519, dispatching on the signer's struct module.
+
+  Returns `{:error, :unsupported_signer}` when the signer module does not
+  implement the optional `c:sign_ed25519/2` callback, and
+  `{:error, :invalid_signature_format}` for signatures that are not
+  64 bytes.
+
+  ## Examples
+
+      iex> X402.Signer.sign_ed25519(:not_a_signer, "message")
+      {:error, :invalid_signer}
+
+      iex> {:ok, evm_signer} = X402.Signer.LocalKey.new("0x" <> String.duplicate("11", 32))
+      iex> X402.Signer.sign_ed25519(evm_signer, "message")
+      {:error, :unsupported_signer}
+  """
+  @spec sign_ed25519(t(), binary()) :: {:ok, ed25519_signature()} | {:error, term()}
+  def sign_ed25519(%module{} = signer, message) when is_binary(message) do
+    case Code.ensure_loaded?(module) and function_exported?(module, :sign_ed25519, 2) do
+      true ->
+        with {:ok, signature} <- module.sign_ed25519(signer, message) do
+          validate_ed25519_signature(signature)
+        end
+
+      false ->
+        {:error, :unsupported_signer}
+    end
+  end
+
+  def sign_ed25519(_signer, _message), do: {:error, :invalid_signer}
 
   @spec normalize_signature(term()) :: {:ok, signature()} | {:error, :invalid_signature_format}
   defp normalize_signature(<<compact::binary-size(64), v>>) when v in [0, 1],
@@ -101,4 +169,9 @@ defmodule X402.Signer do
     do: {:ok, signature}
 
   defp normalize_signature(_signature), do: {:error, :invalid_signature_format}
+
+  @spec validate_ed25519_signature(term()) ::
+          {:ok, ed25519_signature()} | {:error, :invalid_signature_format}
+  defp validate_ed25519_signature(<<signature::binary-size(64)>>), do: {:ok, signature}
+  defp validate_ed25519_signature(_signature), do: {:error, :invalid_signature_format}
 end

--- a/lib/x402/signer/solana_key.ex
+++ b/lib/x402/signer/solana_key.ex
@@ -1,0 +1,113 @@
+defmodule X402.Signer.SolanaKey do
+  @moduledoc """
+  `X402.Signer` backed by a raw Ed25519 private key held in memory.
+
+  Signs Solana transaction message bytes through OTP's `:crypto` (EdDSA on
+  the `ed25519` curve) — no extra dependencies. `new/1` accepts:
+
+  * a raw 32-byte Ed25519 seed
+  * a 64-byte Solana keypair (`seed <> public_key`, the `solana-keygen`
+    format) — the embedded public key is checked against the derived one
+  * the Base64 or Base58 encoding of either
+
+  The struct redacts the private key when inspected, but the key still
+  lives in process memory — prefer an external signer implementation (KMS,
+  hardware wallet) for production payers holding significant funds.
+
+  ## Examples
+
+      {:ok, signer} = X402.Signer.SolanaKey.new(:crypto.strong_rand_bytes(32))
+      {:ok, address} = X402.Signer.SolanaKey.address(signer)
+  """
+
+  @behaviour X402.Signer
+
+  alias X402.Base58
+
+  @enforce_keys [:seed, :address]
+  defstruct [:seed, :address]
+
+  @typedoc "A local Ed25519 signing key with its derived Solana address."
+  @type t :: %__MODULE__{seed: binary(), address: String.t()}
+
+  @doc since: "0.6.0"
+  @doc """
+  Builds a signer from an Ed25519 seed or Solana keypair.
+
+  Returns `{:error, :invalid_private_key}` for malformed keys and for
+  64-byte keypairs whose public half does not match the seed.
+
+  ## Examples
+
+      iex> {:ok, signer} = X402.Signer.SolanaKey.new(:binary.copy(<<1>>, 32))
+      iex> signer.address
+      "AKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9"
+
+      iex> X402.Signer.SolanaKey.new("not a key")
+      {:error, :invalid_private_key}
+  """
+  @spec new(binary()) :: {:ok, t()} | {:error, :invalid_private_key}
+  def new(private_key) when is_binary(private_key) do
+    with {:ok, seed, expected_public} <- normalize_key(private_key) do
+      {public, _private} = :crypto.generate_key(:eddsa, :ed25519, seed)
+
+      case expected_public == nil or expected_public == public do
+        true -> {:ok, %__MODULE__{seed: seed, address: Base58.encode(public)}}
+        false -> {:error, :invalid_private_key}
+      end
+    end
+  end
+
+  def new(_private_key), do: {:error, :invalid_private_key}
+
+  @doc since: "0.6.0"
+  @doc """
+  Returns the Base58 Solana address derived from the private key.
+  """
+  @impl X402.Signer
+  @spec address(t()) :: {:ok, String.t()}
+  def address(%__MODULE__{address: address}), do: {:ok, address}
+
+  @doc since: "0.6.0"
+  @doc """
+  Signs `message` with the local Ed25519 key.
+
+  Ed25519 signing is deterministic (RFC 8032), so the same key and message
+  always produce the same 64-byte signature.
+  """
+  @impl X402.Signer
+  @spec sign_ed25519(t(), binary()) :: {:ok, X402.Signer.ed25519_signature()}
+  def sign_ed25519(%__MODULE__{seed: seed}, message) when is_binary(message) do
+    {:ok, :crypto.sign(:eddsa, :none, message, [seed, :ed25519])}
+  end
+
+  @spec normalize_key(binary()) ::
+          {:ok, binary(), binary() | nil} | {:error, :invalid_private_key}
+  defp normalize_key(<<seed::binary-size(32)>>), do: {:ok, seed, nil}
+
+  defp normalize_key(<<seed::binary-size(32), public::binary-size(32)>>),
+    do: {:ok, seed, public}
+
+  defp normalize_key(encoded) do
+    case decode_key(encoded) do
+      {:ok, raw} when byte_size(raw) in [32, 64] -> normalize_key(raw)
+      _other -> {:error, :invalid_private_key}
+    end
+  end
+
+  @spec decode_key(binary()) :: {:ok, binary()} | :error
+  defp decode_key(encoded) do
+    case Base.decode64(encoded) do
+      {:ok, raw} -> {:ok, raw}
+      :error -> Base58.decode(encoded)
+    end
+  end
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(%{address: address}, opts) do
+      concat(["#X402.Signer.SolanaKey<address: ", to_doc(address, opts), ", ...>"])
+    end
+  end
+end

--- a/lib/x402/signer/solana_key.ex
+++ b/lib/x402/signer/solana_key.ex
@@ -95,11 +95,26 @@ defmodule X402.Signer.SolanaKey do
     end
   end
 
+  # Base58 is tried FIRST: typical Base58 secrets (44/88 characters —
+  # Phantom exports, solana-keygen) are also valid Base64 lengths, so a
+  # Base64-first decode "succeeds" with 33/66 garbage bytes and the real
+  # Base58 form is never tried. Only decodes yielding a valid key size are
+  # accepted from either alphabet; ambiguous strings resolve as Base58, the
+  # Solana convention.
   @spec decode_key(binary()) :: {:ok, binary()} | :error
   defp decode_key(encoded) do
-    case Base.decode64(encoded) do
+    case decode_sized(&Base58.decode/1, encoded) do
       {:ok, raw} -> {:ok, raw}
-      :error -> Base58.decode(encoded)
+      :error -> decode_sized(&Base.decode64/1, encoded)
+    end
+  end
+
+  @spec decode_sized((binary() -> {:ok, binary()} | :error), binary()) ::
+          {:ok, binary()} | :error
+  defp decode_sized(decoder, encoded) do
+    case decoder.(encoded) do
+      {:ok, raw} when byte_size(raw) in [32, 64] -> {:ok, raw}
+      _other -> :error
     end
   end
 

--- a/lib/x402/solana.ex
+++ b/lib/x402/solana.ex
@@ -1,0 +1,331 @@
+defmodule X402.Solana do
+  @moduledoc """
+  Solana address primitives: program IDs, PDA and ATA derivation.
+
+  Implements the address arithmetic the `exact` scheme on `solana:*`
+  networks needs without any RPC or native dependencies:
+
+  * Base58 address validation/decoding (32-byte Ed25519 public keys)
+  * The Ed25519 on-curve check used to reject PDA candidates
+    (RFC 8032 point decompression over integer arithmetic)
+  * `create_program_address/2` / `find_program_address/2` — SHA-256 program
+    derived addresses, as specified by the Solana runtime
+  * `associated_token_address/3` — the Associated Token Account PDA for an
+    (owner, mint, token program) triple, which is where the `exact` scheme
+    says the payment must land (scheme spec §1.1)
+
+  All hashing uses OTP's `:crypto`; no new dependencies.
+  """
+
+  @token_program "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+  @token_2022_program "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+  @ata_program "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+  @memo_program "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+  @compute_budget_program "ComputeBudget111111111111111111111111111111"
+  @lighthouse_program "L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95"
+
+  # Ed25519 field parameters (RFC 8032): p = 2^255 - 19, the twisted
+  # Edwards d constant, and sqrt(-1) mod p.
+  @p 57_896_044_618_658_097_711_785_492_504_343_953_926_634_992_332_820_282_019_728_792_003_956_564_819_949
+  @d 37_095_705_934_669_439_343_138_083_508_754_565_189_542_113_879_843_219_016_388_785_533_085_940_283_555
+  @sqrt_m1 19_681_161_376_707_505_956_807_079_304_988_542_015_446_066_515_923_890_162_744_021_073_123_829_784_752
+
+  @pda_marker "ProgramDerivedAddress"
+
+  @typedoc "A Base58-encoded Solana address."
+  @type address :: String.t()
+
+  @typedoc "A raw 32-byte Ed25519 public key or PDA."
+  @type pubkey :: <<_::256>>
+
+  @doc since: "0.6.0"
+  @doc """
+  The SPL Token program address.
+
+  ## Examples
+
+      iex> X402.Solana.token_program()
+      "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+  """
+  @spec token_program() :: address()
+  def token_program, do: @token_program
+
+  @doc since: "0.6.0"
+  @doc """
+  The Token-2022 program address.
+
+  ## Examples
+
+      iex> X402.Solana.token_2022_program()
+      "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+  """
+  @spec token_2022_program() :: address()
+  def token_2022_program, do: @token_2022_program
+
+  @doc since: "0.6.0"
+  @doc """
+  The Associated Token Account program address.
+
+  ## Examples
+
+      iex> X402.Solana.ata_program()
+      "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+  """
+  @spec ata_program() :: address()
+  def ata_program, do: @ata_program
+
+  @doc since: "0.6.0"
+  @doc """
+  The SPL Memo program address.
+
+  ## Examples
+
+      iex> X402.Solana.memo_program()
+      "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+  """
+  @spec memo_program() :: address()
+  def memo_program, do: @memo_program
+
+  @doc since: "0.6.0"
+  @doc """
+  The Compute Budget program address.
+
+  ## Examples
+
+      iex> X402.Solana.compute_budget_program()
+      "ComputeBudget111111111111111111111111111111"
+  """
+  @spec compute_budget_program() :: address()
+  def compute_budget_program, do: @compute_budget_program
+
+  @doc since: "0.6.0"
+  @doc """
+  The Lighthouse assertion program address (wallet-injected guard
+  instructions; allowed as optional instructions by the scheme spec §3.1).
+
+  ## Examples
+
+      iex> X402.Solana.lighthouse_program()
+      "L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95"
+  """
+  @spec lighthouse_program() :: address()
+  def lighthouse_program, do: @lighthouse_program
+
+  @doc since: "0.6.0"
+  @doc """
+  Decodes a Base58 address into its raw 32-byte public key.
+
+  ## Examples
+
+      iex> X402.Solana.decode_address("11111111111111111111111111111111")
+      {:ok, <<0::256>>}
+
+      iex> X402.Solana.decode_address("tooshort")
+      {:error, :invalid_address}
+
+      iex> X402.Solana.decode_address(nil)
+      {:error, :invalid_address}
+  """
+  @spec decode_address(term()) :: {:ok, pubkey()} | {:error, :invalid_address}
+  def decode_address(address) when is_binary(address) do
+    case X402.Base58.decode(address) do
+      {:ok, <<pubkey::binary-size(32)>>} -> {:ok, pubkey}
+      _other -> {:error, :invalid_address}
+    end
+  end
+
+  def decode_address(_address), do: {:error, :invalid_address}
+
+  @doc since: "0.6.0"
+  @doc """
+  Whether a term is a Base58 string decoding to 32 bytes.
+
+  ## Examples
+
+      iex> X402.Solana.valid_address?("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v")
+      true
+
+      iex> X402.Solana.valid_address?("0x036CbD53842c5426634e7929541eC2318f3dCF7e")
+      false
+  """
+  @spec valid_address?(term()) :: boolean()
+  def valid_address?(address), do: match?({:ok, _pubkey}, decode_address(address))
+
+  @doc since: "0.6.0"
+  @doc """
+  Whether 32 bytes decompress to a point on the Ed25519 curve.
+
+  Program derived addresses must *not* be on the curve (so no private key
+  can exist for them); `create_program_address/2` uses this check. The
+  algorithm mirrors the reference SDKs' vendored Ed25519 decompression:
+  mask the sign bit, solve `x^2 = (y^2 - 1) / (d*y^2 + 1)`, and require a
+  square root to exist (with `x = 0` requiring a zero sign bit).
+
+  ## Examples
+
+      iex> {:ok, system_program} = X402.Solana.decode_address("11111111111111111111111111111111")
+      iex> X402.Solana.on_curve?(system_program)
+      true
+
+      iex> {:ok, ata} = X402.Solana.decode_address("DNDTCnZkNk358qDFZd9unHtnrc73SsXcpVWtwJJMrR4B")
+      iex> X402.Solana.on_curve?(ata)
+      false
+  """
+  @spec on_curve?(pubkey()) :: boolean()
+  def on_curve?(<<_::binary-size(31), last_byte>> = pubkey) when byte_size(pubkey) == 32 do
+    y = decompress_y(pubkey)
+    y2 = mod(y * y)
+    u = mod(y2 - 1)
+    v = mod(@d * y2 + 1)
+
+    case uv_ratio(u, v) do
+      nil -> false
+      0 -> Bitwise.band(last_byte, 0x80) == 0
+      _x -> true
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Derives a program address from seeds and a program ID (no bump search).
+
+  Seeds are binaries of at most 32 bytes each, at most 16 seeds. Returns
+  `{:error, :on_curve}` when the SHA-256 candidate lands on the Ed25519
+  curve (callers should try another bump seed) and
+  `{:error, :invalid_seeds}` for out-of-range seeds.
+  """
+  @spec create_program_address([binary()], address()) ::
+          {:ok, pubkey()} | {:error, :on_curve | :invalid_seeds | :invalid_address}
+  def create_program_address(seeds, program_id) when is_list(seeds) do
+    with :ok <- validate_seeds(seeds),
+         {:ok, program_pubkey} <- decode_address(program_id) do
+      candidate = :crypto.hash(:sha256, [seeds, program_pubkey, @pda_marker])
+
+      case on_curve?(candidate) do
+        true -> {:error, :on_curve}
+        false -> {:ok, candidate}
+      end
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Finds the first off-curve program address, searching bump seeds 255 down
+  to 0 — the canonical `find_program_address` from the Solana SDKs.
+
+  Returns the raw 32-byte address and the bump seed that produced it.
+
+  ## Examples
+
+      iex> {:ok, {address, bump}} =
+      ...>   X402.Solana.find_program_address(
+      ...>     ["hello", "world"],
+      ...>     "11111111111111111111111111111111"
+      ...>   )
+      iex> {X402.Base58.encode(address), bump}
+      {"JDC4d5bNdpBPNLHfugxDcuknk6e9cp2xBis5V5v67PGh", 253}
+  """
+  @spec find_program_address([binary()], address()) ::
+          {:ok, {pubkey(), byte()}} | {:error, :invalid_seeds | :invalid_address | :not_found}
+  def find_program_address(seeds, program_id) when is_list(seeds) do
+    find_with_bump(seeds, program_id, 255)
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Derives the Associated Token Account address for an owner and mint.
+
+  This is the destination the `exact` SVM scheme requires: the ATA derived
+  from `payTo` and `asset` under the relevant token program (scheme spec
+  §1.1–1.2). Seeds are `[owner, token_program, mint]` under the ATA
+  program.
+
+  ## Examples
+
+      iex> X402.Solana.associated_token_address(
+      ...>   "GyGKxMyg1p9SsHfm15MkNUu1u9TN2JtTspcdmrtGUdse",
+      ...>   "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      ...>   X402.Solana.token_program()
+      ...> )
+      {:ok, "DNDTCnZkNk358qDFZd9unHtnrc73SsXcpVWtwJJMrR4B"}
+
+      iex> X402.Solana.associated_token_address("bogus", "also-bogus", "nope")
+      {:error, :invalid_address}
+  """
+  @spec associated_token_address(address(), address(), address()) ::
+          {:ok, address()} | {:error, :invalid_address | :not_found}
+  def associated_token_address(owner, mint, token_program \\ @token_program) do
+    with {:ok, owner_pubkey} <- decode_address(owner),
+         {:ok, mint_pubkey} <- decode_address(mint),
+         {:ok, program_pubkey} <- decode_address(token_program),
+         {:ok, {address, _bump}} <-
+           find_program_address([owner_pubkey, program_pubkey, mint_pubkey], @ata_program) do
+      {:ok, X402.Base58.encode(address)}
+    else
+      {:error, :invalid_seeds} -> {:error, :invalid_address}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # -- PDA internals ----------------------------------------------------------
+
+  @spec find_with_bump([binary()], address(), integer()) ::
+          {:ok, {pubkey(), byte()}} | {:error, :invalid_seeds | :invalid_address | :not_found}
+  defp find_with_bump(_seeds, _program_id, bump) when bump < 0, do: {:error, :not_found}
+
+  defp find_with_bump(seeds, program_id, bump) do
+    case create_program_address(seeds ++ [<<bump>>], program_id) do
+      {:ok, address} -> {:ok, {address, bump}}
+      {:error, :on_curve} -> find_with_bump(seeds, program_id, bump - 1)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec validate_seeds([term()]) :: :ok | {:error, :invalid_seeds}
+  defp validate_seeds(seeds) do
+    valid? =
+      length(seeds) <= 16 and
+        Enum.all?(seeds, &(is_binary(&1) and byte_size(&1) <= 32))
+
+    case valid? do
+      true -> :ok
+      false -> {:error, :invalid_seeds}
+    end
+  end
+
+  # -- Ed25519 field arithmetic ----------------------------------------------
+
+  @spec decompress_y(pubkey()) :: non_neg_integer()
+  defp decompress_y(<<head::binary-size(31), last_byte>>) do
+    :binary.decode_unsigned(<<head::binary, Bitwise.band(last_byte, 0x7F)>>, :little)
+  end
+
+  # Square root of u/v via the (p-5)/8 exponent trick (RFC 8032 §5.1.3).
+  # Returns nil when u/v is not a quadratic residue (candidate not on curve).
+  @spec uv_ratio(non_neg_integer(), non_neg_integer()) :: non_neg_integer() | nil
+  defp uv_ratio(u, v) do
+    v3 = mod(v * v * v)
+    v7 = mod(v3 * v3 * v)
+    x = mod(u * v3 * mod_pow(mod(u * v7), div(@p - 5, 8)))
+    vx2 = mod(v * x * x)
+
+    cond do
+      vx2 == u -> x
+      vx2 == mod(-u) -> mod(x * @sqrt_m1)
+      true -> nil
+    end
+  end
+
+  @spec mod(integer()) :: non_neg_integer()
+  defp mod(a) do
+    case rem(a, @p) do
+      r when r < 0 -> r + @p
+      r -> r
+    end
+  end
+
+  @spec mod_pow(non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  defp mod_pow(base, exponent) do
+    :binary.decode_unsigned(:crypto.mod_pow(base, exponent, @p))
+  end
+end

--- a/lib/x402/solana/transaction.ex
+++ b/lib/x402/solana/transaction.ex
@@ -1,0 +1,559 @@
+defmodule X402.Solana.Transaction do
+  @moduledoc """
+  Solana v0 transaction message building, serialization, and decoding.
+
+  Implements exactly what the `exact` SVM scheme needs, with no RPC and no
+  new dependencies:
+
+  * Instruction constructors for the reference client's instruction set —
+    Compute Budget `SetComputeUnitLimit`/`SetComputeUnitPrice`, SPL Token /
+    Token-2022 `TransferChecked`, and SPL Memo
+  * `compile/3` — compiles instructions into a serialized **version 0**
+    message (the version the reference TypeScript and Python clients
+    produce), including compact-u16 (shortvec) encoding, account
+    deduplication, and the account ordering used by `@solana/kit`, so the
+    output is byte-identical to the reference client
+  * `serialize/2` — the wire transaction: compact-u16 signature count
+    followed by 64-byte signature slots (missing signatures are all-zero
+    placeholders, which is how a *partially signed* transaction represents
+    the fee payer's pending signature) and the message bytes
+  * `decode/1` — parses a wire transaction (v0 or legacy) back into its
+    parts for structural validation
+
+  ## Account ordering
+
+  Static accounts are ordered: fee payer first, then writable signers,
+  read-only signers, writable non-signers, read-only non-signers. Within a
+  group, addresses sort with `@solana/kit`'s comparator (case-insensitive
+  primary pass, lowercase-first tiebreak) so compiled messages are
+  byte-identical to the reference client's.
+
+  ## Signing
+
+  Ed25519 signatures cover the *entire* serialized message returned by
+  `compile/3`, including the leading `0x80` version byte.
+  """
+
+  alias X402.Solana
+
+  # IPv6 minimum MTU (1280) minus packet headers — the Solana network's hard
+  # cap on serialized transaction size.
+  @max_transaction_size 1232
+
+  @compute_unit_limit_discriminator 2
+  @compute_unit_price_discriminator 3
+  @transfer_checked_discriminator 12
+
+  @typedoc "An account referenced by an instruction."
+  @type account_meta :: %{address: Solana.address(), signer?: boolean(), writable?: boolean()}
+
+  @typedoc "An instruction to compile into a message."
+  @type instruction :: %{program: Solana.address(), accounts: [account_meta()], data: binary()}
+
+  @typedoc "A compiled v0 message ready to sign."
+  @type compiled :: %{bytes: binary(), signers: [Solana.address()]}
+
+  @typedoc "A decoded wire transaction."
+  @type decoded :: %{
+          version: 0 | :legacy,
+          num_required_signatures: non_neg_integer(),
+          num_readonly_signed: non_neg_integer(),
+          num_readonly_unsigned: non_neg_integer(),
+          signatures: [binary()],
+          static_accounts: [Solana.pubkey()],
+          recent_blockhash: Solana.pubkey(),
+          instructions: [
+            %{program_index: byte(), account_indices: [byte()], data: binary()}
+          ],
+          address_table_lookups: non_neg_integer(),
+          message_bytes: binary()
+        }
+
+  @doc since: "0.6.0"
+  @doc """
+  The Solana network's maximum serialized transaction size in bytes.
+
+  ## Examples
+
+      iex> X402.Solana.Transaction.max_transaction_size()
+      1232
+  """
+  @spec max_transaction_size() :: pos_integer()
+  def max_transaction_size, do: @max_transaction_size
+
+  @doc since: "0.6.0"
+  @doc """
+  Encodes a non-negative integer as compact-u16 (shortvec).
+
+  Little-endian 7-bit groups with a continuation bit, as used for all
+  counts in Solana's wire format.
+
+  ## Examples
+
+      iex> X402.Solana.Transaction.encode_compact_u16(0)
+      <<0>>
+
+      iex> X402.Solana.Transaction.encode_compact_u16(127)
+      <<0x7F>>
+
+      iex> X402.Solana.Transaction.encode_compact_u16(128)
+      <<0x80, 0x01>>
+
+      iex> X402.Solana.Transaction.encode_compact_u16(16_383)
+      <<0xFF, 0x7F>>
+
+      iex> X402.Solana.Transaction.encode_compact_u16(16_384)
+      <<0x80, 0x80, 0x01>>
+  """
+  @spec encode_compact_u16(non_neg_integer()) :: binary()
+  def encode_compact_u16(value) when value >= 0 and value < 0x80, do: <<value>>
+
+  def encode_compact_u16(value) when value >= 0x80 and value <= 0xFFFF do
+    <<Bitwise.bor(Bitwise.band(value, 0x7F), 0x80)>> <>
+      encode_compact_u16(Bitwise.bsr(value, 7))
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Decodes a compact-u16 prefix, returning the value and the rest.
+
+  ## Examples
+
+      iex> X402.Solana.Transaction.decode_compact_u16(<<0x80, 0x01, "rest">>)
+      {:ok, 128, "rest"}
+
+      iex> X402.Solana.Transaction.decode_compact_u16(<<0xFF, 0x7F>>)
+      {:ok, 16_383, ""}
+
+      iex> X402.Solana.Transaction.decode_compact_u16(<<0x80>>)
+      :error
+  """
+  @spec decode_compact_u16(binary()) :: {:ok, non_neg_integer(), binary()} | :error
+  def decode_compact_u16(binary) when is_binary(binary), do: decode_compact_u16(binary, 0, 0)
+
+  # -- Instruction constructors ----------------------------------------------
+
+  @doc since: "0.6.0"
+  @doc """
+  The Compute Budget `SetComputeUnitLimit` instruction (discriminator 2,
+  `u32` little-endian units).
+
+  ## Examples
+
+      iex> ix = X402.Solana.Transaction.set_compute_unit_limit(20_000)
+      iex> {ix.program, ix.accounts, ix.data}
+      {"ComputeBudget111111111111111111111111111111", [], <<2, 32, 78, 0, 0>>}
+  """
+  @spec set_compute_unit_limit(non_neg_integer()) :: instruction()
+  def set_compute_unit_limit(units) when units >= 0 and units <= 0xFFFFFFFF do
+    %{
+      program: Solana.compute_budget_program(),
+      accounts: [],
+      data: <<@compute_unit_limit_discriminator, units::32-little>>
+    }
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  The Compute Budget `SetComputeUnitPrice` instruction (discriminator 3,
+  `u64` little-endian microlamports).
+
+  ## Examples
+
+      iex> ix = X402.Solana.Transaction.set_compute_unit_price(1)
+      iex> ix.data
+      <<3, 1, 0, 0, 0, 0, 0, 0, 0>>
+  """
+  @spec set_compute_unit_price(non_neg_integer()) :: instruction()
+  def set_compute_unit_price(micro_lamports)
+      when micro_lamports >= 0 and micro_lamports <= 0xFFFFFFFFFFFFFFFF do
+    %{
+      program: Solana.compute_budget_program(),
+      accounts: [],
+      data: <<@compute_unit_price_discriminator, micro_lamports::64-little>>
+    }
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  The SPL Token / Token-2022 `TransferChecked` instruction.
+
+  Discriminator 12, `u64` little-endian amount, `u8` decimals; accounts
+  `[source (writable), mint, destination (writable), authority (signer)]` —
+  the layout the facilitator's static verification path parses.
+  """
+  @spec transfer_checked(%{
+          source: Solana.address(),
+          mint: Solana.address(),
+          destination: Solana.address(),
+          authority: Solana.address(),
+          amount: non_neg_integer(),
+          decimals: byte(),
+          token_program: Solana.address()
+        }) :: instruction()
+  def transfer_checked(%{
+        source: source,
+        mint: mint,
+        destination: destination,
+        authority: authority,
+        amount: amount,
+        decimals: decimals,
+        token_program: token_program
+      })
+      when amount >= 0 and amount <= 0xFFFFFFFFFFFFFFFF and decimals in 0..255 do
+    %{
+      program: token_program,
+      accounts: [
+        %{address: source, signer?: false, writable?: true},
+        %{address: mint, signer?: false, writable?: false},
+        %{address: destination, signer?: false, writable?: true},
+        %{address: authority, signer?: true, writable?: false}
+      ],
+      data: <<@transfer_checked_discriminator, amount::64-little, decimals>>
+    }
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  An SPL Memo instruction carrying UTF-8 `data` (no accounts).
+
+  ## Examples
+
+      iex> ix = X402.Solana.Transaction.memo("pi_3abc123def456")
+      iex> {ix.program, ix.data}
+      {"MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr", "pi_3abc123def456"}
+  """
+  @spec memo(binary()) :: instruction()
+  def memo(data) when is_binary(data) do
+    %{program: Solana.memo_program(), accounts: [], data: data}
+  end
+
+  # -- Compile ----------------------------------------------------------------
+
+  @doc since: "0.6.0"
+  @doc """
+  Compiles instructions into a serialized v0 message.
+
+  Returns the message bytes (starting with the `0x80` version prefix —
+  these are the bytes Ed25519 signatures cover) and the required signer
+  addresses in signature-slot order (the fee payer is always first).
+
+  Returns `{:error, :invalid_address}` when any address fails Base58
+  decoding.
+  """
+  @spec compile(Solana.address(), [instruction()], Solana.address()) ::
+          {:ok, compiled()} | {:error, :invalid_address}
+  def compile(fee_payer, instructions, recent_blockhash) do
+    with {:ok, blockhash} <- Solana.decode_address(recent_blockhash),
+         {:ok, ordered} <- ordered_accounts(fee_payer, instructions),
+         {:ok, encoded_instructions} <- encode_instructions(instructions, ordered) do
+      {signers, header} = header_for(ordered)
+
+      account_section =
+        encode_compact_u16(length(ordered)) <>
+          IO.iodata_to_binary(Enum.map(ordered, & &1.pubkey))
+
+      body =
+        header <>
+          account_section <>
+          blockhash <>
+          encode_compact_u16(length(instructions)) <>
+          encoded_instructions <>
+          encode_compact_u16(0)
+
+      {:ok, %{bytes: <<0x80, body::binary>>, signers: signers}}
+    end
+  end
+
+  @doc since: "0.6.0"
+  @doc """
+  Serializes a wire transaction from message bytes and signatures.
+
+  `signatures` maps signer addresses to 64-byte Ed25519 signatures;
+  signers without an entry get a 64-byte zero placeholder — how a
+  partially signed transaction leaves the fee payer's slot empty for the
+  facilitator to fill at settlement.
+  """
+  @spec serialize(compiled(), %{Solana.address() => binary()}) :: binary()
+  def serialize(%{bytes: message, signers: signers}, signatures) when is_map(signatures) do
+    slots =
+      Enum.map(signers, fn address ->
+        case signatures do
+          %{^address => <<signature::binary-size(64)>>} -> signature
+          _missing -> <<0::512>>
+        end
+      end)
+
+    encode_compact_u16(length(signers)) <> IO.iodata_to_binary(slots) <> message
+  end
+
+  # -- Decode -----------------------------------------------------------------
+
+  @doc since: "0.6.0"
+  @doc """
+  Decodes a wire transaction (v0 or legacy) into its parts.
+
+  Used by the server-side structural checks in `X402.Scheme.ExactSVM`.
+  Rejects trailing bytes and truncated sections with
+  `{:error, :invalid_transaction}`.
+  """
+  @spec decode(binary()) :: {:ok, decoded()} | {:error, :invalid_transaction}
+  def decode(wire) when is_binary(wire) do
+    with {:ok, num_signatures, rest} <- decode_compact_u16(wire),
+         {:ok, signatures, message} <- take_signatures(rest, num_signatures),
+         {:ok, decoded} <- decode_message(message) do
+      case length(decoded.static_accounts) >= decoded.num_required_signatures and
+             num_signatures == decoded.num_required_signatures do
+        true -> {:ok, Map.merge(decoded, %{signatures: signatures, message_bytes: message})}
+        false -> {:error, :invalid_transaction}
+      end
+    else
+      _error -> {:error, :invalid_transaction}
+    end
+  end
+
+  def decode(_wire), do: {:error, :invalid_transaction}
+
+  # -- Compile internals ------------------------------------------------------
+
+  # Ordered static account entries: fee payer, writable signers, read-only
+  # signers, writable non-signers, read-only non-signers; kit's address
+  # comparator within each group.
+  @spec ordered_accounts(Solana.address(), [instruction()]) ::
+          {:ok, [map()]} | {:error, :invalid_address}
+  defp ordered_accounts(fee_payer, instructions) do
+    metas =
+      Enum.flat_map(instructions, fn instruction ->
+        program_meta = %{address: instruction.program, signer?: false, writable?: false}
+        instruction.accounts ++ [program_meta]
+      end)
+
+    merged =
+      Enum.reduce(metas, %{}, fn meta, acc ->
+        Map.update(
+          acc,
+          meta.address,
+          %{signer?: meta.signer?, writable?: meta.writable?},
+          fn existing ->
+            %{
+              signer?: existing.signer? or meta.signer?,
+              writable?: existing.writable? or meta.writable?
+            }
+          end
+        )
+      end)
+      |> Map.put(fee_payer, %{signer?: true, writable?: true})
+
+    entries =
+      merged
+      |> Enum.map(fn {address, roles} ->
+        %{address: address, signer?: roles.signer?, writable?: roles.writable?}
+      end)
+      |> Enum.sort(fn left, right -> account_before?(left, right, fee_payer) end)
+
+    entries
+    |> Enum.reduce_while({:ok, []}, fn entry, {:ok, acc} ->
+      case Solana.decode_address(entry.address) do
+        {:ok, pubkey} -> {:cont, {:ok, [Map.put(entry, :pubkey, pubkey) | acc]}}
+        {:error, :invalid_address} -> {:halt, {:error, :invalid_address}}
+      end
+    end)
+    |> case do
+      {:ok, reversed} -> {:ok, Enum.reverse(reversed)}
+      error -> error
+    end
+  end
+
+  @spec account_before?(map(), map(), Solana.address()) :: boolean()
+  defp account_before?(%{address: fee_payer}, _right, fee_payer), do: true
+  defp account_before?(_left, %{address: fee_payer}, fee_payer), do: false
+
+  defp account_before?(left, right, _fee_payer) do
+    cond do
+      left.signer? != right.signer? -> left.signer?
+      left.writable? != right.writable? -> left.writable?
+      true -> address_compare(left.address, right.address) != :gt
+    end
+  end
+
+  # @solana/kit orders same-role addresses with an English collator:
+  # case-insensitive primary comparison, lowercase-first tiebreak.
+  @spec address_compare(Solana.address(), Solana.address()) :: :lt | :eq | :gt
+  defp address_compare(left, right) do
+    case {String.downcase(left), String.downcase(right)} do
+      {folded, folded} -> case_tiebreak(left, right)
+      {left_folded, right_folded} when left_folded < right_folded -> :lt
+      _greater -> :gt
+    end
+  end
+
+  @spec case_tiebreak(binary(), binary()) :: :lt | :eq | :gt
+  defp case_tiebreak(<<char, left::binary>>, <<char, right::binary>>),
+    do: case_tiebreak(left, right)
+
+  defp case_tiebreak(<<left_char, _::binary>>, <<right_char, _::binary>>) do
+    # Same base letter, differing case: lowercase sorts first.
+    case left_char > right_char do
+      true -> :lt
+      false -> :gt
+    end
+  end
+
+  defp case_tiebreak("", ""), do: :eq
+
+  @spec header_for([map()]) :: {[Solana.address()], binary()}
+  defp header_for(ordered) do
+    signers = for entry <- ordered, entry.signer?, do: entry.address
+    readonly_signed = Enum.count(ordered, &(&1.signer? and not &1.writable?))
+    readonly_unsigned = Enum.count(ordered, &(not &1.signer? and not &1.writable?))
+
+    {signers, <<length(signers), readonly_signed, readonly_unsigned>>}
+  end
+
+  @spec encode_instructions([instruction()], [map()]) :: {:ok, binary()}
+  defp encode_instructions(instructions, ordered) do
+    index_by_address =
+      ordered |> Enum.with_index() |> Map.new(fn {entry, index} -> {entry.address, index} end)
+
+    encoded =
+      Enum.map(instructions, fn instruction ->
+        account_indices =
+          Enum.map(instruction.accounts, &Map.fetch!(index_by_address, &1.address))
+
+        <<Map.fetch!(index_by_address, instruction.program)>> <>
+          encode_compact_u16(length(account_indices)) <>
+          IO.iodata_to_binary(Enum.map(account_indices, &<<&1>>)) <>
+          encode_compact_u16(byte_size(instruction.data)) <>
+          instruction.data
+      end)
+
+    {:ok, IO.iodata_to_binary(encoded)}
+  end
+
+  # -- Decode internals -------------------------------------------------------
+
+  @spec decode_compact_u16(binary(), non_neg_integer(), non_neg_integer()) ::
+          {:ok, non_neg_integer(), binary()} | :error
+  defp decode_compact_u16(<<byte, rest::binary>>, shift, acc) when shift <= 14 do
+    value = Bitwise.bor(acc, Bitwise.bsl(Bitwise.band(byte, 0x7F), shift))
+
+    case Bitwise.band(byte, 0x80) do
+      0 -> if value <= 0xFFFF, do: {:ok, value, rest}, else: :error
+      _continue -> decode_compact_u16(rest, shift + 7, value)
+    end
+  end
+
+  defp decode_compact_u16(_binary, _shift, _acc), do: :error
+
+  @spec take_signatures(binary(), non_neg_integer()) :: {:ok, [binary()], binary()} | :error
+  defp take_signatures(binary, count), do: take_chunks(binary, count, 64, [])
+
+  @spec take_chunks(binary(), non_neg_integer(), pos_integer(), [binary()]) ::
+          {:ok, [binary()], binary()} | :error
+  defp take_chunks(binary, 0, _size, acc), do: {:ok, Enum.reverse(acc), binary}
+
+  defp take_chunks(binary, count, size, acc) do
+    case binary do
+      <<chunk::binary-size(size), rest::binary>> ->
+        take_chunks(rest, count - 1, size, [chunk | acc])
+
+      _short ->
+        :error
+    end
+  end
+
+  @spec decode_message(binary()) :: {:ok, map()} | :error
+  defp decode_message(<<prefix, rest::binary>> = message) do
+    case Bitwise.band(prefix, 0x80) do
+      0x80 ->
+        case Bitwise.band(prefix, 0x7F) do
+          0 -> decode_message_body(rest, 0)
+          _unsupported -> :error
+        end
+
+      0 ->
+        decode_message_body(message, :legacy)
+    end
+  end
+
+  defp decode_message(_message), do: :error
+
+  @spec decode_message_body(binary(), 0 | :legacy) :: {:ok, map()} | :error
+  defp decode_message_body(
+         <<num_required, readonly_signed, readonly_unsigned, rest::binary>>,
+         version
+       ) do
+    with {:ok, num_accounts, rest} <- decode_compact_u16(rest),
+         {:ok, accounts, rest} <- take_chunks(rest, num_accounts, 32, []),
+         <<blockhash::binary-size(32), rest::binary>> <- rest,
+         {:ok, num_instructions, rest} <- decode_compact_u16(rest),
+         {:ok, instructions, rest} <- decode_instructions(rest, num_instructions, []),
+         {:ok, lookups, rest} <- decode_lookups(rest, version),
+         "" <- rest do
+      {:ok,
+       %{
+         version: version,
+         num_required_signatures: num_required,
+         num_readonly_signed: readonly_signed,
+         num_readonly_unsigned: readonly_unsigned,
+         static_accounts: accounts,
+         recent_blockhash: blockhash,
+         instructions: instructions,
+         address_table_lookups: lookups
+       }}
+    else
+      _error -> :error
+    end
+  end
+
+  defp decode_message_body(_binary, _version), do: :error
+
+  @spec decode_instructions(binary(), non_neg_integer(), [map()]) ::
+          {:ok, [map()], binary()} | :error
+  defp decode_instructions(binary, 0, acc), do: {:ok, Enum.reverse(acc), binary}
+
+  defp decode_instructions(<<program_index, rest::binary>>, count, acc) do
+    with {:ok, num_accounts, rest} <- decode_compact_u16(rest),
+         <<indices::binary-size(num_accounts), rest::binary>> <- rest,
+         {:ok, data_len, rest} <- decode_compact_u16(rest),
+         <<data::binary-size(data_len), rest::binary>> <- rest do
+      instruction = %{
+        program_index: program_index,
+        account_indices: :binary.bin_to_list(indices),
+        data: data
+      }
+
+      decode_instructions(rest, count - 1, [instruction | acc])
+    else
+      _error -> :error
+    end
+  end
+
+  defp decode_instructions(_binary, _count, _acc), do: :error
+
+  @spec decode_lookups(binary(), 0 | :legacy) :: {:ok, non_neg_integer(), binary()} | :error
+  defp decode_lookups(binary, :legacy), do: {:ok, 0, binary}
+
+  defp decode_lookups(binary, 0) do
+    with {:ok, count, rest} <- decode_compact_u16(binary),
+         {:ok, rest} <- skip_lookups(rest, count) do
+      {:ok, count, rest}
+    end
+  end
+
+  @spec skip_lookups(binary(), non_neg_integer()) :: {:ok, binary()} | :error
+  defp skip_lookups(binary, 0), do: {:ok, binary}
+
+  defp skip_lookups(<<_table::binary-size(32), rest::binary>>, count) do
+    with {:ok, writable, rest} <- decode_compact_u16(rest),
+         <<_writable::binary-size(writable), rest::binary>> <- rest,
+         {:ok, readonly, rest} <- decode_compact_u16(rest),
+         <<_readonly::binary-size(readonly), rest::binary>> <- rest do
+      skip_lookups(rest, count - 1)
+    else
+      _error -> :error
+    end
+  end
+
+  defp skip_lookups(_binary, _count), do: :error
+end

--- a/test/x402/base58_test.exs
+++ b/test/x402/base58_test.exs
@@ -1,0 +1,63 @@
+defmodule X402.Base58Test do
+  use ExUnit.Case, async: true
+
+  doctest X402.Base58
+
+  alias X402.Base58
+
+  # Bitcoin Core base58_encode_decode.json vectors (hex => base58),
+  # cross-checked against @solana/kit's base58 codec.
+  @vectors [
+    {"", ""},
+    {"61", "2g"},
+    {"626262", "a3gV"},
+    {"636363", "aPEr"},
+    {"73696d706c792061206c6f6e6720737472696e67", "2cFupjhnEsSn59qHXstmK2ffpLv2"},
+    {"00eb15231dfceb60925886b67d065299925915aeb172c06647", "1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L"},
+    {"516b6fcd0f", "ABnLTmg"},
+    {"bf4f89001e670274dd", "3SEo3LWLoPntC"},
+    {"572e4794", "3EFU7m"},
+    {"ecac89cad93923c02321", "EJDM8drfXA6uyA"},
+    {"10c8511e", "Rt5zm"},
+    {"00000000000000000000", "1111111111"}
+  ]
+
+  describe "encode/1" do
+    test "matches the Bitcoin Core test vectors" do
+      for {hex, expected} <- @vectors do
+        assert Base58.encode(Base.decode16!(hex, case: :lower)) == expected
+      end
+    end
+
+    test "encodes 32-byte Solana public keys" do
+      assert Base58.encode(<<0::256>>) == "11111111111111111111111111111111"
+    end
+  end
+
+  describe "decode/1" do
+    test "round-trips the Bitcoin Core test vectors" do
+      for {hex, encoded} <- @vectors do
+        assert Base58.decode(encoded) == {:ok, Base.decode16!(hex, case: :lower)}
+      end
+    end
+
+    test "round-trips random binaries" do
+      for _iteration <- 1..50 do
+        binary = :crypto.strong_rand_bytes(:rand.uniform(64))
+        assert {:ok, decoded} = binary |> Base58.encode() |> Base58.decode()
+        assert decoded == binary
+      end
+    end
+
+    test "rejects characters outside the alphabet" do
+      for invalid <- ["0", "O", "I", "l", "hello world", "abc!"] do
+        assert Base58.decode(invalid) == :error
+      end
+    end
+
+    test "rejects non-binary input" do
+      assert Base58.decode(nil) == :error
+      assert Base58.decode(123) == :error
+    end
+  end
+end

--- a/test/x402/client_test.exs
+++ b/test/x402/client_test.exs
@@ -216,8 +216,15 @@ defmodule X402.ClientTest do
       assert Client.build_payment(cash, signer()) ==
                {:error, {:unsupported_kind, "cash", "eip155:84532"}}
 
+      bitcoin = Map.put(@evm_requirements, "network", "bip122:000000000019d6689c085ae165831e93")
+
+      assert Client.build_payment(bitcoin, signer()) ==
+               {:error, {:unsupported_kind, "exact", "bip122:000000000019d6689c085ae165831e93"}}
+    end
+
+    test "solana requirements without extra.feePayer fail signing" do
       assert Client.build_payment(@solana_requirements, signer()) ==
-               {:error, {:unsupported_kind, "exact", "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"}}
+               {:error, :missing_fee_payer}
     end
 
     test "signs upto requirements via Permit2 when extra carries facilitatorAddress" do

--- a/test/x402/plug/payment_gate_test.exs
+++ b/test/x402/plug/payment_gate_test.exs
@@ -23,12 +23,14 @@ defmodule X402.Plug.PaymentGateTest do
   import Plug.Conn
   import Plug.Test
 
+  alias X402.Client
   alias X402.Extensions.PaymentIdentifier.ETSCache
   alias X402.Facilitator
   alias X402.PaymentIdentifierCacheMock, as: CacheMock
   alias X402.PaymentRequired
   alias X402.PaymentResponse
   alias X402.Plug.PaymentGate
+  alias X402.Signer.SolanaKey
 
   setup :verify_on_exit!
 
@@ -781,7 +783,11 @@ defmodule X402.Plug.PaymentGateTest do
       price: "5000",
       network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
       asset: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-      pay_to: "CKPKJWNdJEqa81x7CkZ14BVPiY6y16Sxs7owznqtWYp5"
+      pay_to: "CKPKJWNdJEqa81x7CkZ14BVPiY6y16Sxs7owznqtWYp5",
+      extra: %{
+        "feePayer" => "9hSR6S7WPtxmTojgo6GG3k4yDPecgJY292j7xrsUGWBu",
+        "recentBlockhash" => "EZ3rST5dvHmbanh75jc4PuLfV96vp9fEYBVeNk4FfM1k"
+      }
     }
 
     @multi_route %{
@@ -821,14 +827,20 @@ defmodule X402.Plug.PaymentGateTest do
     test "selects the matching accept among multiple options" do
       facilitator = start_mock_facilitator()
 
-      solana_payload =
-        valid_payment_payload()
-        |> put_in(["accepted", "scheme"], "exact")
-        |> put_in(["accepted", "network"], @solana_accept.network)
-        |> put_in(["accepted", "amount"], @solana_accept.price)
-        |> put_in(["accepted", "asset"], @solana_accept.asset)
-        |> put_in(["accepted", "payTo"], @solana_accept.pay_to)
-        |> put_in(["payload"], %{"transaction" => "base64-encoded-solana-transaction"})
+      # Full client flow: the 402's PAYMENT-REQUIRED is decoded, the client
+      # selects the SVM entry (the EVM entry lacks its EIP-712 domain and is
+      # not signable), builds a real partially signed Solana transaction, and
+      # the gate's structural validation and static-path pre-checks let it
+      # through to the Bypass-backed facilitator.
+      payment_required =
+        conn(:get, "/api/resource")
+        |> run_request(routes: [@multi_route], facilitator: facilitator)
+        |> decode_payment_required!()
+
+      {:ok, solana_signer} = SolanaKey.new(:crypto.strong_rand_bytes(32))
+      {:ok, solana_payload} = Client.build_payment(payment_required, solana_signer)
+
+      assert solana_payload["accepted"]["network"] == @solana_accept.network
 
       conn =
         conn(:get, "/api/resource")
@@ -836,10 +848,15 @@ defmodule X402.Plug.PaymentGateTest do
         |> run_request(routes: [@multi_route], facilitator: facilitator)
 
       assert conn.status == 200
-      assert_receive {:verify_called, _payload, requirements}
+      assert_receive {:verify_called, payload, requirements}
       assert requirements["network"] == @solana_accept.network
       assert requirements["amount"] == @solana_accept.price
       assert requirements["payTo"] == @solana_accept.pay_to
+      assert requirements["extra"]["feePayer"] == @solana_accept.extra["feePayer"]
+
+      # The facilitator receives the client's partially signed transaction.
+      assert payload["payload"]["transaction"] == solana_payload["payload"]["transaction"]
+      assert {:ok, _wire} = Base.decode64(payload["payload"]["transaction"])
     end
 
     test "rejects when accepted matches none of the multi-accept options" do

--- a/test/x402/scheme/exact_svm_test.exs
+++ b/test/x402/scheme/exact_svm_test.exs
@@ -254,6 +254,47 @@ defmodule X402.Scheme.ExactSVMTest do
 
       assert ExactSVM.sign(requirements(%{"amount" => "-3"}), signer(), []) ==
                {:error, :invalid_amount}
+
+      assert ExactSVM.sign(requirements(%{"amount" => nil}), signer(), []) ==
+               {:error, :invalid_amount}
+    end
+
+    test "rejects invalid asset and payTo addresses" do
+      evm_address = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+
+      assert ExactSVM.sign(requirements(%{"asset" => evm_address}), signer(), []) ==
+               {:error, :invalid_asset}
+
+      assert ExactSVM.sign(requirements(%{"payTo" => evm_address}), signer(), []) ==
+               {:error, :invalid_pay_to}
+    end
+
+    test "rejects a malformed :svm_blockhash option" do
+      no_hint = requirements(%{"extra" => %{"feePayer" => @fee_payer}})
+
+      assert ExactSVM.sign(no_hint, signer(), svm_blockhash: "bogus") ==
+               {:error, :invalid_blockhash}
+    end
+
+    test "wraps a fetcher returning a bare value" do
+      no_hint = requirements(%{"extra" => %{"feePayer" => @fee_payer}})
+
+      assert ExactSVM.sign(no_hint, signer(), svm_blockhash_fetcher: fn _network -> :whoops end) ==
+               {:error, {:blockhash_fetch_failed, :whoops}}
+    end
+
+    test "known assets keep their table metadata under partial overrides" do
+      # Explicit token program with table decimals.
+      assert ExactSVM.sign(requirements(), signer(), svm_token_program: Solana.token_program()) ==
+               {:ok, %{"transaction" => @reference_transaction}}
+
+      # Explicit decimals with the table's token program.
+      assert ExactSVM.sign(requirements(), signer(), svm_decimals: 6) ==
+               {:ok, %{"transaction" => @reference_transaction}}
+    end
+
+    test "signable? requires a requirements map" do
+      refute ExactSVM.signable?(nil)
     end
   end
 
@@ -304,6 +345,16 @@ defmodule X402.Scheme.ExactSVMTest do
     test "skips the fee payer check when the requirements do not advertise one" do
       {payload, reqs} = signed_payload()
       assert ExactSVM.validate_payload(payload, Map.put(reqs, "extra", %{}), []) == :ok
+    end
+
+    test "treats a non-map scheme payload as a missing transaction" do
+      {_payload, reqs} = signed_payload()
+
+      assert ExactSVM.validate_payload(%{"payload" => "nope"}, reqs, []) ==
+               {:error, {:invalid_scheme_payment, :missing_transaction}}
+
+      assert ExactSVM.validate_payload(%{}, reqs, []) ==
+               {:error, {:invalid_scheme_payment, :missing_transaction}}
     end
   end
 
@@ -391,6 +442,51 @@ defmodule X402.Scheme.ExactSVMTest do
 
       assert ExactSVM.precheck(wire_payload(compiled), reqs, []) ==
                {:error, {:precheck_failed, :invalid_compute_limit_instruction}}
+    end
+
+    test "rejects a malformed compute price and a missing positional transfer" do
+      {_payload, reqs} = signed_payload()
+      [limit, price, transfer] = instructions_without_memo()
+
+      bogus_price = %{program: Solana.compute_budget_program(), accounts: [], data: <<9, 9>>}
+
+      {:ok, compiled} =
+        Transaction.compile(@fee_payer, [limit, bogus_price, transfer], @blockhash)
+
+      assert ExactSVM.precheck(wire_payload(compiled), reqs, []) ==
+               {:error, {:precheck_failed, :invalid_compute_price_instruction}}
+
+      {:ok, compiled} =
+        Transaction.compile(@fee_payer, [limit, price, Transaction.memo("x")], @blockhash)
+
+      assert ExactSVM.precheck(wire_payload(compiled), reqs, []) ==
+               {:error, {:precheck_failed, :missing_transfer_instruction}}
+    end
+
+    test "rejects two memo instructions when the seller pinned one" do
+      {_payload, reqs} = signed_payload()
+
+      {:ok, compiled} =
+        Transaction.compile(
+          @fee_payer,
+          instructions_without_memo() ++ [Transaction.memo(@memo), Transaction.memo("second")],
+          @blockhash
+        )
+
+      assert ExactSVM.precheck(wire_payload(compiled), reqs, []) ==
+               {:error, {:precheck_failed, :memo_count}}
+    end
+
+    test "skips semantic checks the requirements cannot back locally" do
+      {payload, reqs} = signed_payload()
+
+      uninterpretable =
+        reqs
+        |> Map.put("amount", "not-a-number")
+        |> Map.put("asset", "0xnot-solana")
+        |> Map.put("payTo", "0xnot-solana")
+
+      assert ExactSVM.precheck(payload, uninterpretable, []) == :ok
     end
 
     test "rejects a fee payer referenced by an instruction (isolation, spec 2.1.1)" do

--- a/test/x402/scheme/exact_svm_test.exs
+++ b/test/x402/scheme/exact_svm_test.exs
@@ -1,0 +1,525 @@
+defmodule X402.Scheme.ExactSVMTest do
+  use ExUnit.Case, async: true
+
+  doctest X402.Scheme.ExactSVM
+
+  alias X402.Base58
+  alias X402.Client
+  alias X402.PaymentSignature
+  alias X402.Scheme.ExactSVM
+  alias X402.Signer.LocalKey
+  alias X402.Signer.SolanaKey
+  alias X402.Solana
+  alias X402.Solana.Transaction
+
+  # ---------------------------------------------------------------------------
+  # Reference fixture, generated with the official Solana TypeScript stack
+  # (@solana/kit 8.0.0 + @solana-program/token{,-2022} + compute-budget),
+  # mirroring typescript/packages/mechanisms/svm/src/exact/client/scheme.ts
+  # from the x402 monorepo verbatim: v0 message, instructions
+  # [SetComputeUnitLimit(20_000), SetComputeUnitPrice(1), TransferChecked,
+  # Memo], partiallySignTransactionMessageWithSigners, base64 wire encoding.
+  #
+  # Keys: client seed 0x01*32, fee payer seed 0x02*32, payTo seed 0x03*32.
+  # ---------------------------------------------------------------------------
+  @client_seed :binary.copy(<<1>>, 32)
+  @client "AKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9"
+  @fee_payer "9hSR6S7WPtxmTojgo6GG3k4yDPecgJY292j7xrsUGWBu"
+  @pay_to "GyGKxMyg1p9SsHfm15MkNUu1u9TN2JtTspcdmrtGUdse"
+  @usdc "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+  @blockhash "EZ3rST5dvHmbanh75jc4PuLfV96vp9fEYBVeNk4FfM1k"
+  @memo "pi_3abc123def456"
+
+  @reference_transaction "AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" <>
+                           "AAAAAAAAAAAAAAAAAAAW+SpluuKWpSopmb3NGvPXNIz0wyrIAv52H2hmLkoT6zq52KCy" <>
+                           "kTjqwZBGQn5/l7gycYMEih9thyEI+tOww8EGgAIBBAiBOXcOqH0XX1ajVGbDTH7My42K" <>
+                           "kbTuN6Jd9g9bj8mzlIqI4910CfGV/VLbLTy6XXLKZwm/HZQSG/N0iAG0D29cK8kCOGhp" <>
+                           "AsJh82TGFPHsq0/z4F9YGhwIBT/HU9NN52y3u4T1/jPeFaQeWwjr0hpa8fhuRvZTRT6H" <>
+                           "DzBHpR7Q4AMGRm/lIRcy/+ytunLDm+e8jOW7xfcSayxDmzpAAAAAxvp6877brTo9ZfNq" <>
+                           "q8l0MbG75MLS9uDkfKYCA0UvXWEFSlNamSkhBk0k6HFg2jh8fDW13bySu4HkH6hAQQVE" <>
+                           "jQbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCpyV29u5s5tb9yxXaxLxIjPB/v" <>
+                           "cv+BhIj3ODTS8YLYlusEBAAFAiBOAAAEAAkDAQAAAAAAAAAHBAIFAwEKDOgDAAAAAAAA" <>
+                           "BgYAEHBpXzNhYmMxMjNkZWY0NTYA"
+
+  defp signer do
+    {:ok, signer} = SolanaKey.new(@client_seed)
+    signer
+  end
+
+  defp requirements(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "scheme" => "exact",
+        "network" => "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+        "amount" => "1000",
+        "asset" => @usdc,
+        "payTo" => @pay_to,
+        "maxTimeoutSeconds" => 60,
+        "extra" => %{
+          "feePayer" => @fee_payer,
+          "memo" => @memo,
+          "recentBlockhash" => @blockhash
+        }
+      },
+      overrides
+    )
+  end
+
+  defp signed_payload(overrides \\ %{}) do
+    reqs = requirements(overrides)
+    {:ok, scheme_payload} = ExactSVM.sign(reqs, signer(), [])
+
+    {%{
+       "x402Version" => 2,
+       "accepted" => reqs,
+       "payload" => scheme_payload
+     }, reqs}
+  end
+
+  describe "sign/3 against the TypeScript reference fixture" do
+    test "produces a byte-identical partially signed transaction" do
+      assert ExactSVM.sign(requirements(), signer(), []) ==
+               {:ok, %{"transaction" => @reference_transaction}}
+    end
+
+    test "decoding the produced bytes re-asserts every field" do
+      {:ok, %{"transaction" => encoded}} = ExactSVM.sign(requirements(), signer(), [])
+      {:ok, decoded} = encoded |> Base.decode64!() |> Transaction.decode()
+
+      assert decoded.version == 0
+      assert decoded.num_required_signatures == 2
+      assert decoded.num_readonly_signed == 1
+      assert decoded.num_readonly_unsigned == 4
+      assert decoded.address_table_lookups == 0
+
+      # Account 0 is the sponsor's fee payer; its signature slot is the
+      # 64-byte zero placeholder (partially signed transaction).
+      {:ok, fee_payer_pubkey} = Solana.decode_address(@fee_payer)
+      assert hd(decoded.static_accounts) == fee_payer_pubkey
+      assert [<<0::512>>, client_signature] = decoded.signatures
+
+      # The client's Ed25519 signature covers the message bytes and
+      # verifies against the client public key.
+      {public, _private} = :crypto.generate_key(:eddsa, :ed25519, @client_seed)
+
+      assert :crypto.verify(
+               :eddsa,
+               :none,
+               decoded.message_bytes,
+               client_signature,
+               [public, :ed25519]
+             )
+
+      {:ok, blockhash} = Solana.decode_address(@blockhash)
+      assert decoded.recent_blockhash == blockhash
+
+      # Reference instruction set, in order.
+      assert [limit_ix, price_ix, transfer_ix, memo_ix] = decoded.instructions
+      assert limit_ix.data == <<2, 20_000::32-little>>
+      assert price_ix.data == <<3, 1::64-little>>
+      assert transfer_ix.data == <<12, 1000::64-little, 6>>
+      assert memo_ix.data == @memo
+
+      # TransferChecked destination is the ATA derived from payTo + asset.
+      {:ok, dest_ata} = Solana.associated_token_address(@pay_to, @usdc)
+      {:ok, dest_pubkey} = Solana.decode_address(dest_ata)
+      destination_index = Enum.at(transfer_ix.account_indices, 2)
+      assert Enum.at(decoded.static_accounts, destination_index) == dest_pubkey
+
+      # The transfer authority is the client, not the fee payer.
+      {:ok, client_pubkey} = Solana.decode_address(@client)
+      authority_index = Enum.at(transfer_ix.account_indices, 3)
+      assert Enum.at(decoded.static_accounts, authority_index) == client_pubkey
+    end
+
+    test "generates a random hex nonce memo when extra.memo is absent" do
+      reqs =
+        requirements(%{
+          "extra" => %{"feePayer" => @fee_payer, "recentBlockhash" => @blockhash}
+        })
+
+      {:ok, %{"transaction" => encoded}} = ExactSVM.sign(reqs, signer(), [])
+      {:ok, decoded} = encoded |> Base.decode64!() |> Transaction.decode()
+
+      memo_ix = List.last(decoded.instructions)
+      assert byte_size(memo_ix.data) == 32
+      assert memo_ix.data =~ ~r/^[0-9a-f]{32}$/
+
+      # Nonces differ between builds (transaction uniqueness).
+      {:ok, %{"transaction" => second}} = ExactSVM.sign(reqs, signer(), [])
+      assert second != encoded
+    end
+  end
+
+  describe "sign/3 option handling" do
+    test "requires extra.feePayer" do
+      assert ExactSVM.sign(requirements(%{"extra" => %{}}), signer(), []) ==
+               {:error, :missing_fee_payer}
+
+      assert ExactSVM.sign(
+               requirements(%{"extra" => %{"feePayer" => "not-an-address"}}),
+               signer(),
+               []
+             ) == {:error, :missing_fee_payer}
+    end
+
+    test "blockhash: server hint wins, then :svm_blockhash, then the fetcher" do
+      no_hint = requirements(%{"extra" => %{"feePayer" => @fee_payer, "memo" => @memo}})
+
+      # Server hint produces the reference transaction even when an option
+      # is also given.
+      assert ExactSVM.sign(requirements(), signer(), svm_blockhash: other_blockhash()) ==
+               {:ok, %{"transaction" => @reference_transaction}}
+
+      # Without the hint the option is used.
+      assert ExactSVM.sign(no_hint, signer(), svm_blockhash: @blockhash) ==
+               {:ok, %{"transaction" => @reference_transaction}}
+
+      # Then the fetcher.
+      parent = self()
+
+      fetcher = fn network ->
+        send(parent, {:fetched, network})
+        {:ok, @blockhash}
+      end
+
+      assert ExactSVM.sign(no_hint, signer(), svm_blockhash_fetcher: fetcher) ==
+               {:ok, %{"transaction" => @reference_transaction}}
+
+      assert_received {:fetched, "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"}
+
+      # A malformed hint falls through to the option (spec: "when absent or
+      # malformed, the client MUST fetch a recent blockhash itself").
+      bad_hint =
+        requirements(%{
+          "extra" => %{
+            "feePayer" => @fee_payer,
+            "memo" => @memo,
+            "recentBlockhash" => "bogus"
+          }
+        })
+
+      assert ExactSVM.sign(bad_hint, signer(), svm_blockhash: @blockhash) ==
+               {:ok, %{"transaction" => @reference_transaction}}
+
+      # With no source at all, a structured error.
+      assert ExactSVM.sign(no_hint, signer(), []) == {:error, :missing_blockhash}
+    end
+
+    test "fetcher failures surface as blockhash_fetch_failed" do
+      no_hint = requirements(%{"extra" => %{"feePayer" => @fee_payer}})
+
+      assert ExactSVM.sign(no_hint, signer(), svm_blockhash_fetcher: fn _n -> {:error, :down} end) ==
+               {:error, {:blockhash_fetch_failed, :down}}
+
+      assert ExactSVM.sign(no_hint, signer(), svm_blockhash_fetcher: fn _n -> {:ok, "bogus"} end) ==
+               {:error, :invalid_blockhash}
+    end
+
+    test "unknown mints need :svm_decimals (and optionally :svm_token_program)" do
+      unknown_mint = Base58.encode(:crypto.strong_rand_bytes(32))
+      reqs = requirements(%{"asset" => unknown_mint})
+
+      assert ExactSVM.sign(reqs, signer(), []) == {:error, {:unknown_asset, unknown_mint}}
+
+      assert {:ok, %{"transaction" => encoded}} =
+               ExactSVM.sign(reqs, signer(),
+                 svm_decimals: 9,
+                 svm_token_program: Solana.token_2022_program()
+               )
+
+      {:ok, decoded} = encoded |> Base.decode64!() |> Transaction.decode()
+      transfer_ix = Enum.at(decoded.instructions, 2)
+      assert transfer_ix.data == <<12, 1000::64-little, 9>>
+
+      {:ok, token_2022} = Solana.decode_address(Solana.token_2022_program())
+      assert Enum.at(decoded.static_accounts, transfer_ix.program_index) == token_2022
+    end
+
+    test "rejects an over-long seller memo" do
+      long_memo = String.duplicate("a", 257)
+      reqs = put_in(requirements()["extra"]["memo"], long_memo)
+
+      assert ExactSVM.sign(reqs, signer(), []) == {:error, :memo_too_long}
+    end
+
+    test "rejects signers without a Solana address or Ed25519 support" do
+      {:ok, evm_signer} = LocalKey.new("0x" <> String.duplicate("11", 32))
+      assert ExactSVM.sign(requirements(), evm_signer, []) == {:error, :invalid_payer_address}
+    end
+
+    test "rejects invalid amounts" do
+      assert ExactSVM.sign(requirements(%{"amount" => "1.5"}), signer(), []) ==
+               {:error, :invalid_amount}
+
+      assert ExactSVM.sign(requirements(%{"amount" => "-3"}), signer(), []) ==
+               {:error, :invalid_amount}
+    end
+  end
+
+  describe "validate_payload/3" do
+    test "accepts a well-formed payload" do
+      {payload, reqs} = signed_payload()
+      assert ExactSVM.validate_payload(payload, reqs, []) == :ok
+    end
+
+    test "rejects structural failures" do
+      {payload, reqs} = signed_payload()
+
+      assert ExactSVM.validate_payload(%{"payload" => %{}}, reqs, []) ==
+               {:error, {:invalid_scheme_payment, :missing_transaction}}
+
+      assert ExactSVM.validate_payload(
+               put_in(payload["payload"], %{"transaction" => "!"}),
+               reqs,
+               []
+             ) ==
+               {:error, {:invalid_scheme_payment, :invalid_base64}}
+
+      oversized = Base.encode64(:binary.copy(<<0>>, 1233))
+
+      assert ExactSVM.validate_payload(
+               put_in(payload["payload"], %{"transaction" => oversized}),
+               reqs,
+               []
+             ) == {:error, {:invalid_scheme_payment, :transaction_too_large}}
+
+      garbage = Base.encode64(:crypto.strong_rand_bytes(100))
+
+      assert ExactSVM.validate_payload(
+               put_in(payload["payload"], %{"transaction" => garbage}),
+               reqs,
+               []
+             ) == {:error, {:invalid_scheme_payment, :invalid_transaction}}
+    end
+
+    test "rejects a fee payer differing from the advertised one" do
+      {payload, reqs} = signed_payload()
+      other_reqs = put_in(reqs["extra"]["feePayer"], @pay_to)
+
+      assert ExactSVM.validate_payload(payload, other_reqs, []) ==
+               {:error, {:invalid_scheme_payment, :fee_payer_mismatch}}
+    end
+
+    test "skips the fee payer check when the requirements do not advertise one" do
+      {payload, reqs} = signed_payload()
+      assert ExactSVM.validate_payload(payload, Map.put(reqs, "extra", %{}), []) == :ok
+    end
+  end
+
+  describe "precheck/3" do
+    test "accepts the reference transaction" do
+      {payload, reqs} = signed_payload()
+      assert ExactSVM.precheck(payload, reqs, []) == :ok
+    end
+
+    test "rejects certain semantic mismatches on the positional transfer" do
+      {payload, reqs} = signed_payload()
+
+      assert ExactSVM.precheck(payload, Map.put(reqs, "amount", "2000"), []) ==
+               {:error, {:precheck_failed, :amount_mismatch}}
+
+      other_mint = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"
+
+      assert ExactSVM.precheck(payload, Map.put(reqs, "asset", other_mint), []) ==
+               {:error, {:precheck_failed, :mint_mismatch}}
+
+      assert ExactSVM.precheck(payload, Map.put(reqs, "payTo", @fee_payer), []) ==
+               {:error, {:precheck_failed, :recipient_mismatch}}
+    end
+
+    test "enforces the seller memo" do
+      {payload, reqs} = signed_payload()
+
+      mismatched = put_in(reqs["extra"]["memo"], "different-memo")
+
+      assert ExactSVM.precheck(payload, mismatched, []) ==
+               {:error, {:precheck_failed, :memo_mismatch}}
+
+      # A transaction without any memo instruction fails the count check.
+      {:ok, compiled} =
+        Transaction.compile(@fee_payer, instructions_without_memo(), @blockhash)
+
+      no_memo_payload = wire_payload(compiled)
+
+      assert ExactSVM.precheck(no_memo_payload, reqs, []) ==
+               {:error, {:precheck_failed, :memo_count}}
+    end
+
+    test "rejects layouts outside the static-path whitelist" do
+      {_payload, reqs} = signed_payload()
+
+      # Too few instructions (spec §3.1 requires 3–7).
+      {:ok, compiled} =
+        Transaction.compile(
+          @fee_payer,
+          Enum.take(instructions_without_memo(), 2),
+          @blockhash
+        )
+
+      assert ExactSVM.precheck(wire_payload(compiled), reqs, []) ==
+               {:error, {:precheck_failed, :instruction_count}}
+
+      # An unknown program in the optional tail.
+      unknown_program = Base58.encode(:crypto.strong_rand_bytes(32))
+
+      rogue = %{program: unknown_program, accounts: [], data: "x"}
+
+      {:ok, compiled} =
+        Transaction.compile(@fee_payer, instructions_without_memo() ++ [rogue], @blockhash)
+
+      assert ExactSVM.precheck(wire_payload(compiled), reqs, []) ==
+               {:error, {:precheck_failed, :unknown_optional_instruction}}
+
+      # Compute unit price beyond the 5 lamports/CU static-path cap.
+      [limit, _price, transfer] = instructions_without_memo()
+
+      {:ok, compiled} =
+        Transaction.compile(
+          @fee_payer,
+          [limit, Transaction.set_compute_unit_price(5_000_001), transfer],
+          @blockhash
+        )
+
+      assert ExactSVM.precheck(wire_payload(compiled), reqs, []) ==
+               {:error, {:precheck_failed, :compute_price_too_high}}
+
+      # Swapped compute-budget instructions break the reference order.
+      [limit, price, transfer] = instructions_without_memo()
+
+      {:ok, compiled} = Transaction.compile(@fee_payer, [price, limit, transfer], @blockhash)
+
+      assert ExactSVM.precheck(wire_payload(compiled), reqs, []) ==
+               {:error, {:precheck_failed, :invalid_compute_limit_instruction}}
+    end
+
+    test "rejects a fee payer referenced by an instruction (isolation, spec 2.1.1)" do
+      # The fee payer as transfer authority would let the sponsor's
+      # signature move the sponsor's funds.
+      {:ok, source_ata} = Solana.associated_token_address(@fee_payer, @usdc)
+      {:ok, dest_ata} = Solana.associated_token_address(@pay_to, @usdc)
+
+      transfer =
+        Transaction.transfer_checked(%{
+          source: source_ata,
+          mint: @usdc,
+          destination: dest_ata,
+          authority: @fee_payer,
+          amount: 1000,
+          decimals: 6,
+          token_program: Solana.token_program()
+        })
+
+      [limit, price, _transfer] = instructions_without_memo()
+
+      {:ok, compiled} =
+        Transaction.compile(
+          @fee_payer,
+          [limit, price, transfer, Transaction.memo(@memo)],
+          @blockhash
+        )
+
+      {_payload, reqs} = signed_payload()
+
+      assert ExactSVM.precheck(wire_payload(compiled), reqs, []) ==
+               {:error, {:precheck_failed, :fee_payer_not_isolated}}
+    end
+
+    test "passes transactions using address lookup tables through to the facilitator" do
+      {payload, reqs} = signed_payload()
+
+      wire = Base.decode64!(payload["payload"]["transaction"])
+      # Rewrite the trailing ALT count (0) to 1 and append a minimal
+      # lookup entry: 32-byte table address, one writable index, none
+      # read-only.
+      body_size = byte_size(wire) - 1
+      <<body::binary-size(body_size), 0>> = wire
+      with_alt = body <> <<1>> <> :binary.copy(<<7>>, 32) <> <<1, 200>> <> <<0>>
+
+      alt_payload = put_in(payload["payload"], %{"transaction" => Base.encode64(with_alt)})
+
+      assert ExactSVM.precheck(alt_payload, reqs, []) == :ok
+    end
+
+    test "rejects undecodable payloads" do
+      {_payload, reqs} = signed_payload()
+
+      assert ExactSVM.precheck(%{"payload" => %{"transaction" => "!"}}, reqs, []) ==
+               {:error, {:precheck_failed, :invalid_transaction}}
+    end
+  end
+
+  describe "client integration" do
+    test "build_payment selects and signs the SVM entry among multiple accepts" do
+      evm_entry = %{
+        "scheme" => "exact",
+        "network" => "eip155:84532",
+        "amount" => "10000",
+        "asset" => "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+        "payTo" => "0x2222222222222222222222222222222222222222",
+        "maxTimeoutSeconds" => 300,
+        # No EIP-712 domain — not signable by ExactEVM.
+        "extra" => %{}
+      }
+
+      payment_required = %{
+        "x402Version" => 2,
+        "resource" => %{"url" => "https://api.example.com/paid", "mimeType" => "application/json"},
+        "accepts" => [evm_entry, requirements()],
+        "extensions" => %{}
+      }
+
+      assert {:ok, payload} = Client.build_payment(payment_required, signer())
+      assert payload["accepted"] == requirements()
+      assert payload["payload"]["transaction"] == @reference_transaction
+
+      # Round-trip through the header codec and server-side validation.
+      {:ok, header} = Client.encode_payment(payload)
+      {:ok, decoded} = PaymentSignature.decode(header)
+      assert {:ok, ^decoded} = PaymentSignature.validate(decoded, requirements())
+    end
+
+    test "select_requirements skips SVM entries without extra.feePayer" do
+      no_fee_payer = requirements(%{"extra" => %{}})
+
+      assert Client.select_requirements(%{"accepts" => [no_fee_payer]}) ==
+               {:error, :no_acceptable_requirements}
+
+      assert Client.select_requirements(%{"accepts" => [no_fee_payer, requirements()]}) ==
+               {:ok, requirements()}
+    end
+  end
+
+  # -- helpers ----------------------------------------------------------------
+
+  defp other_blockhash, do: Base58.encode(:binary.copy(<<9>>, 32))
+
+  defp instructions_without_memo do
+    {:ok, source_ata} = Solana.associated_token_address(@client, @usdc)
+    {:ok, dest_ata} = Solana.associated_token_address(@pay_to, @usdc)
+
+    [
+      Transaction.set_compute_unit_limit(20_000),
+      Transaction.set_compute_unit_price(1),
+      Transaction.transfer_checked(%{
+        source: source_ata,
+        mint: @usdc,
+        destination: dest_ata,
+        authority: @client,
+        amount: 1000,
+        decimals: 6,
+        token_program: Solana.token_program()
+      })
+    ]
+  end
+
+  defp wire_payload(compiled) do
+    wire = Transaction.serialize(compiled, %{})
+
+    %{
+      "x402Version" => 2,
+      "accepted" => requirements(),
+      "payload" => %{"transaction" => Base.encode64(wire)}
+    }
+  end
+end

--- a/test/x402/scheme/registry_test.exs
+++ b/test/x402/scheme/registry_test.exs
@@ -50,8 +50,12 @@ defmodule X402.Scheme.RegistryTest do
   end
 
   describe "builtins/0" do
-    test "seeds exact and upto on EVM" do
-      assert Registry.builtins() == [X402.Scheme.ExactEVM, X402.Scheme.UptoEVM]
+    test "seeds exact on EVM and SVM plus upto on EVM" do
+      assert Registry.builtins() == [
+               X402.Scheme.ExactEVM,
+               X402.Scheme.ExactSVM,
+               X402.Scheme.UptoEVM
+             ]
     end
   end
 
@@ -62,10 +66,17 @@ defmodule X402.Scheme.RegistryTest do
       assert Registry.resolve("upto", "eip155:8453") == {:ok, X402.Scheme.UptoEVM}
     end
 
+    test "resolves exact on any solana network" do
+      assert Registry.resolve("exact", "solana:mainnet") == {:ok, X402.Scheme.ExactSVM}
+
+      assert Registry.resolve("exact", "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1") ==
+               {:ok, X402.Scheme.ExactSVM}
+    end
+
     test "does not resolve unregistered kinds" do
-      assert Registry.resolve("exact", "solana:mainnet") == :error
       assert Registry.resolve("cash", "eip155:1") == :error
       assert Registry.resolve("upto", "solana:mainnet") == :error
+      assert Registry.resolve("exact", "bip122:000000000019d6689c085ae165831e93") == :error
     end
 
     test "does not resolve non-binary scheme or network" do

--- a/test/x402/signer/solana_key_test.exs
+++ b/test/x402/signer/solana_key_test.exs
@@ -29,6 +29,19 @@ defmodule X402.Signer.SolanaKeyTest do
                {:error, :invalid_private_key}
     end
 
+    test "Base58 keys whose text is also valid Base64 decode as Base58" do
+      # 44- and 88-character Base58 strings are valid Base64 lengths too; a
+      # Base64-first decode yields 33/66 garbage bytes and rejects real
+      # Phantom / solana-keygen imports (review finding).
+      base58_seed = Base58.encode(@seed)
+      assert rem(byte_size(base58_seed), 4) == 0 or byte_size(base58_seed) in [43, 44]
+      assert {:ok, %{address: @address}} = SolanaKey.new(base58_seed)
+
+      {public, _} = :crypto.generate_key(:eddsa, :ed25519, @seed)
+      base58_keypair = Base58.encode(@seed <> public)
+      assert {:ok, %{address: @address}} = SolanaKey.new(base58_keypair)
+    end
+
     test "accepts Base58 and Base64 encodings" do
       {public, _private} = :crypto.generate_key(:eddsa, :ed25519, @seed)
 

--- a/test/x402/signer/solana_key_test.exs
+++ b/test/x402/signer/solana_key_test.exs
@@ -1,0 +1,91 @@
+defmodule X402.Signer.SolanaKeyTest do
+  use ExUnit.Case, async: true
+
+  doctest X402.Signer.SolanaKey
+
+  alias X402.Base58
+  alias X402.Signer
+  alias X402.Signer.SolanaKey
+
+  # Seed 0x01*32 derives this address in @solana/kit 8.0.0 too.
+  @seed :binary.copy(<<1>>, 32)
+  @address "AKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9"
+
+  describe "new/1" do
+    test "accepts a raw 32-byte seed" do
+      assert {:ok, signer} = SolanaKey.new(@seed)
+      assert signer.address == @address
+    end
+
+    test "accepts a 64-byte solana-keygen keypair" do
+      {public, _private} = :crypto.generate_key(:eddsa, :ed25519, @seed)
+
+      assert {:ok, signer} = SolanaKey.new(@seed <> public)
+      assert signer.address == @address
+    end
+
+    test "rejects a keypair whose public half does not match" do
+      assert SolanaKey.new(@seed <> :binary.copy(<<9>>, 32)) ==
+               {:error, :invalid_private_key}
+    end
+
+    test "accepts Base58 and Base64 encodings" do
+      {public, _private} = :crypto.generate_key(:eddsa, :ed25519, @seed)
+
+      assert {:ok, %{address: @address}} = SolanaKey.new(Base58.encode(@seed))
+      assert {:ok, %{address: @address}} = SolanaKey.new(Base.encode64(@seed))
+      assert {:ok, %{address: @address}} = SolanaKey.new(Base58.encode(@seed <> public))
+    end
+
+    test "rejects malformed keys" do
+      assert SolanaKey.new("way too short") == {:error, :invalid_private_key}
+      assert SolanaKey.new(:binary.copy(<<1>>, 31)) == {:error, :invalid_private_key}
+      assert SolanaKey.new(nil) == {:error, :invalid_private_key}
+    end
+  end
+
+  describe "sign_ed25519/2" do
+    test "produces a valid deterministic Ed25519 signature" do
+      {:ok, signer} = SolanaKey.new(@seed)
+      {public, _private} = :crypto.generate_key(:eddsa, :ed25519, @seed)
+      message = "solana message bytes"
+
+      assert {:ok, signature} = SolanaKey.sign_ed25519(signer, message)
+      assert byte_size(signature) == 64
+      assert :crypto.verify(:eddsa, :none, message, signature, [public, :ed25519])
+
+      # RFC 8032 signing is deterministic.
+      assert SolanaKey.sign_ed25519(signer, message) == {:ok, signature}
+    end
+
+    test "dispatches through X402.Signer" do
+      {:ok, signer} = SolanaKey.new(@seed)
+
+      assert {:ok, signature} = Signer.sign_ed25519(signer, "message")
+      assert byte_size(signature) == 64
+    end
+
+    test "EVM signing reports unsupported_signer" do
+      {:ok, signer} = SolanaKey.new(@seed)
+
+      assert Signer.sign_eip712(signer, <<0::256>>, %{}) == {:error, :unsupported_signer}
+    end
+  end
+
+  describe "address/1" do
+    test "returns the derived Base58 address" do
+      {:ok, signer} = SolanaKey.new(@seed)
+      assert SolanaKey.address(signer) == {:ok, @address}
+      assert Signer.address(signer) == {:ok, @address}
+    end
+  end
+
+  test "inspect redacts the private key" do
+    {:ok, signer} = SolanaKey.new(@seed)
+    rendered = inspect(signer)
+
+    assert rendered =~ @address
+    refute rendered =~ "seed"
+    refute rendered =~ Base.encode16(@seed, case: :lower)
+  end
+end

--- a/test/x402/solana/transaction_test.exs
+++ b/test/x402/solana/transaction_test.exs
@@ -1,0 +1,178 @@
+defmodule X402.Solana.TransactionTest do
+  use ExUnit.Case, async: true
+
+  doctest X402.Solana.Transaction
+
+  alias X402.Solana
+  alias X402.Solana.Transaction
+
+  # Fixed keys shared with the reference fixture (seeds 0x01/0x02/0x03,
+  # addresses derived with @solana/kit 8.0.0).
+  @client "AKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9"
+  @fee_payer "9hSR6S7WPtxmTojgo6GG3k4yDPecgJY292j7xrsUGWBu"
+  @usdc "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+  @source_ata "3wvJdyFnGvaMWpbq93NU91SggiVRveULUXL6iX5VZDGP"
+  @dest_ata "DNDTCnZkNk358qDFZd9unHtnrc73SsXcpVWtwJJMrR4B"
+  @blockhash "EZ3rST5dvHmbanh75jc4PuLfV96vp9fEYBVeNk4FfM1k"
+
+  defp reference_instructions do
+    [
+      Transaction.set_compute_unit_limit(20_000),
+      Transaction.set_compute_unit_price(1),
+      Transaction.transfer_checked(%{
+        source: @source_ata,
+        mint: @usdc,
+        destination: @dest_ata,
+        authority: @client,
+        amount: 1000,
+        decimals: 6,
+        token_program: Solana.token_program()
+      }),
+      Transaction.memo("pi_3abc123def456")
+    ]
+  end
+
+  defp compiled do
+    {:ok, compiled} = Transaction.compile(@fee_payer, reference_instructions(), @blockhash)
+    compiled
+  end
+
+  describe "encode_compact_u16/1 and decode_compact_u16/1" do
+    test "round-trips the u16 range boundaries" do
+      for value <- [0, 1, 127, 128, 255, 256, 16_383, 16_384, 65_535] do
+        encoded = Transaction.encode_compact_u16(value)
+        assert Transaction.decode_compact_u16(encoded <> "tail") == {:ok, value, "tail"}
+      end
+    end
+
+    test "rejects truncated and oversized encodings" do
+      assert Transaction.decode_compact_u16(<<0x80>>) == :error
+      assert Transaction.decode_compact_u16(<<0x80, 0x80, 0x80, 0x01>>) == :error
+      # 0x04 in the third group is 65_536 — beyond u16.
+      assert Transaction.decode_compact_u16(<<0x80, 0x80, 0x04>>) == :error
+    end
+  end
+
+  describe "compile/3" do
+    test "orders static accounts like @solana/kit and builds the v0 header" do
+      %{bytes: bytes, signers: signers} = compiled()
+
+      # Fee payer first, then the read-only signer (transfer authority).
+      assert signers == [@fee_payer, @client]
+
+      assert {:ok, decoded} = Transaction.decode(Transaction.serialize(compiled(), %{}))
+      assert decoded.version == 0
+      assert decoded.num_required_signatures == 2
+      assert decoded.num_readonly_signed == 1
+      assert decoded.num_readonly_unsigned == 4
+
+      expected_accounts = [
+        @fee_payer,
+        @client,
+        @source_ata,
+        @dest_ata,
+        Solana.compute_budget_program(),
+        @usdc,
+        Solana.memo_program(),
+        Solana.token_program()
+      ]
+
+      decoded_accounts =
+        Enum.map(decoded.static_accounts, fn pubkey -> X402.Base58.encode(pubkey) end)
+
+      assert decoded_accounts == expected_accounts
+
+      # Message bytes start with the v0 version prefix.
+      assert <<0x80, _rest::binary>> = bytes
+    end
+
+    test "rejects invalid addresses" do
+      assert Transaction.compile("bogus", reference_instructions(), @blockhash) ==
+               {:error, :invalid_address}
+
+      assert Transaction.compile(@fee_payer, reference_instructions(), "bogus") ==
+               {:error, :invalid_address}
+    end
+  end
+
+  describe "serialize/2 and decode/1 round-trip" do
+    test "re-asserts every field of the decoded transaction" do
+      seed = :binary.copy(<<1>>, 32)
+      {public, _private} = :crypto.generate_key(:eddsa, :ed25519, seed)
+      signature = :crypto.sign(:eddsa, :none, compiled().bytes, [seed, :ed25519])
+
+      wire = Transaction.serialize(compiled(), %{@client => signature})
+      assert {:ok, decoded} = Transaction.decode(wire)
+
+      # Signature slots: fee payer placeholder, then the client signature.
+      assert decoded.signatures == [<<0::512>>, signature]
+
+      # The signature covers the message bytes, version prefix included.
+      assert decoded.message_bytes == compiled().bytes
+
+      assert :crypto.verify(
+               :eddsa,
+               :none,
+               decoded.message_bytes,
+               Enum.at(decoded.signatures, 1),
+               [public, :ed25519]
+             )
+
+      {:ok, blockhash} = Solana.decode_address(@blockhash)
+      assert decoded.recent_blockhash == blockhash
+      assert decoded.address_table_lookups == 0
+
+      assert [limit_ix, price_ix, transfer_ix, memo_ix] = decoded.instructions
+
+      # Account indices refer to the ordered account list above.
+      assert %{program_index: 4, account_indices: [], data: <<2, 20_000::32-little>>} = limit_ix
+      assert %{program_index: 4, account_indices: [], data: <<3, 1::64-little>>} = price_ix
+
+      assert %{
+               program_index: 7,
+               account_indices: [2, 5, 3, 1],
+               data: <<12, 1000::64-little, 6>>
+             } = transfer_ix
+
+      assert %{program_index: 6, account_indices: [], data: "pi_3abc123def456"} = memo_ix
+    end
+
+    test "decodes legacy (unversioned) messages" do
+      # A legacy wire is the v0 wire without the version prefix and without
+      # the trailing address-table-lookup section.
+      %{bytes: <<0x80, body::binary>>} = compiled()
+      body_size = byte_size(body) - 1
+      <<legacy_message::binary-size(body_size), 0>> = body
+
+      wire = <<2>> <> <<0::512>> <> <<0::512>> <> legacy_message
+
+      assert {:ok, decoded} = Transaction.decode(wire)
+      assert decoded.version == :legacy
+      assert decoded.address_table_lookups == 0
+      assert length(decoded.instructions) == 4
+    end
+
+    test "rejects malformed wires" do
+      wire = Transaction.serialize(compiled(), %{})
+
+      assert Transaction.decode("") == {:error, :invalid_transaction}
+      assert Transaction.decode(<<2, 0, 0>>) == {:error, :invalid_transaction}
+      # Trailing garbage after the message.
+      assert Transaction.decode(wire <> <<0>>) == {:error, :invalid_transaction}
+      # Truncated signature section.
+      assert Transaction.decode(binary_part(wire, 0, 40)) == {:error, :invalid_transaction}
+      # Unsupported message version (v1).
+      <<count, sigs::binary-size(128), 0x80, rest::binary>> = wire
+
+      assert Transaction.decode(<<count, sigs::binary, 0x81, rest::binary>>) ==
+               {:error, :invalid_transaction}
+    end
+
+    test "rejects signature count differing from the header" do
+      %{bytes: bytes} = compiled()
+      # One signature slot, but the header requires two.
+      wire = <<1>> <> <<0::512>> <> bytes
+      assert Transaction.decode(wire) == {:error, :invalid_transaction}
+    end
+  end
+end

--- a/test/x402/solana/transaction_test.exs
+++ b/test/x402/solana/transaction_test.exs
@@ -174,5 +174,23 @@ defmodule X402.Solana.TransactionTest do
       wire = <<1>> <> <<0::512>> <> bytes
       assert Transaction.decode(wire) == {:error, :invalid_transaction}
     end
+
+    test "treats signatures that are not 64 bytes as missing" do
+      wire = Transaction.serialize(compiled(), %{@client => "way too short"})
+      assert {:ok, decoded} = Transaction.decode(wire)
+      assert decoded.signatures == [<<0::512>>, <<0::512>>]
+    end
+
+    test "rejects non-binary input and truncated lookup sections" do
+      assert Transaction.decode(nil) == {:error, :invalid_transaction}
+
+      %{bytes: bytes} = compiled()
+      body_size = byte_size(bytes) - 1
+      <<body::binary-size(body_size), 0>> = bytes
+
+      # ALT count says 1 but only a single byte of the table follows.
+      truncated = <<2>> <> <<0::512>> <> <<0::512>> <> body <> <<1, 7>>
+      assert Transaction.decode(truncated) == {:error, :invalid_transaction}
+    end
   end
 end

--- a/test/x402/solana_test.exs
+++ b/test/x402/solana_test.exs
@@ -1,0 +1,114 @@
+defmodule X402.SolanaTest do
+  use ExUnit.Case, async: true
+
+  doctest X402.Solana
+
+  alias X402.Base58
+  alias X402.Solana
+
+  # Vectors generated with @solana/kit 8.0.0 (`findAssociatedTokenPda` /
+  # `getProgramDerivedAddress` / `createKeyPairSignerFromPrivateKeyBytes`)
+  # against fixed Ed25519 seeds: 0x01*32 (client), 0x02*32 (fee payer),
+  # 0x03*32 (payTo). See the exact SVM scheme fixture in
+  # test/x402/scheme/exact_svm_test.exs for the same provenance.
+  @client "AKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9"
+  @pay_to "GyGKxMyg1p9SsHfm15MkNUu1u9TN2JtTspcdmrtGUdse"
+  @usdc "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+  @pyusd "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo"
+  @source_ata "3wvJdyFnGvaMWpbq93NU91SggiVRveULUXL6iX5VZDGP"
+  @dest_ata "DNDTCnZkNk358qDFZd9unHtnrc73SsXcpVWtwJJMrR4B"
+  @dest_2022_ata "5AJ5PmLBPTY9JkKPSkSdNrghd1iqoWh1U55g3ByVG41y"
+
+  describe "decode_address/1 and valid_address?/1" do
+    test "decodes valid 32-byte addresses" do
+      assert {:ok, pubkey} = Solana.decode_address(@usdc)
+      assert byte_size(pubkey) == 32
+    end
+
+    test "rejects addresses that decode to other sizes" do
+      # 31 bytes of data encodes to a shorter string.
+      short = Base58.encode(:binary.copy(<<7>>, 31))
+      assert Solana.decode_address(short) == {:error, :invalid_address}
+      refute Solana.valid_address?(short)
+    end
+
+    test "rejects invalid base58" do
+      refute Solana.valid_address?("not base58 0OIl")
+      refute Solana.valid_address?(nil)
+      refute Solana.valid_address?(42)
+    end
+  end
+
+  describe "on_curve?/1" do
+    test "Ed25519 public keys are on the curve" do
+      for seed_byte <- 1..10 do
+        {public, _private} =
+          :crypto.generate_key(:eddsa, :ed25519, :binary.copy(<<seed_byte>>, 32))
+
+        assert Solana.on_curve?(public)
+      end
+    end
+
+    test "derived program addresses are off the curve" do
+      for address <- [@source_ata, @dest_ata, @dest_2022_ata] do
+        {:ok, pubkey} = Solana.decode_address(address)
+        refute Solana.on_curve?(pubkey)
+      end
+    end
+  end
+
+  describe "find_program_address/2" do
+    test "matches @solana/kit getProgramDerivedAddress vectors" do
+      {:ok, owner} = Solana.decode_address(@pay_to)
+      {:ok, token_program} = Solana.decode_address(Solana.token_program())
+      {:ok, mint} = Solana.decode_address(@usdc)
+
+      assert {:ok, {address, 255}} =
+               Solana.find_program_address(
+                 [owner, token_program, mint],
+                 Solana.ata_program()
+               )
+
+      assert Base58.encode(address) == @dest_ata
+    end
+
+    test "rejects invalid seeds" do
+      too_long = :binary.copy(<<1>>, 33)
+
+      assert Solana.find_program_address([too_long], Solana.ata_program()) ==
+               {:error, :invalid_seeds}
+
+      too_many = List.duplicate("seed", 17)
+
+      assert Solana.find_program_address(too_many, Solana.ata_program()) ==
+               {:error, :invalid_seeds}
+    end
+
+    test "rejects an invalid program id" do
+      assert Solana.find_program_address(["seed"], "bogus") == {:error, :invalid_address}
+    end
+  end
+
+  describe "associated_token_address/3" do
+    test "derives the SPL Token ATAs from the reference fixture" do
+      assert Solana.associated_token_address(@client, @usdc, Solana.token_program()) ==
+               {:ok, @source_ata}
+
+      assert Solana.associated_token_address(@pay_to, @usdc, Solana.token_program()) ==
+               {:ok, @dest_ata}
+    end
+
+    test "derives Token-2022 ATAs from the reference fixture" do
+      assert Solana.associated_token_address(@pay_to, @pyusd, Solana.token_2022_program()) ==
+               {:ok, @dest_2022_ata}
+    end
+
+    test "rejects invalid inputs" do
+      assert Solana.associated_token_address("nope", @usdc, Solana.token_program()) ==
+               {:error, :invalid_address}
+
+      assert Solana.associated_token_address(@client, "nope", Solana.token_program()) ==
+               {:error, :invalid_address}
+    end
+  end
+end


### PR DESCRIPTION
## What

The Solana `exact` scheme, client-first ([docs/ecosystem-comparison.md](https://github.com/cardotrejos/x402/blob/main/docs/ecosystem-comparison.md) §8 P2.3 — the ecosystem's second-largest network). One scheme module thanks to the #70 seam.

- **Pure Solana primitives, zero new deps**: `X402.Base58` (Bitcoin Core vectors), PDA/ATA derivation over `:crypto` SHA-256 (verified against `@solana/kit` codecs), compact-u16, v0 message serialization.
- **Ed25519 signing**: `X402.Signer` gained an optional `sign_ed25519/2` callback (both chain-family callbacks now optional — fully backward compatible); `X402.Signer.SolanaKey` on OTP `:crypto` eddsa (seed / solana-keygen keypair / Base58/Base64 input, redacted inspect).
- **`X402.Scheme.ExactSVM`** on `solana:*`: `sign/3` builds the reference client's exact transaction — v0 message, `[ComputeUnitLimit, ComputeUnitPrice, TransferChecked(ATA(payTo, asset)), Memo]`, fee payer from `extra.feePayer` (required) with a zero signature slot per the partial-signing flow, `@solana/kit`-identical account ordering; blockhash via `extra.recentBlockhash` or a caller opt/fetcher (module stays RPC-free). Server side: structural `validate_payload` (base64, 1232-byte packet cap, v0/legacy decode) and `precheck` implementing the spec §3.1 static-path instruction whitelist incl. §2.1.1 fee-payer isolation; ALT transactions skip prechecks (§2.1.2 needs RPC). On-chain verify/settle stays facilitator-delegated (documented).

## Vector provenance

Fixtures were generated with the official stack (`@solana/kit` 8.0.0 + `@solana-program/*`) running the reference client's pipeline with fixed seeds and blockhash; the flagship test asserts our `sign/3` output is **byte-identical** to that transaction, plus field-by-field decode re-assertion and `:crypto.verify` of the embedded signature.

## Testing

Suite on current main: 254 doctests + 947 tests, 0 failures; new modules 91–100% coverage. E2E: the gate's multi-accept flow drives 402 → SVM entry selection → build_payment → validate+precheck → Bypass facilitator. All gates green incl. dialyzer and --no-optional-deps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new payment surface (transaction construction and precheck rules) affects payment acceptance; signer callback optionality is backward compatible but misconfigured signers now fail at sign time rather than compile time.
> 
> **Overview**
> Adds **built-in `exact` payments on `solana:*`** so `X402.Client.build_payment/3` can produce partially signed v0 Solana transactions (compute budget, `TransferChecked` to the payee ATA, memo) and resource servers can validate them locally before the facilitator.
> 
> **`X402.Scheme.ExactSVM`** registers with the scheme registry, requires `extra.feePayer`, resolves blockhash from server hint or new client options (`:svm_blockhash`, `:svm_blockhash_fetcher`), and implements `validate_payload/3` plus RPC-free `precheck/3` (static-path whitelist; ALT txs skip precheck). Supporting modules **`X402.Base58`**, **`X402.Solana`**, and **`X402.Solana.Transaction`** implement encoding, PDA/ATA, and wire compile/decode without new dependencies.
> 
> **Signing:** optional **`sign_ed25519/2`** on `X402.Signer` (EVM `sign_eip712/3` also optional; missing family → `{:error, :unsupported_signer}`), plus **`X402.Signer.SolanaKey`** for in-memory Ed25519 keys. Client guide and changelog document Solana usage; tests include byte-identical reference fixtures and a PaymentGate multi-accept E2E path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad9bf49a5e57102d724b0f88def1dd3ef02279ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->