### PR TITLE
chore(release): prepare v0.6.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,15 +9,15 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
           elixir-version: "1.20"
           otp-version: "29"
 
       - name: Cache deps
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: |
             deps
@@ -26,15 +26,18 @@ jobs:
           restore-keys: ${{ runner.os }}-mix-
 
       - run: mix deps.get
-      - run: mix compile
+      - run: mix compile --warnings-as-errors
+
+      - name: Verify tag matches package version
+        run: |
+          package_version="$(mix run --no-start -e 'IO.write(Mix.Project.config()[:version])')"
+          tag_version="${GITHUB_REF_NAME#v}"
+          if [ "$tag_version" != "$package_version" ]; then
+            echo "Tag version $tag_version does not match package version $package_version"
+            exit 1
+          fi
 
       - name: Publish to Hex.pm
-        run: |
-          mix hex.publish --yes 2>&1 || mix hex.publish --yes --replace
-        env:
-          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
-
-      - name: Publish docs to HexDocs
-        run: mix hex.publish docs --yes
+        run: mix hex.publish --yes
         env:
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ The Elixir SDK for the x402 HTTP payment protocol — published on Hex.pm. A **l
 
 ## Quick Context
 - **Language:** Elixir (OTP)
-- **Published:** Hex.pm (`x402 ~> 0.5.0`)
+- **Published:** Hex.pm (`x402 ~> 0.6.0`)
 - **CI:** GitHub Actions → `mix test --cover`
 - **Docs:** Generated via ExDoc, hosted on hexdocs.pm
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-28
+
 ### Added
 
 - **SVM on-chain facilitator — `X402.Facilitator.SVMEngine`**: verify and
@@ -109,9 +111,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   account 0); `precheck/3` enforces the facilitator's static-path
   whitelist (spec §3.1: 3–7 instructions in the reference order, the
   5 lamports/CU cap, §2.1.1 fee payer isolation, transfer semantics, memo
-  enforcement) without any RPC. On-chain verification and settlement stay
-  facilitator-delegated; transactions using address lookup tables skip the
-  local pre-checks
+  enforcement) without any RPC. Full on-chain verification and settlement are
+  available through `X402.Verify.SVM` and `X402.Facilitator.SVMEngine`.
+  Transactions using address lookup tables bypass the pure `precheck/3`, then
+  the bundled verifier and engine reject them fail-closed because lookup-table
+  resolution is not implemented
 - **`X402.Signer.SolanaKey` and the optional `sign_ed25519/2` signer
   callback**: Ed25519 signing over OTP's `:crypto` (no new dependencies);
   `new/1` accepts a raw 32-byte seed, a 64-byte `solana-keygen` keypair,
@@ -401,8 +405,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented the clustered-BEAM double-execution hazard of the per-node ETS
   replay cache in the `PaymentGate`, `Cache`, and `ETSCache` moduledocs
 - Added `SECURITY.md` — private vulnerability reporting, supported versions,
-  and the SDK's trust model (facilitator-delegated verification, transport
-  hardening, per-node replay cache caveat)
+  and the SDK's multi-role trust model: delegated versus optional local
+  verification, transport hardening, replay/settlement configuration, and the
+  pre-1.0 independent-audit boundary
 - Corrected the `X402.Facilitator.Auth.CDP.headers/2` doc: the JWT is signed
   fresh per facilitator operation, and transport retries within one operation
   reuse it inside its 120-second validity window
@@ -437,6 +442,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer occurs; `{:missing_fields, _}` remains for v2 `accepted` objects
   missing required PaymentRequirements fields.
   (Ecosystem report §8 P0.1.)
+
+### Client and transport additions
+
 - Payer client (report §8 P0.4): `X402.Client` — transport-agnostic core with
   `select_requirements/2` (filterable payment-option selection with a
   `max_amount` budget guard), `build_payment/3` (v2 `PaymentPayload` assembly

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add the library and only the optional integrations your application uses:
 ```elixir
 def deps do
   [
-    {:x402, "~> 0.5.0"},
+    {:x402, "~> 0.6.0"},
     {:finch, "~> 0.19"}, # facilitator HTTP calls
     {:plug, "~> 1.14"}   # PaymentGate
   ]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,14 +5,14 @@
 > [docs/ecosystem-comparison.md](docs/ecosystem-comparison.md) (§8); item tags
 > (P0.1, P1.4, …) reference its numbering.
 
-## Current State (v0.5.x)
+## Current State (v0.6.x)
 
 ✅ x402 v2 protocol primitives (PaymentRequired / PaymentSignature / PaymentResponse, 8KB header caps)
 ✅ Plug middleware (PaymentGate): verify-before-handler, settle-after-response, replay claim, extension echo
 ✅ Facilitator client (verify/settle) with CDP JWT auth and Ecto-style runtime config
 ✅ Extensions: payment_identifier (ETS cache), SIWX (local EIP-191 recovery), bazaar builder
 ✅ Lifecycle hooks, telemetry spans, wallet validation (EVM + Solana)
-✅ >90% coverage, dialyzer-clean, live CDP smoke tests, published on Hex.pm
+✅ 95% coverage floor, dialyzer-clean, live CDP smoke tests, published on Hex.pm
 
 ## Gap-closure sprint — all P0/P1/P2 items shipped
 
@@ -54,10 +54,17 @@ covers EVM (`exact`/`upto`) and Solana (`exact`) schemes.
 
 ## Next up — production polish (v1.0)
 
+Release gates for the stable API:
+
+- [ ] Independent security audit of the crypto verification and settlement paths
+- [ ] Official upstream e2e harness acceptance plus a passing cross-language run
+- [ ] Live EVM exact/upto and SVM exact settlement matrix, including Redis replay
+  protection and pending-settlement reconciliation
+- [ ] Public API, error-contract, and migration-policy stability review
+
 - [ ] LiveDashboard integration, rate limiting per wallet, multi-facilitator failover
 - [ ] Guides: "Build a paid API in 5 minutes", "x402 for AI agents", "Deploying on Fly.io"
 - [ ] Example Phoenix app, `mix x402.gen.paywall` generator
-- [ ] Security audit of crypto verification paths
 - [ ] Hex v1.0 publish
 
 ## Follow-ups noted during the sprint — closed 2026-08-28

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,28 +17,29 @@ receives security fixes.
 
 ## Trust model
 
-This library implements the **resource server** and **facilitator client**
-roles of the x402 payment protocol. Understanding what it does and does not
-verify matters for deploying it safely:
+This library implements the payer client, resource server, facilitator client,
+and self-hosted EVM/SVM facilitator roles of the x402 payment protocol.
+Understanding which checks are enabled in each deployment matters:
 
-- **Payment signature verification is delegated to the facilitator you
-  configure.** `X402.Plug.PaymentGate` validates payload structure, matches
-  requirements, and runs cheap local pre-checks (payTo binding, exact amount
-  equality, validity windows), but it performs no signature cryptography and
-  no on-chain checks. Your resource server's payment security equals your
-  facilitator's — choose one you trust, and note that no x402 SDK's server
-  role independently verifies settlement on-chain.
+- **Resource servers delegate verification and settlement to their configured
+  facilitator by default.** `X402.Plug.PaymentGate` always validates payload
+  structure, matches the complete advertised requirements, and runs the
+  registered scheme's local pre-checks. Exact-EVM routes can additionally run
+  `X402.Verify.EVM` at `:structural`, `:signature`, or `:full` through the
+  `:local_verification` option. This narrows trust in the facilitator but does
+  not replace the settle call; choose and authenticate a facilitator you trust,
+  or operate the bundled facilitator engines yourself.
 - **Facilitator transport is enforced to `https://`** (loopback exempt for
   development), with TLS peer verification and system CA certificates on the
   default pool. Per-request facilitator authentication (Coinbase CDP JWT) is
   supported via `X402.Facilitator.Auth`.
 - **Inbound payment headers are capped at 8 KB before any decoding** and
   fail closed on malformed Base64/JSON.
-- **Replay protection** in `X402.Plug.PaymentGate` (the payment-identifier
-  cache claim) is **per-node** with the bundled ETS adapter. In a clustered
-  deployment each node claims independently — use a shared adapter
-  (implementing `X402.Extensions.PaymentIdentifier.Cache`) if a duplicate
-  request served by a second node is unacceptable for your resource.
+- **Replay protection** in `X402.Plug.PaymentGate` is **per-node** with the
+  bundled ETS adapter. In a clustered deployment, configure a shared adapter;
+  `X402.Extensions.PaymentIdentifier.RedisCache` provides an atomic Redis
+  implementation. Replay keys for the built-in EVM and SVM schemes derive
+  from signature-covered payment identity rather than unsigned client fields.
 - **ERC-6492 counterfactual settlement is allowlist-gated.** The facilitator
   engine (`X402.Facilitator.Engine`) signs caller-supplied factory calldata
   only toward addresses explicitly listed in `:eip6492_allowed_factories`,
@@ -48,6 +49,15 @@ verify matters for deploying it safely:
   caller-supplied calldata. Allowlist only factories you have audited — a
   listed factory receives deployment transactions paid for by your fee
   payer.
+- **SVM duplicate-settlement protection is opt-in.** Production
+  `X402.Facilitator.SVMEngine` deployments should configure both
+  `:settlement_cache` and `:pending_settlement_store`. Without the cache,
+  concurrent settle calls can all broadcast; without the pending store, an
+  uncertain broadcast cannot be reconciled on retry.
+- **The cryptographic verification and transaction-settlement paths have not
+  yet received an independent third-party audit.** The project is still on a
+  pre-1.0 release line; apply normal defense in depth, conservative allowlists,
+  and testnet/live-smoke validation before handling production value.
 
 ## Known advisories affecting the wider x402 ecosystem
 
@@ -57,5 +67,5 @@ This SDK is not affected by, but its design responds to,
 on decoded `path_info` segments and carries regression tests for that bug
 class) and
 [GHSA-qr2g-p6q7-w82m](https://github.com/advisories/GHSA-qr2g-p6q7-w82m)
-(SVM duplicate settlement in the official SDKs — this SDK does not implement
-SVM settlement).
+(SVM duplicate settlement in the official SDKs — the bundled SVM engine has
+an atomic settlement-cache integration, but operators must configure it).

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -1,30 +1,31 @@
 # Quality Status — x402 Elixir SDK
 
-> Last updated: 2026-04-01
+> Last updated: 2026-08-28
 
 ## Current Grades
 
 | Area | Grade | Notes |
 |------|-------|-------|
-| Tests | A | >90% line coverage (ExCoveralls), doctests on all pure functions; new HTTP + PaymentSignature tests added |
+| Tests | A | 95% line-coverage floor (97.0% on the v0.6.0 release candidate); 295 doctests + 1,430 tests |
 | Architecture | A | Flat modules, behaviours, minimal deps — Dashbit-level |
-| Docs | A | hexdocs published, @moduledoc + @doc + @spec on all publics |
-| Type Safety | A | Dialyzer-clean, full typespecs |
-| Security | A- | TLS peer verification enforced, HTTPS-only base_url, 8KB size caps on all headers, atomic ETS claim |
+| Docs | A | ExDoc builds cleanly; public modules and APIs are documented with release-version metadata |
+| Type Safety | A | Dialyzer-clean; public APIs are expected to carry typespecs |
+| Security | B+ | Fail-closed verification, TLS and size caps, canonical replay keys; independent crypto/settlement audit remains a v1.0 gate |
 | Optional Deps | A | Compiles cleanly with `--no-optional-deps` |
 
 ## Coverage Target
-- **Hard minimum:** 90% line coverage via ExCoveralls
+- **Hard minimum:** 95% line coverage via ExCoveralls
 - Run: `MIX_ENV=test mix coveralls`
-- CI enforces this — PRs that drop below 90% are blocked
+- CI enforces this — PRs that drop below 95% fail
 
 ## Known Debt
 
 - [ ] Property-based tests (StreamData) for PaymentRequired encode/decode
 - [ ] SIWX fuzzing — edge cases in EVM signature recovery
 - [ ] Benchmark idempotency cache under high concurrency (bench_ets_cache.exs exists but not in CI)
-- [ ] Facilitator retry/backoff not implemented — single attempt only
-- [ ] "upto" scheme: bidding logic validation is minimal
+- [ ] Independent audit of cryptographic verification and facilitator settlement paths
+- [ ] Credential-backed EVM/SVM settlement and Redis conformance matrix in a protected release environment
+- [ ] Official upstream cross-language e2e harness acceptance and recurring run
 
 ## Testing Stack
 
@@ -37,7 +38,14 @@
 ## CI Checks (GitHub Actions)
 
 1. `mix compile --warnings-as-errors`
-2. `mix test --cover` (must be ≥90%)
-3. `mix dialyzer`
-4. `mix compile --no-optional-deps` (optional-dep safety)
-5. `mix format --check-formatted`
+2. `mix format --check-formatted`
+3. `mix credo --strict`
+4. `mix coveralls` (must be ≥95%)
+5. `mix compile --no-optional-deps --warnings-as-errors`
+6. Compile and smoke-test `integration/consumer`
+7. `mix dialyzer --format github`
+
+Release candidates additionally build ExDoc, audit Hex dependencies, inspect
+the generated package, and run a clean exact-version downstream smoke test.
+Credential-backed CDP, Redis, and chain settlement suites remain explicit live
+gates rather than default PR checks.

--- a/guides/client.md
+++ b/guides/client.md
@@ -29,7 +29,7 @@ Add the optional dependencies the payer needs — `finch` for HTTP and
 ```elixir
 def deps do
   [
-    {:x402, "~> 0.6"},
+    {:x402, "~> 0.6.0"},
     {:finch, "~> 0.19"},
     {:ex_secp256k1, "~> 0.8.0"},
     {:ex_keccak, "~> 0.7.8"}

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -18,7 +18,7 @@ is one of four roles the SDK covers end to end:
 ```elixir
 def deps do
   [
-    {:x402, "~> 0.6"},
+    {:x402, "~> 0.6.0"},
     {:finch, "~> 0.19"},
     {:plug, "~> 1.14"}
   ]

--- a/guides/local-verification.md
+++ b/guides/local-verification.md
@@ -41,7 +41,7 @@ Add the optional dependencies and a Finch pool:
 ```elixir
 def deps do
   [
-    {:x402, "~> 0.6"},
+    {:x402, "~> 0.6.0"},
     {:finch, "~> 0.19"},
     {:ex_secp256k1, "~> 0.8"},
     {:ex_keccak, "~> 0.7"}

--- a/integration/e2e_server/UPSTREAM_PATCHES.md
+++ b/integration/e2e_server/UPSTREAM_PATCHES.md
@@ -6,7 +6,7 @@ configuration examples (#3277)").
 
 The component itself is `upstream/servers/elixir/http/bandit/` in this
 directory — copy it verbatim to `e2e/servers/elixir/http/bandit/` in the
-foundation repo. It depends on the published Hex package (`{:x402, "~> 0.5"}`),
+foundation repo. It depends on the published Hex package (`{:x402, "~> 0.6.0"}`),
 ships its own `install.sh` / `build.sh` / `run.sh`, and declares a full local
 `test.config.json` overlay (endpoints, environment, capability matrix), so the
 harness does not need catalog-driven config synthesis for Elixir.

--- a/integration/e2e_server/upstream/servers/elixir/http/bandit/mix.exs
+++ b/integration/e2e_server/upstream/servers/elixir/http/bandit/mix.exs
@@ -21,7 +21,7 @@ defmodule X402.E2EServer.MixProject do
   defp deps do
     [
       # The Elixir x402 SDK (https://hex.pm/packages/x402)
-      {:x402, "~> 0.5"},
+      {:x402, "~> 0.6.0"},
       {:bandit, "~> 1.0"},
       {:finch, "~> 0.19"},
       {:jason, "~> 1.2"}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule X402.MixProject do
   use Mix.Project
 
-  @version "0.5.0"
+  @version "0.6.0"
   @source_url "https://github.com/cardotrejos/x402"
   @description "Elixir SDK for the x402 HTTP payment protocol"
 

--- a/test/support/test_rlp_decoder.ex
+++ b/test/support/test_rlp_decoder.ex
@@ -15,27 +15,27 @@ defmodule X402.TestRLPDecoder do
 
   def decode(<<byte, rest::binary>>) when byte <= 0xB7 do
     length = byte - 0x80
-    <<payload::binary-size(length), rest::binary>> = rest
+    <<payload::binary-size(^length), rest::binary>> = rest
     {payload, rest}
   end
 
   def decode(<<byte, rest::binary>>) when byte <= 0xBF do
     length_size = byte - 0xB7
-    <<length::unsigned-big-integer-size(length_size)-unit(8), rest::binary>> = rest
-    <<payload::binary-size(length), rest::binary>> = rest
+    <<length::unsigned-big-integer-size(^length_size)-unit(8), rest::binary>> = rest
+    <<payload::binary-size(^length), rest::binary>> = rest
     {payload, rest}
   end
 
   def decode(<<byte, rest::binary>>) when byte <= 0xF7 do
     length = byte - 0xC0
-    <<payload::binary-size(length), rest::binary>> = rest
+    <<payload::binary-size(^length), rest::binary>> = rest
     {decode_list(payload, []), rest}
   end
 
   def decode(<<byte, rest::binary>>) do
     length_size = byte - 0xF7
-    <<length::unsigned-big-integer-size(length_size)-unit(8), rest::binary>> = rest
-    <<payload::binary-size(length), rest::binary>> = rest
+    <<length::unsigned-big-integer-size(^length_size)-unit(8), rest::binary>> = rest
+    <<payload::binary-size(^length), rest::binary>> = rest
     {decode_list(payload, []), rest}
   end
 

--- a/test/x402/scheme/exact_svm_test.exs
+++ b/test/x402/scheme/exact_svm_test.exs
@@ -578,7 +578,7 @@ defmodule X402.Scheme.ExactSVMTest do
       # lookup entry: 32-byte table address, one writable index, none
       # read-only.
       body_size = byte_size(wire) - 1
-      <<body::binary-size(body_size), 0>> = wire
+      <<body::binary-size(^body_size), 0>> = wire
       with_alt = body <> <<1>> <> :binary.copy(<<7>>, 32) <> <<1, 200>> <> <<0>>
 
       alt_payload = put_in(payload["payload"], %{"transaction" => Base.encode64(with_alt)})

--- a/test/x402/solana/transaction_test.exs
+++ b/test/x402/solana/transaction_test.exs
@@ -142,7 +142,7 @@ defmodule X402.Solana.TransactionTest do
       # the trailing address-table-lookup section.
       %{bytes: <<0x80, body::binary>>} = compiled()
       body_size = byte_size(body) - 1
-      <<legacy_message::binary-size(body_size), 0>> = body
+      <<legacy_message::binary-size(^body_size), 0>> = body
 
       wire = <<2>> <> <<0::512>> <> <<0::512>> <> legacy_message
 
@@ -186,7 +186,7 @@ defmodule X402.Solana.TransactionTest do
 
       %{bytes: bytes} = compiled()
       body_size = byte_size(bytes) - 1
-      <<body::binary-size(body_size), 0>> = bytes
+      <<body::binary-size(^body_size), 0>> = bytes
 
       # ALT count says 1 but only a single byte of the table follows.
       truncated = <<2>> <> <<0::512>> <> <<0::512>> <> body <> <<1, 7>>

--- a/test/x402/verify/svm_test.exs
+++ b/test/x402/verify/svm_test.exs
@@ -174,7 +174,7 @@ defmodule X402.Verify.SVMTest do
       # entry, and RE-SIGN the mutated message so the signature check
       # (which runs first) passes and the ALT rejection itself is hit.
       message_size = byte_size(decoded.message_bytes) - 1
-      <<body::binary-size(message_size), 0>> = decoded.message_bytes
+      <<body::binary-size(^message_size), 0>> = decoded.message_bytes
       alt_message = body <> <<1>> <> :binary.copy(<<7>>, 32) <> <<1, 200>> <> <<0>>
       client_signature = :crypto.sign(:eddsa, :none, alt_message, [@client_seed, :ed25519])
       wire = <<2>> <> <<0::512>> <> client_signature <> alt_message


### PR DESCRIPTION
## What

- set the package and installation examples to version 0.6.0
- establish the v0.6.0 release contract and explicit pre-1.0 gates
- harden the tag-triggered Hex publisher with immutable action pins, tag/version validation, warnings-as-errors, and a single non-replacing publish
- remove Elixir 1.20 test-only bitstring pin warnings

## Why 0.6.0 instead of 1.0.0

The SDK has grown into a full payer, facilitator, EVM/SVM, MCP, replay-protection, and reconciliation stack. That is a substantial minor release, but the newer public surfaces need one stabilization cycle before a compatibility promise. The 1.0 gates now call out an independent cryptography/protocol audit, upstream end-to-end acceptance, live EVM/SVM/Redis/reconciliation coverage, and a final API/error/migration review.

## Validation

- mix ci: 1,725 tests passed, 7 excluded, 97.0% coverage, strict Credo and Dialyzer green
- mix docs --warnings-as-errors
- mix compile --no-optional-deps --warnings-as-errors
- mandatory-dependency consumer compile and smoke
- upstream Elixir verification matrix: 7/7
- facilitator example boot and stub-RPC smoke
- mix hex.audit (only explicitly ignored test-only Cowlib advisories)
- unpacked mix hex.build artifact and required-only package smoke

The seven credential-gated CDP/Redis/live-chain tests were not run locally. They remain an explicit 1.0 release gate rather than being represented as covered here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are versioning, documentation, CI publish guards, and test-only pattern fixes; no production library logic changes in this diff.
> 
> **Overview**
> **Release 0.6.0** bumps `mix.exs` and all install/e2e dependency examples from `~> 0.5.0` to `~> 0.6.0`, adds the dated **0.6.0** changelog section (including clarified SVM verify/settle and ALT fail-closed wording), and aligns **README**, **guides**, **AGENTS.md**, **ROADMAP**, **SECURITY.md**, and **docs/quality.md** with the current scope (95% coverage floor, v1.0 release gates, expanded trust model).
> 
> The **tag-triggered Hex publish workflow** is tightened: GitHub Actions are pinned to commit SHAs, `mix compile --warnings-as-errors` runs before publish, a step **fails the job if the git tag does not match** `Mix.Project` version, publishing is a single `mix hex.publish --yes` (no `--replace` fallback), and the separate **HexDocs publish** step is removed.
> 
> **Elixir 1.20 compatibility**: test-only bitstring matches use pinned sizes (`binary-size(^length)`) in `test_rlp_decoder.ex` and SVM/transaction tests so compile stays warning-clean under stricter pattern typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2085f8c60451b09f240ca3097f012691b3ec779c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->