### PR TITLE
fix: restore alphabetical alias order in PaymentGate (unbreak main CI)

### DIFF
--- a/lib/x402/plug/payment_gate.ex
+++ b/lib/x402/plug/payment_gate.ex
@@ -106,10 +106,10 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(Plug.Conn) do
 
     @behaviour Plug
 
+    alias X402.EIP712
     alias X402.Extensions.PaymentIdentifier
     alias X402.Extensions.PaymentIdentifier.Cache
     alias X402.Extensions.PaymentIdentifier.ETSCache
-    alias X402.EIP712
     alias X402.Facilitator
     alias X402.Facilitator.Error
     alias X402.Hooks


### PR DESCRIPTION
Main's CI fails at `mix credo --strict` since #78 merged: the upto replay-key hardening commit (`16d8c09`, pushed via `@cursor push`) inserted `alias X402.EIP712` below the `X402.Extensions.PaymentIdentifier*` aliases, violating credo's alphabetical-alias check. The equivalent one-line fix was pushed to the PR branch in the same minute the PR merged and lost the race.

One line: move `alias X402.EIP712` to its alphabetical position. `mix credo --strict` clean, full suite green (1,725 passed), compile `--warnings-as-errors` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic alias reordering only; no logic, API, or security behavior changes.
> 
> **Overview**
> Restores **CI compliance** by reordering module aliases in `X402.Plug.PaymentGate`: `alias X402.EIP712` is moved from below the `X402.Extensions.PaymentIdentifier*` aliases to immediately after `@behaviour Plug`, so the list satisfies Credo's alphabetical-alias rule (`mix credo --strict`).
> 
> No runtime or payment-gate behavior changes—only import ordering in `payment_gate.ex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ac154f28f62379730f061dd4271f15786e90219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->