### PR TITLE
docs: bring guides, README, and ExDoc up to date with the gap-closure wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,7 +224,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     typed-transaction encoders (no new dependencies), tested against the
     published RLP specification vectors and a signed-transaction
     sender-recovery proof.
-  - `X402.EIP3009.transfer_calldata/2` — the `transferWithAuthorization`
+  - `X402.EIP3009.transfer_calldata/3` — the `transferWithAuthorization`
     calldata builder (both the `(v, r, s)` and dynamic-`bytes` variants),
     extracted from `X402.Verify.EVM` so verification's simulation and the
     engine's settlement sign the exact same bytes; plus

--- a/README.md
+++ b/README.md
@@ -14,16 +14,17 @@ facilitator, chain, or web framework.
 
 ## Features
 
-- x402 v2 `PAYMENT-REQUIRED`, `PAYMENT-SIGNATURE`, and `PAYMENT-RESPONSE` headers
-- Complete v2 payment-requirement and extension-echo validation
-- Payer client with EIP-3009 signing and an automatic `402 → sign → retry` Finch flow
+- x402 v2 `PAYMENT-REQUIRED`, `PAYMENT-SIGNATURE`, and `PAYMENT-RESPONSE` headers with complete requirement and extension-echo validation
+- Payer client signing `"exact"` (EIP-3009), metered `"upto"` (Permit2), and Solana `"exact"` payments, with an automatic `402 → sign → retry` Finch flow
+- Plug/Phoenix payment gate with signature-bound replay protection, optional inline local verification, and settlement only after successful resource handling
+- Local payment verification without trusting a facilitator: EVM (EIP-712 + ERC-1271/6492, balance and simulation checks) and Solana (Ed25519, fee-payer isolation, instruction whitelist)
 - Facilitator `/verify` and `/settle` client with retries, hooks, and telemetry
-- Local payment verification (EIP-712 + ERC-1271/6492, balance and simulation checks) without trusting a facilitator
-- Plug/Phoenix payment gate that settles only after successful resource handling
-- `"exact"` and metered `"upto"` authorization flows
-- Optional payment-identifier idempotency cache and SIWX support
-- EVM and Solana wallet validation
-- Optional Finch, Plug, and cryptography dependencies
+- A runnable facilitator server for EVM and Solana from one Plug — ERC-6492 counterfactual settlement, ERC-20 Transfer-event proof of delivery, pending-settlement reconciliation
+- Paid MCP tools over the x402 MCP transport, server and client side
+- Browser paywall: a self-contained HTML 402 page with an EIP-1193 wallet flow
+- Pluggable payment schemes through the `X402.Scheme` behaviour
+- Extensions: payment-identifier idempotency (ETS or Redis), SIWX, signed offers and receipts, gas sponsoring, Bazaar discovery
+- Optional Finch, Plug, Redix, and cryptography dependencies
 
 ## Installation
 
@@ -89,6 +90,26 @@ with status 400 or greater are not settled.
 The verified payload and matched requirement are available to the handler as
 `conn.assigns.x402_payment_payload` and
 `conn.assigns.x402_payment_requirements`.
+
+## Run your own facilitator
+
+The SDK also implements the facilitator role itself — verify and settle
+payments on-chain instead of delegating to a hosted service:
+
+```elixir
+{:ok, engine} =
+  X402.Facilitator.Engine.new(rpc: rpc, signer: signer, networks: ["eip155:84532"])
+
+children = [
+  {Bandit, plug: {X402.Plug.Facilitator, engine: engine}, port: 4022}
+]
+```
+
+That serves `POST /verify`, `POST /settle`, and `GET /supported` over the
+standard facilitator wire protocol. Pass `engines: [evm_engine, svm_engine]`
+instead of `engine:` to serve EVM and Solana (`X402.Facilitator.SVMEngine`)
+from the same endpoint. See the
+[Run Your Own Facilitator](https://hexdocs.pm/x402/facilitator.html) guide.
 
 ## Metered `"upto"` payments
 
@@ -235,8 +256,13 @@ Facilitator requests use the v2 wire object:
 ## Documentation
 
 - [Getting Started](https://hexdocs.pm/x402/getting-started.html)
+- [Paying for Resources](https://hexdocs.pm/x402/client.html)
 - [Plug/Phoenix Integration](https://hexdocs.pm/x402/plug-integration.html)
+- [Custom Payment Schemes](https://hexdocs.pm/x402/custom-schemes.html)
+- [Paid MCP Tools](https://hexdocs.pm/x402/mcp.html)
+- [Browser Paywall](https://hexdocs.pm/x402/paywall.html)
 - [Local Payment Verification](https://hexdocs.pm/x402/local-verification.html)
+- [Run Your Own Facilitator](https://hexdocs.pm/x402/facilitator.html)
 - [Live Smoke Tests](https://hexdocs.pm/x402/live-smoke-tests.html)
 - [API Reference](https://hexdocs.pm/x402/api-reference.html)
 - [Official x402 v2 specification](https://github.com/x402-foundation/x402/blob/main/specs/x402-specification-v2.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture — x402 Elixir SDK
 
-> Last updated: 2026-08-15
+> Last updated: 2026-08-28
 
 ## Overview
 
@@ -9,7 +9,7 @@ A pure Elixir library implementing the x402 HTTP payment protocol. Ships as a He
 ## Design Philosophy
 
 - **Zero lock-in**: works with any facilitator, chain, or framework
-- **Minimal deps**: only `jason` and `nimble_options` are required
+- **Minimal deps**: only `jason`, `nimble_options`, and `telemetry` are required
 - **Behaviours over config**: extensibility via `@callback`, not application environment
 - **Flat modules**: short, discoverable names (`X402.Wallet`, not `X402.Utils.Validators.Wallet`)
 
@@ -23,16 +23,45 @@ X402                         # Top-level convenience API (delegates to submodule
 ├── PaymentRequirements      # Validate and match v2 accepted requirements
 ├── PaymentSignature         # Decode and validate PAYMENT-SIGNATURE header
 ├── PaymentResponse          # Encode PAYMENT-RESPONSE header
+├── Client                   # Payer: select, sign, 402 → sign → retry
+│   └── Finch                # HTTP payer flow over Finch (optional)
+├── Signer                   # Behaviour — LocalKey (secp256k1), SolanaKey (Ed25519)
+├── Scheme                   # Behaviour + Registry — ExactEVM, UptoEVM, ExactSVM
+├── EIP3009 / EIP712 / Permit2  # EVM authorization building and typed-data signing
 ├── Facilitator              # GenServer — HTTP client for /verify + /settle
-│   └── HTTP                 # Transport implementation (uses Finch, optional)
+│   ├── HTTP                 # Transport implementation (uses Finch, optional)
+│   ├── Engine               # Facilitator role, EVM — verify/settle/supported,
+│   │                        #   ERC-6492 counterfactual deploy-then-settle,
+│   │                        #   Transfer-event receipt verification
+│   ├── SVMEngine            # Facilitator role, Solana — co-sign fee payer,
+│   │                        #   broadcast, confirm, duplicate-settlement dedup
+│   ├── NonceManager         # Serialized fee-payer nonces for concurrent settles
+│   └── PendingSettlementStore  # Behaviour + ETS adapter — settlement_pending
+│                            #   reconciliation (delete-before-reconcile)
+├── Verify
+│   ├── EVM                  # Local verify checklist (EIP-712, ERC-1271/6492,
+│   │                        #   balance, simulation) at explicit levels
+│   └── SVM                  # Local verify checklist (Ed25519 signatures,
+│                            #   fee-payer isolation, instruction whitelist)
+├── RPC                      # Minimal JSON-RPC transport (EVM and Solana hosts)
+├── RLP / Transaction        # EIP-1559 typed-transaction encoding for settlement
+├── Solana                   # Address, PDA, and ATA primitives (+ Base58)
+│   ├── RPC                  # Solana JSON-RPC calls over X402.RPC
+│   └── Transaction          # v0 message compile/serialize/decode, co-signing
 ├── Plug
-│   └── PaymentGate          # Drop-in Plug middleware for Phoenix/Plug pipelines
+│   ├── PaymentGate          # Drop-in Plug middleware for Phoenix/Plug pipelines
+│   └── Facilitator          # Facilitator API endpoint — one engine or many
+│                            #   (engines: routed by scheme/network)
+├── MCP                      # Paid MCP tools — Server and Client transports
+├── Paywall                  # Browser 402 page behaviour + Default renderer
 ├── Wallet                   # EVM (secp256k1) + Solana (ed25519) address validation
-├── Hooks                    # Behaviour: before_verify / after_verify / on_failure
+├── Hooks                    # Behaviour: before/after verify and settle
 ├── Telemetry                # Telemetry event definitions and metadata
 └── Extensions
-    ├── PaymentIdentifier    # Idempotency — pluggable cache (ETS default)
-    └── SIWX                 # Sign-In-With-X (wallet-authenticated repeat access)
+    ├── PaymentIdentifier    # Idempotency — pluggable cache (ETS, Redis)
+    ├── SIWX                 # Sign-In-With-X (wallet-authenticated repeat access)
+    ├── OfferReceipt         # Signed offers and receipts (EIP-712 + JWS)
+    └── Bazaar, gas sponsoring extensions
 ```
 
 ## Payment Flow (SDK perspective)
@@ -53,13 +82,17 @@ X402.Plug.PaymentGate
                 ├─ Match complete payload.accepted + extension echoes
                 │     no match → 402 + PAYMENT-REQUIRED
                 │
-                ├─ Facilitator.verify
-                │     invalid payment → 402; server/facilitator fault → 500
+                ├─ Inline local verification (optional :local_verification, exact-EVM)
+                │     rejection → 402; infrastructure failure → 500
+                │
+                ├─ Facilitator.verify + signature-bound replay claim (:claim_order)
+                │     invalid or replayed payment → 402; server/facilitator fault → 500
                 │
                 ├─ Assign payload/requirements → protected handler
                 │     handler status >= 400 → skip settlement
                 │
                 └─ Successful handler → Facilitator.settle before send
+                      settlement_pending → exactly one retried settle
                       success → PAYMENT-RESPONSE + original resource response
                       payment failure → 402; server/facilitator fault → 500
 ```
@@ -68,10 +101,11 @@ X402.Plug.PaymentGate
 
 | Dep | When Required |
 |-----|--------------|
-| `finch` | HTTP calls to facilitator (`X402.Facilitator`) |
-| `plug` | Phoenix/Plug middleware (`X402.Plug.PaymentGate`) |
-| `ex_secp256k1` | SIWX signature verification (EVM) |
-| `ex_keccak` | SIWX keccak hashing |
+| `finch` | HTTP calls to facilitator and RPC endpoints (`X402.Facilitator`, `X402.RPC`) |
+| `plug` | Phoenix/Plug middleware (`X402.Plug.PaymentGate`, `X402.Plug.Facilitator`) |
+| `ex_secp256k1` | EVM signing and signature recovery (client signing, SIWX, facilitator engine) |
+| `ex_keccak` | Keccak hashing (EIP-712, local verification, settlement transactions) |
+| `redix` | Redis payment-identifier cache adapter (`RedisCache`) |
 
 All optional integrations are guarded by dependency-availability checks. The
 package must compile successfully with `mix compile --no-optional-deps`.
@@ -100,21 +134,28 @@ validation may raise only in APIs whose contract explicitly uses
 ## Telemetry Events
 
 ```
-[:x402, :facilitator, :verify, :start]
-[:x402, :facilitator, :verify, :stop]
-[:x402, :facilitator, :verify, :exception]
-[:x402, :facilitator, :settle, :start]
-[:x402, :facilitator, :settle, :stop]
-[:x402, :facilitator, :settle, :exception]
-[:x402, :plug, :payment_required]
-[:x402, :plug, :payment_verified]
-[:x402, :plug, :payment_rejected]
+[:x402, :facilitator, :verify | :settle, :start | :stop | :exception]
+[:x402, :facilitator_engine, :verify | :settle]
+[:x402, :plug, :payment_required | :payment_verified | :payment_rejected]
+[:x402, :client, :select | :sign | :build | :request]
+[:x402, :verify, :evm | :svm]
+[:x402, :rpc, :request]
+[:x402, :payment_required | :payment_signature | :payment_response, ...]
 ```
 
-## v0.4 payment lifecycle
+The full event list lives in `X402.Telemetry`.
+
+## Payment lifecycle
 
 - The Plug validates a v2 payload and verifies payment before invoking the handler.
-- Settlement is deferred until a successful handler response is ready to send.
+- Replay claims use a signature-covered key per scheme family (EIP-3009
+  `from` + nonce, Permit2 owner + canonicalized nonce, SVM message hash;
+  raw-header hash for unknown schemes). The `paymentId` extension is decoded
+  and surfaced but is deliberately **not** the dedup key — it is
+  client-chosen and not covered by the payment signature.
+- Settlement is deferred until a successful handler response is ready to
+  send; a `settlement_pending` settle is retried exactly once, and engines
+  reconcile the retry against the already-broadcast transaction.
 - `"upto"` routes may replace the advertised maximum with the actual metered
   settlement amount through `put_settlement_amount/2`.
 - Missing facilitator decision fields fail closed, and internal/facilitator

--- a/guides/client.md
+++ b/guides/client.md
@@ -18,7 +18,8 @@ letting the SDK handle the `402 → sign → retry` dance.
    settlement receipt.
 
 The SDK signs the `exact` scheme (EIP-3009) and the `upto` scheme
-(Permit2) on EVM (`eip155:*`) networks.
+(Permit2) on EVM (`eip155:*`) networks, and the `exact` scheme on Solana
+(`solana:*`) networks (see below).
 
 ## Quick start with Finch
 
@@ -143,7 +144,7 @@ facilitator can settle it. Two things to know:
 
 The signed maximum is not what you pay — the server meters actual usage
 and settles for less (or nothing). See the
-[Plug Integration](plug-integration.md) guide for the server half.
+[Plug/Phoenix Integration](plug-integration.html) guide for the server half.
 
 ## Gas-sponsoring extensions
 
@@ -209,7 +210,9 @@ the payer's Ed25519 key, and leaves the fee payer's signature slot empty.
 The server's sponsor (`extra.feePayer`, **required** in the advertised
 requirements) verifies and co-signs at settlement, so the payer never pays
 network fees. On-chain verification and settlement stay with the
-facilitator; the SDK never talks to a Solana RPC node.
+facilitator; the signing path never talks to a Solana RPC node. The SDK
+can also be that facilitator — see
+[Run Your Own Facilitator](facilitator.html).
 
 ```elixir
 {:ok, signer} = X402.Signer.SolanaKey.new(System.fetch_env!("SOLANA_PAYER_KEY"))
@@ -220,8 +223,8 @@ facilitator; the SDK never talks to a Solana RPC node.
     # Only needed when the server's 402 does not include an
     # extra.recentBlockhash hint: bring a blockhash yourself...
     svm_blockhash: recent_blockhash
-    # ...or let the client fetch one through your RPC layer:
-    # svm_blockhash_fetcher: fn _network -> MyApp.RPC.latest_blockhash() end
+    # ...or let the client fetch one on demand — see :svm_blockhash_fetcher
+    # below.
   )
 ```
 
@@ -233,12 +236,31 @@ Two option pairs matter for less common setups:
 
 * **Blockhash** — servers should advertise `extra.recentBlockhash` in
   their requirements (it saves the client an RPC round-trip); when they
-  do, no option is needed. Otherwise pass `:svm_blockhash` or
-  `:svm_blockhash_fetcher`.
+  do, no option is needed. Otherwise pass `:svm_blockhash`, or
+  `:svm_blockhash_fetcher` — a 1-arity fun receiving the CAIP-2 network
+  and returning `{:ok, blockhash}`.
 * **Asset metadata** — `TransferChecked` needs the mint's decimals and
   owning token program. Well-known stablecoins (USDC, USDT, USDG, PYUSD,
   CASH on mainnet/devnet/testnet) are built in; for other mints pass
   `:svm_decimals` and `:svm_token_program`.
+
+`X402.Solana.RPC.get_latest_blockhash/2` — Solana JSON-RPC over an
+`X402.RPC` endpoint — makes a ready-made fetcher:
+
+```elixir
+{:ok, rpc} =
+  X402.RPC.new(rpc_url: "https://api.mainnet-beta.solana.com", finch: MyApp.Finch)
+
+{:ok, payload} =
+  X402.Client.build_payment(payment_required, signer,
+    network: "solana:*",
+    svm_blockhash_fetcher: fn _network ->
+      with {:ok, %{blockhash: blockhash}} <- X402.Solana.RPC.get_latest_blockhash(rpc) do
+        {:ok, blockhash}
+      end
+    end
+  )
+```
 
 Custom Solana signers implement the optional
 `X402.Signer.sign_ed25519/2` callback instead of `sign_eip712/3` — see

--- a/guides/custom-schemes.md
+++ b/guides/custom-schemes.md
@@ -7,15 +7,19 @@ scheme means writing **one module** and passing it as an option; no core
 module needs to change.
 
 The built-ins cover `exact` (`X402.Scheme.ExactEVM`) and `upto`
-(`X402.Scheme.UptoEVM`) on EVM (`eip155:*`) networks. Resolution — exact
-CAIP-2 matches beating wildcards, user modules beating built-ins — is
-handled by `X402.Scheme.Registry`.
+(`X402.Scheme.UptoEVM`) on EVM (`eip155:*`) networks, and `exact`
+(`X402.Scheme.ExactSVM`) on Solana (`solana:*`) networks. Resolution —
+exact CAIP-2 matches beating wildcards, user modules beating built-ins —
+is handled by `X402.Scheme.Registry`.
 
 ## Writing a scheme module
 
 Implement `X402.Scheme`. Only `c:X402.Scheme.scheme/0` and
 `c:X402.Scheme.networks/0` are required; implement the callbacks for the
-roles your scheme plays:
+roles your scheme plays. A fourth optional callback,
+`c:X402.Scheme.signable?/1`, lets `X402.Client.select_requirements/2`
+skip advertised entries the module cannot sign (the built-in `upto`
+scheme uses it to skip entries missing `extra.facilitatorAddress`):
 
 ```elixir
 defmodule MyApp.SolanaExact do
@@ -52,6 +56,11 @@ defmodule MyApp.SolanaExact do
 end
 ```
 
+(`exact` on `solana:*` now ships built-in as `X402.Scheme.ExactSVM` — the
+sketch above shows the shape such a module takes. A user module listed in
+`:schemes` is consulted before the built-ins, so registering your own
+overrides it.)
+
 ## Registering it
 
 There is no global registry and no application environment — scheme modules
@@ -85,6 +94,17 @@ Kinds with no registered module keep their historical neutral behavior:
 validation passes through with `:ok`, the gate skips pre-checks (the
 facilitator remains the authority), and the client returns
 `{:error, {:unsupported_kind, scheme, network}}`.
+
+## Replay keys for custom schemes
+
+`X402.Plug.PaymentGate`'s replay protection derives canonical,
+signature-covered replay keys only for the built-in kinds (`exact` and
+`upto` on `eip155:*`, `exact` on `solana:*`). Every other kind — custom
+schemes included — falls back to hashing the raw `PAYMENT-SIGNATURE`
+header, so only byte-identical replays are deduplicated: re-encoding the
+same signed proof (different JSON key order, whitespace, or Base64
+variant) mints a distinct key, and catching such duplicates is left to
+the facilitator.
 
 See the `X402.Scheme` module documentation for the full callback reference
 and error conventions.

--- a/guides/facilitator.md
+++ b/guides/facilitator.md
@@ -2,17 +2,26 @@
 
 Every x402 resource server needs a facilitator to verify and settle
 payments — and until now, running one meant trusting a hosted service or
-writing your own from scratch. `X402.Facilitator.Engine` and
-`X402.Plug.Facilitator` turn this SDK into the facilitator itself: a
-supervised, self-hosted verify/settle service for the `exact`/EVM scheme,
-speaking the same wire protocol as the reference facilitators.
+writing your own from scratch. `X402.Facilitator.Engine` (EVM),
+`X402.Facilitator.SVMEngine` (Solana), and `X402.Plug.Facilitator` turn
+this SDK into the facilitator itself: a supervised, self-hosted
+verify/settle service for the `exact` scheme, speaking the same wire
+protocol as the reference facilitators.
 
-The engine assembles pieces you may already use — `X402.Verify.EVM` for the
-full local verification checklist, `X402.RPC` for chain access,
-`X402.Signer` for the fee-payer key — and adds the settlement pipeline:
-EIP-1559 transaction assembly, signing, broadcast, and receipt tracking.
+The engines assemble pieces you may already use — `X402.Verify.EVM` and
+`X402.Verify.SVM` for the full local verification checklists, `X402.RPC`
+for chain access, `X402.Signer` for the fee-payer key — and add the
+settlement pipeline: transaction assembly, signing, broadcast, receipt
+tracking, and reconciliation of broadcasts whose confirmation could not
+be established.
 
-## Quick start
+## Quick start (EVM)
+
+A production-shaped facilitator supervises three processes next to the
+engine: the HTTP pool, an `X402.Facilitator.NonceManager` (so concurrent
+settlements never race on the fee payer's pending nonce), and an
+`X402.Facilitator.PendingSettlementStore.ETS` (so a `settlement_pending`
+retry reconciles instead of broadcasting twice):
 
 ```elixir
 # In your supervision tree:
@@ -30,13 +39,18 @@ defmodule MyFacilitator.Application do
       X402.Facilitator.Engine.new(
         rpc: rpc,
         signer: signer,
-        networks: ["eip155:84532"]
+        networks: ["eip155:84532"],
+        nonce_manager: MyFacilitator.NonceManager,
+        pending_settlement_store:
+          {X402.Facilitator.PendingSettlementStore.ETS, MyFacilitator.PendingStore}
       )
 
     children = [
       {Finch,
        name: MyFacilitator.Finch,
        pools: %{default: X402.Facilitator.HTTP.secure_pool_opts()}},
+      {X402.Facilitator.NonceManager, name: MyFacilitator.NonceManager},
+      {X402.Facilitator.PendingSettlementStore.ETS, name: MyFacilitator.PendingStore},
       {Bandit, plug: {X402.Plug.Facilitator, engine: engine}, port: 4022}
     ]
 
@@ -60,66 +74,331 @@ transport, skipping HTTP entirely.
 
 A complete runnable project lives in `examples/facilitator/`.
 
+## Serve Solana too
+
+`X402.Facilitator.SVMEngine` is the SVM counterpart: `exact` payments on
+`solana:*` networks, verified with `X402.Verify.SVM` and settled by
+co-signing the fee-payer slot of the client-built transaction. The signer
+must implement the `sign_ed25519/2` callback — `X402.Signer.SolanaKey`
+does (it accepts a raw 32-byte seed, a 64-byte `solana-keygen` keypair,
+or Base58/Base64 encodings of either):
+
+```elixir
+{:ok, sol_rpc} =
+  X402.RPC.new(rpc_url: "https://api.devnet.solana.com", finch: MyFacilitator.Finch)
+
+{:ok, sol_signer} = X402.Signer.SolanaKey.new(System.fetch_env!("SOLANA_FEE_PAYER_KEY"))
+
+{:ok, svm_engine} =
+  X402.Facilitator.SVMEngine.new(
+    rpc: sol_rpc,
+    signer: sol_signer,
+    networks: ["solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"],
+    settlement_cache:
+      {X402.Extensions.PaymentIdentifier.ETSCache, MyFacilitator.SettlementCache},
+    pending_settlement_store:
+      {X402.Facilitator.PendingSettlementStore.ETS, MyFacilitator.PendingStore}
+  )
+```
+
+with the two stores supervised alongside the others:
+
+```elixir
+{X402.Extensions.PaymentIdentifier.ETSCache,
+ name: MyFacilitator.SettlementCache, ttl_ms: 120_000},
+{X402.Facilitator.PendingSettlementStore.ETS, name: MyFacilitator.PendingStore}
+```
+
+Configure **both** stores, as above — the pairing the module documentation
+recommends. The `:settlement_cache` is the atomic duplicate-settlement
+claim: settle computes the transaction's key (SHA-256 of its message
+bytes) and claims it before any RPC work, so a concurrent settle of the
+same payment is rejected with `duplicate_settlement` instead of racing
+the broadcast. The 120-second TTL matches the reference facilitators —
+roughly twice the blockhash lifetime, after which the transaction can no
+longer land anyway. The `:pending_settlement_store` is what makes the
+claim safe under a `settlement_pending` verdict: with a store, the claim
+is kept and the retry reconciles against the recorded signature; with a
+cache but *no* store, the engine must release the claim so the retry can
+re-broadcast the identical wire bytes (collapsed by the network to one
+transaction id) rather than dead-end on `duplicate_settlement`. Without
+either, duplicate protection is disabled entirely.
+
+### One Plug, both chains
+
+`X402.Plug.Facilitator` serves several engines from one endpoint via
+`:engines` (exactly one of `:engine` or `:engines` must be given):
+
+```elixir
+{Bandit, plug: {X402.Plug.Facilitator, engines: [engine, svm_engine]}, port: 4022}
+```
+
+`POST /verify` and `POST /settle` dispatch to the first engine whose
+`supported/1` kinds contain the request's `(scheme, network)` pair; when
+none matches, the request is answered with a `200` protocol rejection
+(`unsupported_scheme`, or `invalid_network` when some engine serves the
+scheme on other networks). `GET /supported` merges the engines'
+responses — kinds concatenated, extensions unioned, signer families
+merged:
+
+```json
+{
+  "kinds": [
+    {"x402Version": 2, "scheme": "exact", "network": "eip155:84532"},
+    {"x402Version": 2, "scheme": "exact",
+     "network": "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+     "extra": {"feePayer": "9hSR..."}}
+  ],
+  "extensions": [],
+  "signers": {"eip155:*": ["0x..."], "solana:*": ["9hSR..."]}
+}
+```
+
+Note the SVM kinds carry `extra.feePayer` — the channel through which
+resource servers discover which fee payer to advertise in their 402
+challenges (SVM clients must build their transaction around the sponsor's
+key, so the gate injects it into the requirements it serves).
+
 ## What verify checks
 
-`verify/3` runs `X402.Verify.EVM` at the `:full` level: scheme, network,
-and EIP-712 domain requirements; recipient and exact-amount equality; the
-validity window; signature verification routed by payer bytecode (EOA
-`ecrecover`, strict ERC-1271 `isValidSignature` for deployed smart
-wallets); asset bytecode presence; `balanceOf` funding; and an `eth_call`
+**EVM** — `Engine.verify/3` runs `X402.Verify.EVM` at the `:full` level:
+scheme, network, and EIP-712 domain requirements; recipient and
+exact-amount equality; the validity window; signature verification routed
+by payer bytecode (EOA `ecrecover`, strict ERC-1271 `isValidSignature`
+for deployed smart wallets, and — only with a configured
+`:eip6492_allowed_factories` allowlist — the atomic Multicall3
+deploy-and-transfer simulation for ERC-6492 counterfactual wallets);
+asset bytecode presence; `balanceOf` funding; and an `eth_call`
 simulation of the transfer with failure diagnosis. Rejections use the
-canonical cross-SDK `invalidReason` strings. See the Local Payment
-Verification guide for the full checklist.
+canonical cross-SDK `invalidReason` strings. See the
+[Local Payment Verification](local-verification.html) guide for the full
+checklist.
+
+**SVM** — `SVMEngine.verify/3` runs `X402.Verify.SVM` at `:full`,
+mirroring the exact-SVM specification's static verification path:
+fee-payer identity (the requirements' `extra.feePayer` must be this
+engine's signer, and account 0 of the transaction must be that fee
+payer); **local Ed25519 verification of every required signer except the
+fee-payer slot** — mandatory, because the simulation runs with
+`sigVerify: false` (the fee-payer slot is unsigned until settlement), so
+local verification *is* the signature check; the static instruction
+whitelist (compute-budget bounds, `TransferChecked` amount/mint/
+destination, memo enforcement, and fee-payer isolation — no instruction
+may reference the sponsor's key, so its signature can never move its
+funds); and a `simulateTransaction` round-trip. Transactions using
+address lookup tables are rejected fail-closed — their account set cannot
+be verified without table resolution. Rejections use the TypeScript
+reference's `invalid_exact_svm_*` reason strings
+(`X402.Verify.SVM.reason_string/1`).
 
 ## The settlement pipeline
 
-`settle/3` never trusts a prior verify — it re-verifies the payment
-independently (the exact-EVM scheme's normative requirement), then:
+Both engines' `settle/3` never trusts a prior verify — they re-verify the
+payment independently (the exact scheme's normative requirement) before
+touching the chain.
+
+**EVM** — after checking the pending store (next section) and
+re-verifying:
 
 1. Builds `transferWithAuthorization` calldata with
-   `X402.EIP3009.transfer_calldata/2` — the same builder verification
-   simulates with, so simulation and settlement cannot diverge.
+   `X402.EIP3009.transfer_calldata/3` — the same builder verification
+   simulates with, so simulation and settlement cannot diverge. For a
+   verified counterfactual payment, the wallet is deployed first (see
+   Fee-payer safety below).
 2. Fetches gas and fee data in one batched RPC round-trip:
    `eth_estimateGas` (a revert here is itself a simulation failure and
    rejects the settlement), `eth_maxPriorityFeePerGas` + `eth_feeHistory`
    for EIP-1559 fees (`eth_gasPrice` fallback for nodes without them), and
-   the `pending` nonce.
+   the `pending` nonce — or a nonce assigned by the configured
+   `X402.Facilitator.NonceManager`.
 3. Encodes the EIP-1559 transaction (`X402.Transaction`), signs its keccak
    digest through the configured `X402.Signer`, and broadcasts it via
    `eth_sendRawTransaction`.
 4. Polls `eth_getTransactionReceipt` until confirmation or
    `:receipt_timeout_ms`.
+5. Checks the confirmed receipt for the matching ERC-20 `Transfer` event.
+   A confirmed receipt only proves the transaction did not revert; the
+   `Transfer(from, to, value)` log — checked against the *signed*
+   authorization's `from`, `to`, and `value` and emitted by the
+   requirements' `asset` contract — is what proves the payment moved.
+   A parseable receipt without the matching event is the terminal
+   `invalid_exact_evm_transfer_event_mismatch`; logs the engine cannot
+   read structurally leave the transfer unestablished and degrade to the
+   non-terminal `settlement_pending` instead.
 
-A broadcast whose confirmation cannot be established — receipt timeout, or
-a transport failure mid-broadcast — returns the spec's **non-terminal**
-`"settlement_pending"` with a non-empty transaction hash, so the caller
-can reconcile on chain before deciding whether to retry.
+**SVM** — after the duplicate-settlement claim, the pending-store check,
+and the re-verify (which re-simulates by default — the blockhash-freshness
+and balance guard right before a preflight-skipping broadcast; see
+`:simulate_in_settle`):
+
+1. Signs the transaction's message bytes with the configured signer and
+   splices the signature into the fee payer's slot 0
+   (`X402.Solana.Transaction.attach_signature/3`).
+2. Broadcasts via `X402.Solana.RPC.send_transaction/2` with
+   `skipPreflight: true` — verification and simulation already ran.
+3. Polls `getSignatureStatuses` until the transaction reaches
+   `confirmed`/`finalized` or `:confirm_timeout_ms`.
+
+On both chains, a broadcast whose confirmation cannot be established —
+receipt/confirmation timeout, or a transport failure mid-broadcast —
+returns the spec's **non-terminal** `"settlement_pending"` with a
+non-empty transaction hash (EVM) or Base58 signature (Solana).
+
+## Pending settlements and reconciliation
+
+`settlement_pending` means "a transaction was broadcast, and its fate is
+unknown". Without more machinery that knowledge dies with the response: a
+client retrying the identical payment would re-verify and re-broadcast a
+second transaction. The `X402.Facilitator.PendingSettlementStore`
+behaviour closes the loop — before verifying, `settle/3` looks the
+payment up in the store and, on a hit, re-awaits the already-broadcast
+transaction instead of broadcasting a new one.
+
+What an entry records:
+
+* `:transaction` — the transaction hash (EVM) or Base58 signature (SVM).
+* `:provenance` — `:node_acknowledged` when the node returned the hash,
+  or `:local_hash` when the transport failed mid-broadcast and the hash
+  was computed locally from the signed bytes (the node may never have
+  seen it).
+* `:raw_transaction` — the raw signed bytes, kept for `:local_hash`
+  entries only, so operators can inspect or manually rebroadcast a
+  transaction the node may have missed. **The engine itself never
+  rebroadcasts** — rebroadcasting a transaction the node may have
+  accepted risks a duplicate-spend race, so `:local_hash` entries are
+  re-awaited exactly like node-acknowledged ones.
+
+Three details of the design are load-bearing:
+
+* **Delete before reconcile.** On a store hit the entry is deleted first,
+  then the recorded transaction is re-awaited. A concurrent retry of the
+  same payload therefore misses the store and falls through to the normal
+  path, where the chain itself rejects the duplicate — the EIP-3009
+  authorization nonce can only be consumed once, and a Solana resend of
+  the identical bytes collapses to the same transaction id.
+* **Pending keys bind the signed content.** The EVM key hashes the
+  payment's signature *together with* every authorization field the
+  reconcile path later checks (`from`, `to`, `value`, `validAfter`,
+  `validBefore`, `nonce`) and the requirements' `asset`; the SVM key is
+  the SHA-256 of the transaction's message bytes. This matters because
+  the reconcile fast path runs *without* re-verification: if the key were
+  the signature alone, anyone who saw the `PAYMENT-SIGNATURE` header
+  could replay it with a mutated authorization, hit the entry, burn it
+  (delete-before-reconcile), and turn a confirmed transfer into a
+  terminal mismatch. With the full binding, a mutated retry simply misses
+  the store and falls through to re-verification, which rejects it — the
+  honest retry's entry survives.
+* **A failed store write downgrades to a terminal response.** A pending
+  answer that was not persisted cannot be made good on — the retry would
+  miss the store and double-broadcast. The engine logs a warning and
+  answers with a terminal failure that keeps the transaction hash for
+  manual reconciliation.
+
+On the resource-server side, `X402.Plug.PaymentGate` complements this
+automatically: a `success: false` settle whose `errorReason` is
+`"settlement_pending"` *and* that carries a transaction hash is re-settled
+exactly once with the identical payload — the retry hits the
+facilitator's pending-store fast path and reconciles. A second pending,
+and every other failure, follows the normal failure path.
+
+The bundled `X402.Facilitator.PendingSettlementStore.ETS` adapter expires
+entries after five minutes and is per-node; a facilitator running several
+instances behind a load balancer needs a shared store instead — the
+behaviour's documentation includes a Redis adapter sketch.
 
 ## Fee-payer safety
 
 The facilitator's key pays gas for strangers' payments, so what it signs
-is structurally constrained:
+is structurally constrained.
 
-* Settlement transactions always have `to` set to the *verified*
-  requirements' `asset`, `value` `0`, and calldata built exclusively from
-  the authorization fields the signature check just proved. There is no
-  code path that signs caller-supplied calldata — the key can broadcast
-  transfers the payer authorized, and nothing else.
-* ERC-6492 **counterfactual** payments (undeployed smart wallets whose
-  signature wrapper carries factory deployment calldata) are rejected
-  fail-closed at verify *and* at settle's re-verify, because settling them
-  would require broadcasting that arbitrary factory calldata. Deployed
-  ERC-1271 smart wallets are fully supported.
+On EVM, settlement transactions always have `to` set to the *verified*
+requirements' `asset`, `value` `0`, and calldata built exclusively from
+the authorization fields the signature check just proved. With the
+default configuration there is no code path that signs caller-supplied
+calldata — ERC-6492 **counterfactual** payments (undeployed smart wallets
+whose signature wrapper carries factory deployment calldata) are rejected
+fail-closed at verify *and* at settle's re-verify, while deployed
+ERC-1271 smart wallets are fully supported.
 
-Even so: fund the fee-payer key with gas money only, and prefer a
-KMS-backed `X402.Signer` implementation over `X402.Signer.LocalKey` for
-production (the signer must support signing raw 32-byte digests).
+A non-empty `:eip6492_allowed_factories` relaxes exactly that one
+constraint, opting into counterfactual *settlement* the way the reference
+facilitators support it:
+
+* The wrapper's factory calldata is broadcast as its own transaction
+  first — but only when the factory address appears on the allowlist
+  (`eip6492_factory_not_allowed` otherwise, re-checked at settle even
+  though the re-verify already enforced it), and capped by
+  `:max_deploy_gas_limit` (smart-account deployments legitimately cost
+  far more than a transfer, so they carry their own ceiling).
+* Settle then requires a successful deploy receipt
+  (`smart_wallet_deployment_failed` otherwise — terminal but safe: the
+  EIP-3009 authorization was not consumed, so the client may retry the
+  identical payment) before settling with the unwrapped inner signature.
+  A wallet that was deployed since verification skips the deployment
+  transaction.
+* Verification must predict settlement: the allowlist is threaded into
+  verify, where a counterfactual signature is proven by an atomic
+  Multicall3 simulation that deploys and transfers in one `eth_call`.
+  That proof is the *only* possible check of a counterfactual signature,
+  so it runs even when simulation is otherwise off — `X402.Verify.EVM`'s
+  `:counterfactual_only` simulate mode, which is what the engine uses
+  internally when `:simulate` or `:simulate_in_settle` is `false`.
+
+Independent of the allowlist, `:max_gas_limit` caps every settlement
+transaction (a legitimate `transferWithAuthorization` costs well under
+100k gas; an estimate above the ceiling means the asset contract is
+burning the fee payer's gas, and the settlement is refused with
+`settle_gas_limit_exceeded`).
+
+On Solana, the constraint is verification itself: the engine only ever
+co-signs a transaction whose account 0 is its own key, whose instructions
+match the static whitelist, and in which the fee payer is referenced by
+no instruction — the sponsor's signature can never move the sponsor's
+funds. `:max_required_signatures` optionally caps the signature count
+(each one adds 5000 lamports of base fee, paid by the engine's key).
+
+Even so: fund the fee-payer keys with gas money only, and prefer a
+KMS-backed `X402.Signer` implementation over the bundled local-key
+signers for production (the EVM signer must support signing raw 32-byte
+digests).
+
+## The nonce manager
+
+An EVM engine without a nonce manager reads `eth_getTransactionCount`
+(`pending`) per settlement, which races under concurrency: two settles
+can read the same nonce, sign two different payments with it, and the
+node rejects one even though its EIP-3009 authorization was never used —
+a valid payment fails. `X402.Facilitator.NonceManager` assigns nonces
+instead: `checkout/3` hands out the next nonce (fetching from the node
+only on first use per address), `complete/3` marks it consumed once the
+transaction reached the node, and `release/3` returns it when the
+settlement failed before the node could have seen the transaction —
+rolling the tail nonce straight back, or scheduling a node re-fetch when
+releasing a middle nonce would leave a gap that stalls later
+transactions. The engine drives this lifecycle itself; you only supervise
+the process and pass its name:
+
+```elixir
+children = [
+  {X402.Facilitator.NonceManager, name: MyFacilitator.NonceManager},
+  # ...
+]
+
+X402.Facilitator.Engine.new(
+  # ...
+  nonce_manager: MyFacilitator.NonceManager
+)
+```
+
+Nonce tracking is per-node: running the same fee-payer key on several
+facilitator instances still races at the chain level — use one fee payer
+per instance, or coordinate externally.
 
 ## Hooks
 
-`X402.Hooks` callbacks wrap both operations, mirroring the reference
-facilitator's lifecycle hooks — payment tracking, allow/deny policies, and
-failure recovery without touching the engine:
+`X402.Hooks` callbacks wrap both engines' operations, mirroring the
+reference facilitator's lifecycle hooks — payment tracking, allow/deny
+policies, and failure recovery without touching the engine:
 
 ```elixir
 defmodule MyFacilitator.Hooks do
@@ -149,8 +428,11 @@ replacement response.
 ## Production notes
 
 * **Authentication** — the scaffold's `:auth_token` is a minimal bearer
-  check for private deployments. Put real authentication, TLS
-  termination, and rate limiting in front of a public facilitator.
+  check for private deployments, and the plug warns at init when it is
+  not configured — an unauthenticated facilitator lets anyone make its
+  fee payer broadcast (gas-capped) settlement transactions. Put real
+  authentication, TLS termination, and rate limiting in front of a
+  public facilitator.
 * **The wire contract** — protocol-level rejections are `200` responses
   (`isValid: false` / `success: false`); `400`/`413` cover malformed or
   oversized bodies, and `500` (opaque body, details logged) means an
@@ -158,12 +440,22 @@ replacement response.
 * **`/discovery/resources`** — optional in the facilitator API and not
   served by the scaffold (it answers `404`); bazaar serving is out of
   scope here.
-* **Observability** — the engine emits
+* **Observability** — both engines emit
   `[:x402, :facilitator_engine, :verify]` and
-  `[:x402, :facilitator_engine, :settle]` telemetry, and every RPC call
-  emits `[:x402, :rpc, :request]`.
-* **One settle per payment** — the EIP-3009 nonce makes on-chain replay
-  impossible: a second settle of the same payload is rejected by the
-  token contract (`nonce_already_used`). A `settlement_pending` result
-  should be reconciled against the returned transaction hash rather than
-  blindly retried.
+  `[:x402, :facilitator_engine, :settle]` telemetry with `:status`
+  metadata, and every RPC call emits `[:x402, :rpc, :request]`.
+* **One settle per payment** — the chain enforces it: a second settle of
+  the same EVM payload is rejected by the token contract
+  (`invalid_exact_evm_nonce_already_used`), and a Solana resend of
+  identical bytes
+  collapses to one transaction id. The engines handle the ambiguous
+  middle on their own — a `settlement_pending` retry reconciles against
+  the recorded broadcast through the pending store, and the SVM
+  settlement cache rejects concurrent duplicates before broadcast — so
+  configure the stores rather than reconciling by hand.
+* **Stores are per-node with the bundled adapters** — the ETS
+  pending-settlement store and the ETS settlement cache both live on the
+  local node. Multi-instance facilitators need shared adapters (the
+  pending-store behaviour documents a Redis sketch, and
+  `X402.Extensions.PaymentIdentifier.RedisCache` covers the settlement
+  cache) so a retry routed to a different instance still reconciles.

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -1,13 +1,24 @@
 # Getting Started
 
-This guide adds an x402 v2 payment gate to an Elixir application.
+This guide adds an x402 v2 payment gate to an Elixir application. Gating
+is one of four roles the SDK covers end to end:
+
+- **Pay** for x402-protected resources from Elixir —
+  [Paying for Resources](client.html)
+- **Gate** your own routes behind payment — this guide, then
+  [Plug/Phoenix Integration](plug-integration.html) for the full option
+  reference
+- **Verify** payments locally instead of trusting a remote facilitator —
+  [Local Payment Verification](local-verification.html)
+- **Run the facilitator** yourself, on EVM and Solana —
+  [Run Your Own Facilitator](facilitator.html)
 
 ## Install the integrations you use
 
 ```elixir
 def deps do
   [
-    {:x402, "~> 0.4"},
+    {:x402, "~> 0.6"},
     {:finch, "~> 0.19"},
     {:plug, "~> 1.14"}
   ]

--- a/guides/local-verification.md
+++ b/guides/local-verification.md
@@ -2,15 +2,21 @@
 
 By default an x402 resource server delegates payment verification to a remote
 facilitator: the server's security posture equals the facilitator's, fully.
-`X402.Verify.EVM` removes that dependency for EVM `exact`/`eip3009` payments
-by running the facilitator verify checklist locally — the same checks the
-reference TypeScript, Go, and Python facilitator engines perform, from
-EIP-712 signature recovery to on-chain `transferWithAuthorization`
-simulation.
+Two modules remove that dependency by running the facilitator verify
+checklist locally — the same checks the reference TypeScript, Go, and Python
+facilitator engines perform:
 
-Use it to cross-check a facilitator you do not fully trust, to reject junk
+- `X402.Verify.EVM` for EVM `exact`/`eip3009` payments, from EIP-712
+  signature recovery to on-chain `transferWithAuthorization` simulation.
+- `X402.Verify.SVM` for `exact` payments on `solana:*` networks, from local
+  Ed25519 signature verification to `simulateTransaction`.
+
+Use them to cross-check a facilitator you do not fully trust, to reject junk
 before paying for a facilitator round-trip, or as the verification core of
-your own facilitator.
+your own facilitator — that last use is not hypothetical:
+`X402.Facilitator.Engine` verifies through `X402.Verify.EVM` and
+`X402.Facilitator.SVMEngine` through `X402.Verify.SVM` (see
+[Run Your Own Facilitator](facilitator.html)).
 
 ## Verification levels
 
@@ -82,13 +88,70 @@ Pure levels need no RPC at all:
 {:ok, _} = X402.Verify.EVM.verify(payload, requirements, level: :signature)
 ```
 
-## Gating requests with the `before_verify` hook
+## Verifying inside the payment gate
 
-`X402.Plug.PaymentGate` already runs cheap structural prechecks
-(`local_prechecks: true`) before every facilitator call. To add cryptographic
-verification without waiting for the scheme-behaviour integration, run
-`X402.Verify.EVM` from a `before_verify` hook — the gate aborts with a 402
-when the hook halts:
+`X402.Plug.PaymentGate` runs local verification inline when you pass the
+`local_verification:` option — before the facilitator round-trip, on every
+exact-EVM payment a gated route matches. A bare level atom is shorthand for
+`[level: level]`:
+
+```elixir
+plug X402.Plug.PaymentGate,
+  facilitator: MyApp.Facilitator,
+  local_verification: :signature,
+  routes: [...]
+```
+
+The keyword form accepts the full `X402.Verify.EVM.verify/3` configuration:
+`:level`, `:rpc` (an `X402.RPC` struct), `:simulate`
+(`true | false | :counterfactual_only`), `:verify_chain_id`,
+`:eip6492_allowed_factories`, and `:multicall_address`:
+
+```elixir
+{:ok, rpc} = X402.RPC.new(rpc_url: "https://mainnet.base.org", finch: MyApp.Finch)
+
+plug X402.Plug.PaymentGate,
+  facilitator: MyApp.Facilitator,
+  local_verification: [level: :full, rpc: rpc],
+  routes: [...]
+```
+
+Level `:full` requires `:rpc` at `init/1` — the gate raises on the
+misconfiguration when the plug initializes rather than answering
+`{:error, :rpc_not_configured}` on the first paid request.
+
+Scope and failure semantics:
+
+- **Exact-EVM only.** Local verification runs when the matched requirements
+  have scheme `"exact"` and an `eip155:*` network. Every other
+  scheme/network combination — `upto`, exact-SVM, custom schemes — skips it
+  silently; the facilitator remains the authority for those kinds, and for
+  exact-EVM too: it still verifies and settles payments local verification
+  accepted.
+- **Rejections answer 402.** `{:invalid, reason}` is a definitive verdict
+  about the payment: the gate rejects with 402 exactly like a facilitator
+  rejection, carrying the canonical `invalidReason` string
+  (`X402.Verify.EVM.reason_string/1`) as the rejection reason — the response
+  is indistinguishable from the facilitator having rejected it.
+- **Infrastructure failures answer 500.** A missing crypto dependency
+  (`:missing_dependency`), an unconfigured or unreachable RPC endpoint
+  (`:rpc_not_configured`, `{:rpc_error, _}`), or a chain-id mismatch is not
+  a verdict about the payment: the gate fails closed with 500 rather than
+  silently downgrading the configured level.
+
+`level: :signature` is a good default: it proves the EOA signature with zero
+added RPC latency on the request path, while the facilitator remains the
+authority on chain state. `level: :full` runs the whole checklist — funding,
+nonce state, transfer simulation — at the cost of RPC round-trips per
+request. Note that `:signature` rejects smart-wallet signers fail-closed
+(`smart_wallet_requires_rpc`); accepting them locally requires `:full`.
+
+### The `before_verify` hook
+
+The hook approach the gate supported before `local_verification:` existed
+remains available for custom policy — a different verifier, per-route
+levels, or checks on non-EVM schemes. The gate aborts with a 402 when the
+hook halts:
 
 ```elixir
 defmodule MyApp.LocalVerification do
@@ -115,18 +178,12 @@ defmodule MyApp.LocalVerification do
   @impl true
   def on_settle_failure(context, _metadata), do: {:cont, context}
 end
-
-plug X402.Plug.PaymentGate,
-  accepts: [requirements],
-  facilitator: [url: "https://facilitator.example.com", finch: MyApp.Finch],
-  hooks: MyApp.LocalVerification
 ```
 
-`level: :signature` is a good fit here: it proves the EOA signature without
-adding RPC latency to the request path, while the facilitator (or a
-`level: :full` check) remains the authority on chain state. Payments the
-signature level cannot prove — smart-wallet signers — halt fail-closed; relax
-that only by running `level: :full` with an `:rpc` config in the hook.
+Pass the module as the gate's `hooks:` option. For plain exact-EVM
+verification, prefer `local_verification:` — it maps rejections onto the
+canonical reason strings and fails closed on infrastructure errors without
+any hook code.
 
 ## ERC-6492 counterfactual wallets
 
@@ -140,9 +197,7 @@ the strength of the wrapper alone:
    `{:invalid, :eip6492_factory_not_allowed}` — list only factories you
    trust, since settlement executes their calldata.
 2. Validity is proven exclusively by an atomic Multicall3 simulation that
-   deploys the wallet and executes the transfer in a single `eth_call`. With
-   `simulate: false` counterfactual payments are rejected with
-   `{:invalid, :undeployed_smart_wallet}`.
+   deploys the wallet and executes the transfer in a single `eth_call`.
 
 ```elixir
 X402.Verify.EVM.verify(payload, requirements,
@@ -151,6 +206,19 @@ X402.Verify.EVM.verify(payload, requirements,
   eip6492_allowed_factories: ["0x0BA5ED0c6AA8c49038F819E587E2633c4A9F428a"]
 )
 ```
+
+Because that simulation is the only possible proof, the `:simulate` option
+interacts with counterfactual payments in three modes:
+
+- `true` (default) — the EOA/ERC-1271 transfer simulation runs, and
+  counterfactual payments get the atomic deploy-and-transfer simulation.
+- `false` — no simulation at all; counterfactual payments are rejected with
+  `{:invalid, :undeployed_smart_wallet}` rather than accepted unproven.
+- `:counterfactual_only` — the EOA/ERC-1271 transfer simulation is skipped
+  like `false`, but the atomic counterfactual proof still runs. This is the
+  mode `X402.Facilitator.Engine` uses for the independent re-verify inside
+  `settle/3`: verify and settle apply the same counterfactual policy without
+  paying a second transfer simulation for ordinary payments.
 
 Deployed smart wallets (including ERC-7702-delegated EOAs) take the strict
 ERC-1271 path: `isValidSignature` must return the magic value, with no ECDSA
@@ -170,18 +238,104 @@ or `:simulation_failed`.
 
 `X402.Verify.EVM.reason_string/1` maps each reason atom onto the canonical
 cross-SDK `invalidReason` string (for example `:nonce_already_used` →
-`"invalid_exact_evm_nonce_already_used"`), so a future facilitator engine can
-answer wire-compatible verify responses.
+`"invalid_exact_evm_nonce_already_used"`), so a facilitator engine built on
+it answers wire-compatible verify responses.
+
+## SVM verification
+
+`X402.Verify.SVM` is the Solana counterpart: the facilitator verify
+checklist for `exact` payments on `solana:*` networks, following the
+exact-SVM scheme specification's *static verification path*. It is
+`X402.Facilitator.SVMEngine`'s verification core the way `X402.Verify.EVM`
+is the EVM engine's.
+
+| Level | Checks | Needs |
+|---|---|---|
+| `:structural` | scheme/network match, fee-payer requirements, transaction decoding, Ed25519 verification of every required signer except the fee-payer slot, address-lookup-table rejection, fail-closed requirements validation, and the static instruction whitelist via `X402.Scheme.ExactSVM` | nothing — Ed25519 rides on OTP `:crypto` |
+| `:full` | `:structural` + `simulateTransaction` of the exact payload bytes settlement would co-sign | an `X402.RPC` endpoint (called through `X402.Solana.RPC`), else `{:error, :rpc_not_configured}` |
+
+```elixir
+{:ok, payload} = X402.PaymentSignature.decode_and_validate(header_value, requirements)
+
+{:ok, rpc} =
+  X402.RPC.new(
+    rpc_url: "https://api.mainnet-beta.solana.com",
+    finch: MyApp.Finch
+  )
+
+case X402.Verify.SVM.verify(payload, requirements,
+       level: :full,
+       rpc: rpc,
+       fee_payer: "9hSR6S7WPtxmTojgo6GG3k4yDPecgJY292j7xrsUGWBu"
+     ) do
+  {:ok, %{payer: payer}} ->
+    # payer is the Base58 authority of the TransferChecked instruction —
+    # the account whose tokens move.
+    {:ok, payer}
+
+  {:error, {:invalid, reason}} ->
+    {:reject, X402.Verify.SVM.reason_string(reason)}
+
+  {:error, other} ->
+    # :rpc_not_configured or {:rpc_error, _}. Fail closed.
+    {:reject, other}
+end
+```
+
+The `:fee_payer` option is required at every level: the requirements'
+`extra.feePayer` must equal an address you actually control
+(`fee_payer_not_managed` otherwise) and must be the transaction's account 0
+(`fee_payer_mismatch`) — a facilitator must never co-sign a transaction
+whose fee payer it does not manage. The optional
+`:max_required_signatures` caps the signature count (each adds 5000
+lamports of base fee, paid by the fee payer), and `:commitment` (default
+`"confirmed"`) sets the simulation's commitment level.
+
+What the checks guard, and why:
+
+- **Local Ed25519 verification is the signature check, not an
+  optimization.** The fee-payer slot (slot 0) stays unsigned until
+  settlement co-signs it, so `simulateTransaction` necessarily runs with
+  `sigVerify: false` — simulation proves nothing about signatures. Every
+  required signer except the fee-payer slot is therefore verified locally
+  (pure OTP `:crypto`, no optional dependency) at **every** level; without
+  this, a forged payload would pass simulation and only the broadcast would
+  reject it.
+- **Requirements are validated fail-closed.** `X402.Scheme.ExactSVM`'s
+  gate-side pre-check skips comparisons whose requirements field it cannot
+  interpret locally, deferring to the facilitator. `X402.Verify.SVM` *is*
+  the deferral target, so an uninterpretable `amount`, `asset`, or `payTo`
+  is rejected, never skipped — otherwise the skip would silently drop the
+  money-matching checks.
+- **The static instruction whitelist** (dispatched through
+  `X402.Scheme.ExactSVM`) pins the transaction to the reference layout:
+  3–7 instructions in the specified order, compute-budget bounds, the
+  fee-payer isolation rule (the fee payer must not be the account
+  transferring funds), amount / mint / destination-ATA equality against
+  the requirements, and memo enforcement.
+- **Address lookup tables are rejected fail-closed**
+  (`alt_resolution_not_available`): an ALT transaction's account set cannot
+  be verified without resolving the tables — the spec's opt-in smart-wallet
+  path, currently out of scope.
+
+`X402.Verify.SVM.reason_string/1` maps each reason atom onto the TypeScript
+reference's `invalid_exact_svm_*` vocabulary (for example
+`:amount_mismatch` → `"invalid_exact_svm_payload_amount_mismatch"`) — the
+strings the hosted facilitator emits.
 
 ## What local verification cannot tell you
 
 - **Replay across servers.** A valid authorization can be presented to many
   resource servers until it is settled on chain. Local verification proves
-  the payment *could* settle — pair it with the payment-identifier replay
-  cache and settlement.
+  the payment *could* settle — pair it with `X402.Plug.PaymentGate`'s replay
+  protection, which claims a canonical key derived from signature-covered
+  content for every proof (see
+  [Replay protection](plug-integration.html#replay-protection)), and with
+  settlement.
 - **Race to settlement.** Funding and nonce state hold at the instant of the
   `eth_call`; they can change before you settle. Settlement remains the only
   proof of payment.
-- **Non-EVM schemes.** Only `exact` with the default `eip3009` asset transfer
-  method is supported; other schemes and networks return
-  `{:error, {:invalid, ...}}` rather than guessing.
+- **Other schemes.** `X402.Verify.EVM` understands `exact` with the default
+  `eip3009` asset transfer method; `X402.Verify.SVM` understands `exact` on
+  `solana:*`. Anything else returns `{:error, {:invalid, ...}}` rather than
+  guessing.

--- a/guides/mcp.md
+++ b/guides/mcp.md
@@ -80,10 +80,15 @@ x402 v2, its `accepted` must match an advertised option exactly (including
 `extra` preservation), and advertised `extensions` must be echoed without
 dropping values.
 
-`payment_identifier_cache:` enables replay protection — the same
-`X402.Extensions.PaymentIdentifier.ETSCache` option the Plug gate takes. Each
-payment proof is atomically claimed before settlement, so the same signed
-payment cannot be settled twice.
+`payment_identifier_cache:` enables replay protection — an
+`X402.Extensions.PaymentIdentifier.ETSCache` server or any
+`X402.Extensions.PaymentIdentifier.Cache` adapter, the same option the Plug
+gate takes. Each payment proof is atomically claimed before settlement, so
+the same signed payment cannot be settled twice. The claim key is a
+deterministic hash of the signed scheme payload — never the
+client-controlled `paymentId` extension — so neither re-encoding the
+payment envelope nor varying `paymentId` can mint a fresh claim for the
+same signed authorization.
 
 To advertise the price outside a rejection (for example in a `tools/list`
 response), use `X402.MCP.Server.payment_required_result/2`.

--- a/guides/plug-integration.md
+++ b/guides/plug-integration.md
@@ -12,8 +12,13 @@ The plug accepts these options (validated via `NimbleOptions`):
 |--------|------|----------|---------|-------------|
 | `:facilitator` | `GenServer.server()` | no | `X402.Facilitator` | Facilitator process name or pid for verify/settle calls |
 | `:hooks` | `module()` | no | `X402.Hooks.Default` | Lifecycle hook module implementing `X402.Hooks` |
-| `:payment_identifier_cache` | `atom() \| pid()` | no | `nil` | `ETSCache` server for idempotency (strongly recommended) |
+| `:payment_identifier_cache` | `atom() \| pid() \| {module, cache}` | no | `nil` | Replay-protection cache: an `ETSCache` server, or an adapter tuple whose module implements `X402.Extensions.PaymentIdentifier.Cache` (strongly recommended — see "Replay Protection") |
+| `:claim_order` | `:after_verify \| :before_verify` | no | `:after_verify` | When the replay claim is taken relative to facilitator verification (see "Replay Protection") |
 | `:routes` | `[map()]` | **yes** | — | Route gate definitions (see below) |
+| `:schemes` | `[module()]` | no | `[]` | Additional `X402.Scheme` modules for custom schemes — see the [Custom Payment Schemes](custom-schemes.html) guide |
+| `:local_prechecks` | `boolean()` | no | `true` | Cheap scheme-dispatched checks before the facilitator call; certain mismatches answer 402 without a round-trip |
+| `:local_verification` | `atom() \| keyword()` | no | `nil` | Inline cryptographic verification of exact-EVM payments before the facilitator verify (see "Local Verification") |
+| `:paywall` | `module()` | no | `nil` | Browser paywall renderer implementing `X402.Paywall` — see the [Browser Paywall](paywall.html) guide |
 
 > **Important:** When `:payment_identifier_cache` is not configured, the plug
 > emits a runtime warning. Without it, concurrent identical requests can
@@ -45,7 +50,7 @@ plug X402.Plug.PaymentGate,
 | `:method` | `atom()` | **yes** | HTTP method (`:get`, `:post`, `:put`, `:delete`, `:patch`, `:head`, `:options`, `:trace`, or `:any` for all) |
 | `:path` | `String.t()` | **yes** | Route path. Exact matches (`/api/data`) or glob patterns (`/api/*`) |
 | `:accepts` | `[map()]` | no | Multiple payment options (see "Multiple Accepts" below) |
-| `:scheme` | `String.t()` | no | `"exact"` (default), `"upto"`, or the scheme name of a module passed in the plug's `:schemes` option — see the [Custom Payment Schemes](custom-schemes.md) guide |
+| `:scheme` | `String.t()` | no | `"exact"` (default), `"upto"`, or the scheme name of a module passed in the plug's `:schemes` option — see the [Custom Payment Schemes](custom-schemes.html) guide |
 | `:price` | `String.t()` | conditionally | Payment amount in atomic token units. Required when `:accepts` is empty |
 | `:network` | `String.t()` | conditionally | CAIP-2 network identifier (e.g. `"eip155:8453"`) |
 | `:asset` | `String.t()` | conditionally | Token contract address |
@@ -90,7 +95,8 @@ amounts), use the `:accepts` list:
       price: "5000",
       network: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
       asset: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-      pay_to: "YourSolanaAddress"
+      pay_to: "YourSolanaAddress",
+      extra: %{"feePayer" => "YourFacilitatorFeePayer"}
     }
   ]
 }
@@ -102,6 +108,12 @@ server-advertised requirement. Every core field, including
 `accepted.extra`, but it cannot remove or mutate fields advertised by the
 server. Echoed protocol extensions are validated with the same fail-closed
 rule.
+
+Exact-SVM options require `extra.feePayer` — the facilitator-managed
+sponsor account that co-signs and pays fees at settlement. A facilitator's
+`GET /supported` response advertises its fee payer in each SVM kind's
+`extra.feePayer`; copy it into the route (or build routes from that
+response).
 
 ### Metered `"upto"` settlement
 
@@ -170,10 +182,36 @@ plug X402.Plug.PaymentGate,
   routes: [...]
 ```
 
-## Idempotency (Payment Identifier Cache)
+## Local Verification
 
-To prevent double-settlement of the same payment proof from concurrent
-requests, configure an ETS cache:
+Facilitator verification is a delegation: the gate trusts the facilitator's
+verdict. The `local_verification:` option narrows that gap by running
+`X402.Verify.EVM` inline, before the facilitator verify, on every exact-EVM
+payment (`"exact"` scheme, `eip155:*` network). It accepts a bare level
+(`:structural`, `:signature`, or `:full`) or a keyword list with `:level`,
+`:rpc` (required for `:full`), and the other `X402.Verify.EVM.verify/3`
+options:
+
+```elixir
+plug X402.Plug.PaymentGate,
+  facilitator: MyApp.Facilitator,
+  local_verification: :signature,
+  routes: [...]
+```
+
+Rejections answer 402 carrying the canonical `invalidReason` string, exactly
+like a facilitator rejection; infrastructure failures (missing crypto
+dependencies, RPC errors, chain-id mismatches) fail closed with 500; other
+scheme/network kinds skip it silently, and the facilitator remains the
+authority for every payment either way. See the
+[Local Payment Verification](local-verification.html) guide for the levels,
+their capability requirements, and ERC-6492 counterfactual handling.
+
+## Replay Protection
+
+A valid payment proof can be presented many times — concurrently to the same
+server, or replayed after the client observed a response. Configure a cache
+so the gate atomically claims each proof before the protected handler runs:
 
 ```elixir
 # In your supervision tree
@@ -189,10 +227,56 @@ plug X402.Plug.PaymentGate,
   routes: [...]
 ```
 
-The Plug performs an atomic `put_new` claim on the payment proof hash after
-verification and before the handler. A handler error or failed settlement
-releases the claim; a successful settlement retains it. If the claim fails
-(duplicate), the request is rejected with `"payment already processed"`.
+### Canonical replay keys
+
+The claim key is derived from the payment proof itself. For the built-in
+schemes the gate derives a canonical identity from the fields the payment's
+signature covers, so re-encoding the same signed authorization (JSON key
+order, whitespace, Base64 variant) cannot mint a fresh key:
+
+| Kind | Key derives from |
+|---|---|
+| `"exact"` on `eip155:*` | the EIP-3009 authorization's `from` + `nonce` |
+| `"upto"` on `eip155:*` | the Permit2 owner (`from`) + the nonce canonicalized to its 32-byte `uint256` encoding, so the equivalent JSON forms `1`, `"1"`, and `"01"` mint the same key |
+| `"exact"` on `solana:*` | the SHA-256 of the transaction's **signed message bytes** — not the wire bytes, whose fee-payer signature slot is mutable (a co-signed or stripped slot must not mint a fresh key) |
+| everything else | the SHA-256 of the raw `PAYMENT-SIGNATURE` header |
+
+Every family's keys carry a distinct prefix, so keys from different families
+can never collide. The consequence of the fallback row: re-encoded
+duplicates of the same signed proof **are** caught for the built-in schemes,
+while custom schemes without a canonical derivation catch byte-identical
+replays only.
+
+The key derives **only** from signature-covered content — never from
+unsigned client-controlled fields, and in particular never from the payment
+identifier extension's `paymentId` (see "Payment Identifiers" below). A
+replayer could vary an unsigned field to mint a fresh key and bypass
+deduplication, or squat another payment's id to deny it service.
+
+### Claim lifecycle
+
+The claim is an atomic `put_new` through the
+`X402.Extensions.PaymentIdentifier.Cache` behaviour. A duplicate claim
+rejects the request with 402 (`"payment already processed"`). The claim is
+released when the protected handler responds with a status >= 400 or
+settlement fails — so a client may retry a payment whose resource was never
+delivered — and retained after a successful settlement.
+
+The `:claim_order` option controls when the claim is taken relative to
+facilitator verification:
+
+- `:after_verify` (default) — verify first, then claim. A replayed proof can
+  never strand a claim through verification, but **every** replayed request
+  pays a full facilitator verify round-trip before it is rejected, so a
+  replay storm translates directly into facilitator load.
+- `:before_verify` — claim first, rejecting duplicates locally without any
+  facilitator call, which sheds replay-storm load; the claim is released
+  when verification fails for any reason. The trade-off: a node that
+  crashes between claiming and releasing strands the claim until the cache
+  TTL expires, so a legitimate retry of that same payment is rejected with
+  402 until then.
+
+### Cache adapters
 
 The ETS cache is per-node: in a clustered deployment each node keeps its own
 table, so a replayed proof routed to two nodes is served once per node. For
@@ -220,6 +304,26 @@ nodes; Redis or connection errors fail closed (the protected handler does not
 run). Configure the Redis server with `maxmemory-policy noeviction` so live
 claims are never evicted.
 
+### Payment Identifiers
+
+Separate from replay protection, a client may echo the payment identifier
+extension under `extensions["paymentIdentifier"]` in its payment payload.
+The gate decodes it — both the bare form and the `%{"info" => ...}` envelope
+(`X402.Extensions.PaymentIdentifier`) — and rejects a malformed one (bad
+Base64, invalid JSON, missing `paymentId`) with 400. A valid identifier is
+surfaced for correlation:
+
+- `conn.assigns[:x402_payment_id]` in the protected handler,
+- the settlement context the gate carries into its before-send settlement,
+- the `[:x402, :plug, :payment_verified]` telemetry metadata, as
+  `:payment_id`.
+
+It is deliberately **not** the deduplication key: `paymentId` is
+client-controlled and covered by no signature, so building replay protection
+on it would let a replayer mint fresh keys at will. The replay key comes
+from the signed content above; the payment identifier is for tracing a
+payment through your logs and the client's.
+
 ## Conn Assigns
 
 After successful verification, the Plug assigns these to the connection before
@@ -229,6 +333,7 @@ the protected handler runs:
 |--------|-------|
 | `:x402_payment_payload` | The decoded `PaymentPayload` map |
 | `:x402_payment_requirements` | The matched `PaymentRequirements` map |
+| `:x402_payment_id` | The client's echoed payment identifier (only set when the extension was present) |
 
 Your controller can access these:
 
@@ -252,6 +357,19 @@ produced a response below HTTP 400. On successful settlement, a
 response includes both
 `PAYMENT-REQUIRED` (so the client can retry) and `PAYMENT-RESPONSE` (with
 the error reason).
+
+### Settlement retries
+
+A settle response of `success: false` with `errorReason:
+"settlement_pending"` **and** a transaction hash means the facilitator
+broadcast the transaction but could not confirm it within its wait window.
+The gate retries such a settle exactly once, with the identical payload —
+mirroring the reference SDKs' `settleWithPendingRetry` — so a facilitator
+with a pending-settlement store reconciles against the already-broadcast
+transaction instead of broadcasting twice (see
+[Run Your Own Facilitator](facilitator.html)). A second pending verdict, or
+any other failure, follows the normal failure path: the replay claim is
+released and the response carries the failure headers described above.
 
 ## Signed Offers and Receipts
 
@@ -286,13 +404,15 @@ alias X402.Extensions.OfferReceipt
 
 plug X402.Plug.PaymentGate,
   routes: [
-    {"/premium-data",
-     [
-       amount: "10000",
-       pay_to: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
-       network: "eip155:84532",
-       extensions: %{"offer-receipt" => OfferReceipt.build_extension([offer])}
-     ]}
+    %{
+      method: :get,
+      path: "/premium-data",
+      price: "10000",
+      network: "eip155:84532",
+      asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      pay_to: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      extensions: %{"offer-receipt" => OfferReceipt.build_extension([offer])}
+    }
   ]
 ```
 
@@ -340,9 +460,9 @@ The plug follows the x402 v2 HTTP transport status mapping:
 
 | Status | When |
 |--------|------|
-| **402** | Payment required (no `PAYMENT-SIGNATURE` header), no matching requirements, or payment verification/settlement failed |
-| **400** | Malformed `PAYMENT-SIGNATURE` header, invalid Base64, invalid JSON, payload too large, or wrong `x402Version` |
-| **500** | Facilitator transport failure, malformed facilitator response, invalid server-provided settlement amount, or response-encoding failure |
+| **402** | Payment required (no `PAYMENT-SIGNATURE` header), no matching requirements, a duplicate payment proof, a local pre-check or local-verification rejection, or facilitator verification/settlement failure |
+| **400** | Malformed `PAYMENT-SIGNATURE` header, invalid Base64, invalid JSON, payload too large, wrong `x402Version`, a scheme payload validation failure, or a malformed payment identifier extension |
+| **500** | Facilitator transport failure, malformed facilitator response, local-verification infrastructure failure (missing dependency, RPC error, chain-id mismatch), invalid server-provided settlement amount, or response-encoding failure |
 
 ## Telemetry Events
 
@@ -355,8 +475,10 @@ The plug emits these telemetry events:
 | `[:x402, :plug, :payment_verified]` | Payment successfully verified and settled |
 | `[:x402, :plug, :payment_rejected]` | Payment rejected (invalid payload, no match, verification failed, etc.) |
 
-Metadata includes `%{method: atom(), path: String.t()}` and for
-`:payment_required` / `:payment_rejected` also `:route` and `:reason`.
+Metadata always includes `:method` and `:path`. Every event except
+`:pass_through` adds `:route`; `:payment_rejected` adds `:reason`; and
+`:payment_verified` adds `:payment_id` when the client echoed a payment
+identifier extension.
 
 ## Full Example
 
@@ -369,6 +491,7 @@ defmodule MyAppWeb.Router do
       facilitator: MyApp.Facilitator,
       hooks: MyApp.PaymentHooks,
       payment_identifier_cache: MyApp.PaymentCache,
+      local_verification: :signature,
       routes: [
         %{
           method: :get,

--- a/lib/x402/solana/rpc.ex
+++ b/lib/x402/solana/rpc.ex
@@ -20,7 +20,7 @@ defmodule X402.Solana.RPC do
 
   All transport, TLS, and telemetry behaviour is inherited from `X402.RPC`
   (events carry the Solana method name as `:method` metadata), and errors are
-  `X402.RPC.error/0` values — node-side failures come back as
+  `t:X402.RPC.error/0` values — node-side failures come back as
   `{:error, {:jsonrpc_error, %{code: _, message: _, data: _}}}`.
   """
 

--- a/mix.exs
+++ b/mix.exs
@@ -158,13 +158,16 @@ defmodule X402.MixProject do
           X402.Client.Finch,
           X402.Signer,
           X402.Signer.LocalKey,
+          X402.Signer.SolanaKey,
           X402.EIP3009,
-          X402.EIP712
+          X402.EIP712,
+          X402.Permit2
         ],
         "Facilitator Client": [
           X402.Facilitator,
           X402.Facilitator.Auth,
           X402.Facilitator.Auth.CDP,
+          X402.Facilitator.Error,
           X402.Facilitator.HTTP,
           X402.Hooks,
           X402.Hooks.Context,
@@ -179,6 +182,7 @@ defmodule X402.MixProject do
           X402.Scheme,
           X402.Scheme.Registry,
           X402.Scheme.ExactEVM,
+          X402.Scheme.ExactSVM,
           X402.Scheme.UptoEVM,
           X402.Scheme.EVM
         ],
@@ -189,17 +193,31 @@ defmodule X402.MixProject do
         ],
         "Local Verification": [
           X402.Verify.EVM,
+          X402.Verify.SVM,
           X402.RPC,
           X402.ERC6492
         ],
         "Facilitator Server": [
           X402.Facilitator.Engine,
+          X402.Facilitator.SVMEngine,
+          X402.Facilitator.NonceManager,
+          X402.Facilitator.PendingSettlementStore,
+          X402.Facilitator.PendingSettlementStore.ETS,
           X402.Plug.Facilitator,
           X402.RLP,
           X402.Transaction
         ],
+        Solana: [
+          X402.Solana,
+          X402.Solana.RPC,
+          X402.Solana.Transaction,
+          X402.Base58
+        ],
         Utilities: [
-          X402.Wallet
+          X402.Wallet,
+          X402.Telemetry,
+          X402.Behaviour,
+          X402.Utils
         ],
         Extensions: [
           X402.Extensions.Bazaar,


### PR DESCRIPTION
Documentation catch-up for the gap-closure wave (#78/#79): every guide, the README, the ExDoc config, and the architecture map now describe the SDK as it actually is — role-complete across payer, gate, local verifier, and a runnable EVM + Solana facilitator.

## What changed

**`guides/facilitator.md` — full overhaul.** The guide predated the wave and made three now-false claims (ERC-6492 counterfactuals "always rejected"; settlement_pending "reconcile it yourself"; `transfer_calldata/2`). Now covers: a production-shaped EVM quick start (NonceManager + pending store supervised and wired in), a "Serve Solana too" section (SVMEngine with the recommended `settlement_cache` + `pending_settlement_store` pairing and why the pair matters, multi-engine plug, merged `GET /supported` with `extra.feePayer`), dual-engine verify checklists, the settlement pipelines including Transfer-event verification, a "Pending settlements and reconciliation" section (provenance, delete-before-reconcile, signed-content-bound keys and the mutated-retry rationale, the gate's exactly-once retry), truthful fee-payer safety (default-`[]` invariant vs. allowlisted deploy-then-settle with `max_deploy_gas_limit`), and refreshed production notes.

**`guides/local-verification.md`** — the `before_verify`-hook workaround is replaced by the first-class `local_verification:` gate option (levels, `:full`-requires-`:rpc` at init, exact-EVM scope, 402/500 mapping); new SVM verification section (`X402.Verify.SVM`, why local Ed25519 is mandatory under `sigVerify: false` simulation); the three-mode `:simulate` explanation including `:counterfactual_only`.

**`guides/plug-integration.md`** — options table rebuilt with all nine current options; new Replay Protection section (per-family signature-bound key derivations, prefixes, header-hash fallback, why paymentId is never the dedup key), Payment Identifiers section (decode/400/`conn.assigns[:x402_payment_id]`/telemetry), Settlement Retries note; fixed a pre-existing broken routes example.

**Freshness pass** on `client.md` (real `X402.Solana.RPC.get_latest_blockhash/2` blockhash-fetcher example; retired the "never talks to a Solana RPC node" claim), `getting-started.md` (four-role framing + `~> 0.6` pin), `custom-schemes.md` (ExactSVM as built-in, `signable?/1`, replay-key note for custom schemes), `mcp.md` (claim-key derivation note). `paywall.md` verified current, untouched.

**README** — features list rewritten for the role-complete SDK, a compact "Run your own facilitator" section, and the Documentation list now links all nine guides.

**ExDoc config** — `groups_for_modules` now covers every public module (16 were missing, incl. SVMEngine, PendingSettlementStore, Verify.SVM, the new Solana group); zero ungrouped modules in the generated sidebar. `docs/architecture.md` module map and payment-lifecycle description updated. Two stale doc references fixed (`transfer_calldata/2`→`/3` in the changelog; `t:X402.RPC.error/0` type link).

## Verification

Every code example and option name was checked against the lib/ source (NimbleOptions schemas, function arities, return shapes) by the writers — details in each commit. `mix docs` builds with **zero warnings**; suite 1,725 passed; credo --strict clean; format clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and ExDoc grouping only; no application code behavior changes beyond a moduledoc type link fix.
> 
> **Overview**
> **Documentation catch-up** so public docs describe the role-complete SDK (payer, gate, local verifier, EVM + Solana facilitator) after the gap-closure wave—not new runtime behavior in this PR.
> 
> **`guides/facilitator.md`** is rewritten: production EVM setup with `NonceManager` and `PendingSettlementStore`, **`SVMEngine`** and multi-engine **`X402.Plug.Facilitator`**, verify/settle pipelines (Transfer-event checks, pending reconciliation, ERC-6492 allowlist deploy-then-settle), nonce manager, and updated production/security notes. Stale claims (always-reject 6492, manual `settlement_pending`, `transfer_calldata/2`) are removed.
> 
> **`guides/local-verification.md`** documents first-class **`local_verification:`** on the payment gate (replacing the hook-only pattern), **`:simulate`** modes including **`:counterfactual_only`**, and a new **`X402.Verify.SVM`** section.
> 
> **`guides/plug-integration.md`** expands the options table (**`claim_order`**, **`local_verification`**, **`paywall`**, Redis cache tuples), adds **Replay Protection** (signature-bound keys per scheme; `paymentId` is not the dedup key), **Payment Identifiers**, **settlement_pending** one-shot retry, and fixes a broken offer-receipt routes example.
> 
> **README**, **`getting-started.md`**, **`client.md`**, **`custom-schemes.md`**, and **`mcp.md`** are refreshed (four-role framing, Solana payer/facilitator paths, `ExactSVM`, ExDoc link fixes). **`docs/architecture.md`** updates the module map, payment flow, telemetry, and lifecycle. **`mix.exs`** ExDoc **`groups_for_modules`** adds missing modules (SVM engine, Solana, verify, etc.). **CHANGELOG** and **`X402.Solana.RPC`** get minor reference fixes (`transfer_calldata/3`, type link).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 482257010c52e296a1aeaaeced5d04a6e7ef5c73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->